### PR TITLE
When you call setSelected, the onchange event is not fired, this fixes t...

### DIFF
--- a/source/ui/Select.js
+++ b/source/ui/Select.js
@@ -45,6 +45,7 @@ enyo.kind({
 	setSelected: function(inIndex) {
 		// default property mechanism can't track changed correctly for virtual properties
 		this.setPropertyValue("selected", Number(inIndex), "selectedChanged");
+		this.bubbleUp("onchange", {index: Number(inIndex)}, this); 
 	},
 	selectedChanged: function() {
 		this.setNodeProperty("selectedIndex", this.selected);


### PR DESCRIPTION
_that_. 

As the title says, when you call setSelected on the enyo.Select, the onchange event was never fired off. 
