### PR TITLE
Prevents minify.js from exiting with an error when output folder already exists

### DIFF
--- a/tools/minifier/minify.js
+++ b/tools/minifier/minify.js
@@ -133,7 +133,7 @@ finish = function(loader) {
 	//
 	var output = opt.output || "build";
 	var outfolder = path.dirname(output);
-	if (outfolder != ".") {
+	if (outfolder != "." && !path.existsSync(outfolder)) {
 		fs.mkdirSync(outfolder);
 	}
 	//


### PR DESCRIPTION
I simply added a path.existsSync check before trying to create the output folder; the minify.sh script was failing for me without building my project otherwise because the directory already existed.
