### PR TITLE
Add a Safari-desktop regex to enyo.platform

### DIFF
--- a/source/dom/platform.js
+++ b/source/dom/platform.js
@@ -43,7 +43,9 @@ enyo.platform = {
 		// Apple likes to make this complicated
 		{platform: "ios", regex: /iP(?:hone|ad;(?: U;)? CPU) OS (\d+)/},
 		// webOS 1 - 3
-		{platform: "webos", regex: /(?:web|hpw)OS\/(\d+)/}
+		{platform: "webos", regex: /(?:web|hpw)OS\/(\d+)/},
+		// desktop safari
+		{platform: "safari", regex: /Version\/(\d+)[.\d]+\s+Safari/}
 	];
 	for (var i = 0, p, m, v; p = platforms[i]; i++) {
 		m = p.regex.exec(ua);


### PR DESCRIPTION
Need to be able to distinguish Safari desktop version in order to work around bug ENYO-661
