### PR TITLE
Fix for Enyo-418 - testCors bad response in Firefox

### DIFF
--- a/tools/test/ajax/tests/AjaxTest.js
+++ b/tools/test/ajax/tests/AjaxTest.js
@@ -74,8 +74,8 @@ enyo.kind({
 	},
 	// test CORS (Cross-Origin Resource Sharing) by testing against youtube api
 	testCORS: function() {
-		this._testAjax({url: "http://gdata.youtube.com/feeds/api/videos/"}, {q: "waterfall", alt: "json", format: 5}, function(inValue) {
-			return inValue && inValue.feed && inValue.feed.entry && inValue.feed.entry.length > 0;
+		this._testAjax({url: "http://query.yahooapis.com/v1/public/yql/jonathan/weather/"}, {q:'select * from weather.forecast where location=94025', format: "json"}, function(inValue) {
+			return inValue && inValue.query && inValue.query.results && inValue.query.count > 0;
 		});
 	}
 });

--- a/tools/test/ajax/tests/WebServiceTest.js
+++ b/tools/test/ajax/tests/WebServiceTest.js
@@ -75,8 +75,8 @@ enyo.kind({
 	},
 	// test CORS (Cross-Origin Resource Sharing) by testing against youtube api
 	testCORS: function() {
-		this._testWebService({url: "http://gdata.youtube.com/feeds/api/videos/"}, {q: "waterfall", alt: "json", format: 5}, function(inValue) {
-			return inValue && inValue.feed && inValue.feed.entry && inValue.feed.entry.length > 0;
+		this._testWebService({url: "http://query.yahooapis.com/v1/public/yql/jonathan/weather/"}, {q: 'select * from weather.forecast where location=94025', format: "json"}, function(inValue) {console.log(inValue)
+			return inValue && inValue.query && inValue.query.results && inValue.query.count > 0;
 		});
 	},
 	testJsonp: function() {


### PR DESCRIPTION
Swapped the youtube api with a yql api call since the youtube api sometimes returns a nonstandard response for the Access-Control-Allow-Origin field.

Updated can be tested here - http://apps.stevenf.webfactional.com/enyo/enyo/tools/test/ajax/
