### PR TITLE
ENYO-736 Call checkedChanged() at create to allow setting initial state.

### DIFF
--- a/source/ui/Checkbox.js
+++ b/source/ui/Checkbox.js
@@ -25,6 +25,7 @@ enyo.kind({
 	},
 	create: function() {
 		this.inherited(arguments);
+		this.checkedChanged();
 	},
 	rendered: function() {
 		this.inherited(arguments);


### PR DESCRIPTION
Please double check to make sure this is the right fix... I'm a little skeptical this hasn't been reported yet, so might be missing something, but seems to have been broken all along.
