### PR TITLE
ENYO-726: fixing popup behavior for drag events

### DIFF
--- a/source/ui/Popup.js
+++ b/source/ui/Popup.js
@@ -171,7 +171,6 @@ enyo.kind({
 			inSender.setShowing(false);
 		}
 		return true;
-
 	},
 	keydown: function(inSender, inEvent) {
 		if (this.showing && this.autoDismiss && inEvent.keyCode == 27 /* escape */) {


### PR DESCRIPTION
Enyo-DCO-1.0-Signed-off-by: Dave Freeman Dave.Freeman@palm.com

This could definitely use some more eyes/testing.  The Sampler exposed a few weaknesses with Popups and drag events and it is confusing when non-modal Popups have scrims.  This change adds listeners for onmousedown and ondragstart and handles most cases correctly.
