### PR TITLE
Fix checks in enyo.kind for mistakenly undefined base kinds and throw an error if the kind property exists and is explicitly set to a misspelt value or if it evaluates to undefined at run-time. 

### DIFF
--- a/source/kernel/Component.js
+++ b/source/kernel/Component.js
@@ -445,7 +445,7 @@ enyo.defaultCtor = enyo.Component;
 
 enyo.create = enyo.Component.create = function(inConfig) {
 	if (!inConfig.kind && ("kind" in inConfig)) {
-		throw "enyo.create: Attempt to create a null kind. Check dependencies for [" + inConfig.name + "].";
+		throw "enyo.create: Attempt to create a null kind. Check dependencies for [" + (inConfig.name || "") + "].";
 	}
 	var kind = inConfig.kind || inConfig.isa || enyo.defaultCtor;
 	var ctor = enyo.constructorForKind(kind);

--- a/tools/test/core/tests/ComponentTest.js
+++ b/tools/test/core/tests/ComponentTest.js
@@ -1,0 +1,28 @@
+enyo.kind({
+	name: "ComponentTest",
+	kind: enyo.TestSuite,
+	testNestedComponentUndefinedKind: function() {
+		var pass = false;
+		// should throw exception as this is an error
+		try {
+			var a = enyo.kind(
+				{ 
+					name: "parentComponent", 
+					components: [
+					    {
+					    	name: "nestedComponent", 
+					    	kind: undefined
+					    }
+					]
+				}
+			);
+			new a({});
+		} catch(e) {
+			pass = true;
+		}
+		if (!pass) {
+			throw("no exception for explicitly undefined kind in a nested component");
+		}
+		this.finish();
+	}
+});

--- a/tools/test/core/tests/package.js
+++ b/tools/test/core/tests/package.js
@@ -4,6 +4,7 @@ enyo.depends(
 	"JsonTest.js",
 	"AsyncTest.js",
 	"AjaxTest.js",
+	"ComponentTest.js",
 	"ComponentDispatchTest.js",
 	"ComponentHandlersTest.js",
 	"ControlPropsTest.js",


### PR DESCRIPTION
Fix checks in enyo.kind for mistakenly undefined base kinds and throw an error if the kind property exists and is explicitly set to a misspelt value or if it evaluates to undefined at run-time.

Added unit test for the same in ComponentTest.js
