### PR TITLE
Fix for enyo core package.json "bugs" link

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "licenses": [{
         "type": "Apache-2.0", "url": "http://www.apache.org/licenses/LICENSE-2.0"
     }],
-    "bugs": "https://github.com/enyojs/enyo/issues/",
+    "bugs": "https://enyojs.atlassian.net/",
     "repositories": [{
         "type": "git", "url": "http://github.com/enyojs/enyo"
     }]


### PR DESCRIPTION
Changed package.json "bugs" https link to point new Atlassian issue tracker (previous GitHub issues URL currently 404s and has been deprecated).
# EnyoJS hackathon reppin'
