### PR TITLE
Fixed a typo in the enyo.dom.byId documentation comment

### DIFF
--- a/source/dom/dom.js
+++ b/source/dom/dom.js
@@ -14,7 +14,7 @@ enyo.dom = {
 		parameter.
 
 			// find 'node' if it's a string id, or return it unchanged if it's already a node reference
-			var domNode = enyo.byId(node);
+			var domNode = enyo.dom.byId(node);
 	*/
 	byId: function(id, doc){
 		return (typeof id == "string") ? (doc || document).getElementById(id) : id; 


### PR DESCRIPTION
Comment was improperly referring to `enyo.byId` which was the Enyo 1.0 call and causes an error in Enyo 2.
