### PR TITLE
Scroll fixes for TouchScrollStrategy

### DIFF
--- a/source/touch/TouchScrollStrategy.js
+++ b/source/touch/TouchScrollStrategy.js
@@ -78,9 +78,6 @@ enyo.kind({
 	scrollTo: function(inX, inY) {
 		this.$.scrollMath.scrollTo(inY || inY == 0 ? inY : null, inX);
 	},
-	calcScrollNode: function() {
-		return this.$.client.hasNode();
-	},
 	calcAutoScrolling: function() {
 		var v = (this.vertical == "auto");
 		var h = (this.horizontal == "auto") || (this.horizontal == "default");
@@ -182,13 +179,14 @@ enyo.kind({
 		}
 	},
 	effectOverscroll: function(inX, inY) {
-		var n = this.scrollNode;
+		var c = this.scrollNode;
+		var n = this.$.client.hasNode();
 		var o = "";
-		if (inY !== null && Math.abs(inY - n.scrollTop) > 1) {
-			o += " translateY(" + (n.scrollTop - inY) + "px)";
+		if (inY !== null && Math.abs(inY - c.scrollTop) > 1) {
+			o += " translateY(" + (c.scrollTop - inY) + "px)";
 		}
-		if (inX !== null && Math.abs(inX - n.scrollLeft) > 1) {
-			o += " translateX(" + (n.scrollLeft - inX) + "px)";
+		if (inX !== null && Math.abs(inX - c.scrollLeft) > 1) {
+			o += " translateX(" + (c.scrollLeft - inX) + "px)";
 		}
 		if (n) {
 			var s = n.style;


### PR DESCRIPTION
Over the course of testing an upcoming Enyo 2-based app on iOS 4.3 I discovered that the TouchScrollStrategy that automatically kicks in when native scrolling is not supported was not actually updating the scroll position. After some debugging and testing, I think the commits in this branch should fix the problem.

The root issue was that TouchScrollStrategy was overriding ScrollStrategy's `calcScrollNode` method and using `this.$.client` instead of `this.container` to calculate the scroll boundaries. My best guess is this change was made in order to allow overscrolling to work properly (since you need to adjust the transform on client, not container, for the overscroll effect to work right). However, the side effect was that the `scrollTop` and `scrollLeft` properties were never changing, and the boundary calculations were incorrect (because the container element was the small viewport, while client was a full-size wrapper around the scrollable content).

I removed the override, reverting `this.scrollNode` to reference the container element, and added some logic into the overscroll function to apply the adjustments to `this.$.client`.

I additionally switched to explicitly using the container to calculate boundaries instead of the client in `calcBoundaries`.

I have been testing these changes both in Safari 5 (with `scrollStrategy: "TouchScrollStrategy"` explicitly set on the Scroller component) and iOS 4.3 (with automatic detection of TouchScrollStrategy), and they seem to work great so far without impacting the default native scrolling support. As noted in my original commit, this closes issue #35, which I opened last week regarding the scrolling problems.

Let me know if you have any questions!
