### PR TITLE
fix deployment of external libraries

### DIFF
--- a/tools/deploy.js
+++ b/tools/deploy.js
@@ -182,7 +182,7 @@ shell.cp('-r', path.join(sourceDir, 'assets'), buildDir, outDir);
 
 var libSrcDir = path.join(sourceDir, 'lib');
 if(shell.test('-d', libSrcDir)) {
-	shell.ls(libSrcDir).forEach(deployLib(lib));
+	shell.ls(libSrcDir).forEach(deployLib);
 }
 
 function deployLib(lib) {


### PR DESCRIPTION
Invoke forEach with a function as an arguments, not the return value if said function.
Enyo-DCO-1.1-Signed-off-by: Johann Jacobsohn johann.jacobsohn@directbox.com
