### PR TITLE
Consistent usage of typeof operator

### DIFF
--- a/source/ajax/xhr.js
+++ b/source/ajax/xhr.js
@@ -40,7 +40,7 @@ enyo.xhr = {
 			}
 		}
 		//
-		if(typeof(xhr.overrideMimeType) == "function" && inParams.mimeType) {
+		if((typeof xhr.overrideMimeType == "function") && inParams.mimeType) {
 			xhr.overrideMimeType(inParams.mimeType);
 		}
 		//

--- a/source/dom/dispatcher.js
+++ b/source/dom/dispatcher.js
@@ -17,7 +17,7 @@ enyo.dispatcher = {
 		for (i=0; (n=d.windowEvents[i]); i++) {
 			// Chrome Packaged Apps don't like "unload"
 			if(n === "unload" && 
-				typeof(window.chrome) === "object" &&
+				(typeof window.chrome === "object") &&
 				window.chrome.app) {
 				continue;
 			}
@@ -135,7 +135,7 @@ enyo.bubbler = "enyo.bubble(arguments[0])";
 		var args = Array.prototype.slice.call(arguments, 0),
 			control = args.shift();
 
-		if(typeof(control) === "object" && typeof(control.hasNode) === "function") {
+		if((typeof control === "object") && (typeof control.hasNode === "function")) {
 			enyo.forEach(args, function(event) {
 				if(this.hasNode()) {
 					enyo.dispatcher.listen(this.node, event, bubbleUp);


### PR DESCRIPTION
- The typeof operator looks like a function when used with optional parameters ()
- This is just an attempt to make it consistent across the code

Enyo-DCO-1.1-Signed-off-by: Iván Perdomo katratxo@gmail.com
