### PR TITLE
Fix for ENYO-1413

### DIFF
--- a/source/ajax/Ajax.js
+++ b/source/ajax/Ajax.js
@@ -89,7 +89,7 @@ enyo.kind({
 	receive: function(inText, inXhr) {
 		if (!this.failed && !this.destroyed) {
 			if (this.isFailure(inXhr)) {
-				this.fail(inXhr.status);
+				this.fail(this.xhrToResponse(inXhr));
 			} else {
 				this.respond(this.xhrToResponse(inXhr));
 			}


### PR DESCRIPTION
When an ajax request failed, only the status code was returned to the
callback function. This fix returns the body of responses with a status
code other then the 200 range.

Enyo-DCO-1.1-Signed-off-by: Jan-Rixt Van Hoye jixt@burntide.eu
