### PR TITLE
ENYO-1168: Updated transform.js - removed condition for calling domStylesChanged() in enyo.dom.transformsToDom()

### DIFF
--- a/source/dom/transform.js
+++ b/source/dom/transform.js
@@ -52,9 +52,8 @@
 			ds[cp] = t;
 			if (st) {
 				st[sp] = t;
-			} else {
-				inControl.domStylesChanged();
 			}
+			inControl.domStylesChanged();
 		}
 	}
 	//* @public


### PR DESCRIPTION
Enyo-DCO-1.0-Signed-off-by: Chris Patalano chris.patalano@palm.com
