### PR TITLE
Fix typo in enyo.Select example in comments

### DIFF
--- a/source/ui/Select.js
+++ b/source/ui/Select.js
@@ -10,7 +10,7 @@
 		]}
 
 		selectChanged: function(inSender, inEvent) {
-			var s = inSender.getSelected();
+			var s = inSender.getValue();
 			if (s == "d") {
 				this.sortListDescending();
 			} else {


### PR DESCRIPTION
getSelected() returns the index, getValue() returns the value.
