### PR TITLE
ENYO-1279: change inOrigin test to treat an empty port value for window....

### DIFF
--- a/source/ajax/xhr.js
+++ b/source/ajax/xhr.js
@@ -60,7 +60,10 @@ enyo.xhr = {
 	inOrigin: function(inUrl) {
 		var a = document.createElement("a"), result = false;
 		a.href = inUrl;
-		if (a.protocol === ":" || (a.protocol === window.location.protocol && a.hostname === window.location.hostname && a.port === window.location.port)) {
+		if (a.protocol === ":" ||
+				(a.protocol === window.location.protocol &&
+					a.hostname === window.location.hostname &&
+					a.port === (window.location.port || 80))) {
 			result = true;
 		}
 		return result;


### PR DESCRIPTION
...location as port 80, avoids using XDomainRequest object to do local-origin requests breaking sync requests

ENYO-DCO-1.0-Signed-Off-By: Ben Combee (ben.combee@palm.com)
