### PR TITLE
ENYO-544: use IE XDomainRequest for CORS

### DIFF
--- a/source/ajax/xhr.js
+++ b/source/ajax/xhr.js
@@ -68,23 +68,18 @@ enyo.xhr = {
 	},
 	getXMLHttpRequest: function(inUrl) {
 		try {
-			if (window.XDomainRequest) {
-				if (!this.inOrigin(inUrl) && !/^file:\/\//.test(inUrl)) {
-					try {
-						return new XDomainRequest();
-					} catch (e) {}
-				} else if (/^file:\/\//.test(inUrl) || (this.inOrigin(inUrl) && /^file:\/\//.test(window.location.href))) {
-					try {
-						return new ActiveXObject('Msxml2.XMLHTTP');
-					} catch (e) {}
-					try {
-						return new ActiveXObject('Microsoft.XMLHTTP');
-					} catch (e) {}
-				}
+			if (window.XDomainRequest && !this.inOrigin(inUrl) && !/^file:\/\//.test(window.location.href)) {
+				return new XDomainRequest();
 			}
 		} catch(e) {}
 		try {
 			return new XMLHttpRequest();
+		} catch (e) {}
+		try {
+			return new ActiveXObject('Msxml2.XMLHTTP');
+		} catch(e) {}
+		try {
+			return new ActiveXObject('Microsoft.XMLHTTP');
 		} catch (e) {}
 		return null;
 	}


### PR DESCRIPTION
Enyo-DCO-1.0-Signed-off-by: Dave Freeman dave.freeman@palm.com

This changed up the getXMLHttpRequest method in xhr.js a bit.  It tries
to deal with IE requirements first before returning a new
XMLHttpRequest.  This requires passing the url to getXMLHttpRequest now.

Additonally, XDomainRequest does not have onreadystatechange, so
makeReadyStateHandler adds to onload in that case.
