### PR TITLE
Variable name typo fix

### DIFF
--- a/source/kernel/lang.js
+++ b/source/kernel/lang.js
@@ -205,7 +205,7 @@
 				'propertyIsEnumerable',
 				'constructor'
 			];
-			for (var i = 0, p; p = donEnums[i]; i++) {
+			for (var i = 0, p; p = dontEnums[i]; i++) {
 				if (hop.call(inObject, p)) {
 					results.push(p);
 				}


### PR DESCRIPTION
IE8-specific variable name typo
