### PR TITLE
ENYO-1339: enyo.Ajax broken on IE due to use of console.warn

### DIFF
--- a/source/ajax/Ajax.js
+++ b/source/ajax/Ajax.js
@@ -106,7 +106,7 @@ enyo.kind({
 		try {
 			return r && enyo.json.parse(r);
 		} catch (x) {
-			console.warn("Ajax request set to handleAs JSON but data was not in JSON format");
+			enyo.warn("Ajax request set to handleAs JSON but data was not in JSON format");
 			return r;
 		}
 	},


### PR DESCRIPTION
Enyo-DCO-1.0-Signed-off-by: Yves Del Medico yves.del-medico@hp.com
