### PR TITLE
Fix error in Motorola XOOM

### DIFF
--- a/source/touch/TranslateScrollStrategy.js
+++ b/source/touch/TranslateScrollStrategy.js
@@ -138,7 +138,7 @@ enyo.kind({
 	},
 	// FIXME: we can fix scrolling artifacts BUGS on Android 4.04 with this heinous incantation.
 	twiddle: function() {
-		if (this.translateOptimized) {
+		if (this.translateOptimized && this.scrollNode) { // this.scrollNode is not always defined and makes Motorola XOOM crash
 			this.scrollNode.scrollTop = 1;
 			this.scrollNode.scrollTop = 0;
 		}


### PR DESCRIPTION
A fix for Android 4 creates problems in Motorolas XOOM, which uses Android 3
