### PR TITLE
Add missing closing parenthesis in enyo.kind "Hello From Enyo" example

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Enyo contains a constructor/prototype-generator that we call enyo.kind. Construc
 		helloTap: function() {
 			this.$.hello.addStyles("color: red");
 		}
-	};
+	});
 	// make two, they're small
 	new Hello().write();
 	new Hello().write();


### PR DESCRIPTION
The enyo.kind "Hello From Enyo" example in the README.md file is missing a closing parenthesis. 
