### PR TITLE
Adds quotes around paths in minify.sh to prevent breakage when spaces are in path

### DIFF
--- a/tools/minify.sh
+++ b/tools/minify.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 
 # the folder this script is in (*/enyo/tools)
-TOOLS=$(cd `dirname $0`; pwd)
+TOOLS="$(cd `dirname $0`; pwd)"
 # enyo location
-ENYO=$TOOLS/..
+ENYO="$TOOLS/.."
 # minify script location
-MINIFY=$TOOLS/minifier/minify.js
+MINIFY="$TOOLS/minifier/minify.js"
 
 # check for node, but quietly
 if command -v node >/dev/null 2>&1; then
 	# use node to invoke minify with a known path to enyo and imported parameters
-	node $MINIFY -enyo $ENYO $@
+	node "$MINIFY" -enyo "$ENYO" $@
 else
 	echo "No node found in path"
 	exit 1


### PR DESCRIPTION
Pretty much like the title says. The minify.sh script previously only worked if you had a path like `/path/to/enyo`. Something like `/path/to/my projects/enyo` would break it.
