### PR TITLE
Add enyo.Control.getComputedStyleValue

### DIFF
--- a/source/dom/Control.js
+++ b/source/dom/Control.js
@@ -303,6 +303,13 @@ enyo.kind({
 		enyo.Control.cssTextToDomStyles(inCssText, this.domStyles);
 		this.domStylesChanged();
 	},
+	getComputedStyleValue: function(style, defaultValue) {
+		if (this.hasNode()) {
+			return enyo.dom.getComputedStyleValue(this.node, style);
+		} else {
+			return defaultValue;
+		}
+	},
 	domStylesChanged: function() {
 		this.domCssText = enyo.Control.domStylesToCssText(this.domStyles);
 		this.invalidateTags();


### PR DESCRIPTION
What about adding a shortcut to enyo.dom.getComputedStyleValue in enyo.Control?
This would be helpful when working directly on the dom node (Animations for instance)
