### PR TITLE
ENYO-809: getParentNode modified

### DIFF
--- a/source/dom/Control.js
+++ b/source/dom/Control.js
@@ -629,7 +629,6 @@ enyo.kind({
 		}
 	},
 	getParentNode: function() {
-		//return this.parentNode || (this.parent && this.parent.hasNode()) || (this.parent && this.parent.getParentNode && this.parent.getParentNode());
 		return this.parentNode || (this.parent && (this.parent.hasNode() || this.parent.getParentNode()));
 	},
 	addNodeToParent: function() {


### PR DESCRIPTION
Enyo-DCO-1.0-Signed-off-by: Dave Freeman Dave.Freeman@palm.com

This change adds another possible rendering parent for enyo.Control's
getParentNode() method to return.  This is necessary for cases where the
kind's parentNode is null or its parent has no node, such as a
ScrollStrategy.
