### PR TITLE
Forcing enyo.requestAnimationFrame to use setTimeout on iOS 6 since the ...

### DIFF
--- a/source/dom/animation.js
+++ b/source/dom/animation.js
@@ -11,6 +11,11 @@
 		return window.clearTimeout(inId);
 	};
 	for (var i = 0, pl = prefix.length, p, wc, wr; (p = prefix[i]) || i < pl; i++) {
+		// if we're on ios 6 just use setTimeout, requestAnimationFrame has some kinks currently
+		if (enyo.platform.ios >= 6) {
+			break;
+		}
+		
 		// if prefixed, becomes Request and Cancel
 		wc = p ? (p + enyo.cap(c)) : c;
 		wr = p ? (p + enyo.cap(r)) : r;

--- a/source/dom/package.js
+++ b/source/dom/package.js
@@ -1,9 +1,10 @@
 enyo.depends(
-	"dom.css",
+	"dom.css",	
 	"dom.js",
 	"transform.js",
 	"Control.js",
 	"platform.js",
+	"animation.js",	
 	"phonegap.js",
 	"dispatcher.js",
 	"preview.js",

--- a/source/kernel/package.js
+++ b/source/kernel/package.js
@@ -3,7 +3,6 @@ enyo.depends(
 	"lang.js",
 	"job.js",
 	"macroize.js",
-	"animation.js",
 	"Oop.js",
 	"Object.js",
 	"Component.js",


### PR DESCRIPTION
...native function has some kinks. Moved animation.js to dom directory from kernel & updated related package.js files so that enyo.platform was available in animation.js

Enyo-DCO-1.0-Signed-off-by: Steven Feaster steven.feaster@palm.com
