### PR TITLE
ENYO-1421: make default enyo.Button type "button" instead of the default...

### DIFF
--- a/source/ui/Button.js
+++ b/source/ui/Button.js
@@ -11,6 +11,11 @@ enyo.kind({
 	//* @protected
 	kind: enyo.ToolDecorator,
 	tag: "button",
+	attributes: { 
+		// set to button, as default is "submit" which can cause unexpected
+		// problems when controls are used inside a form
+		type: "button"
+	},
 	//* @public
 	published: {
 		//* When true, button is shown as disabled and does not generate tap


### PR DESCRIPTION
..., "submit"

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@palm.com)
