### PR TITLE
ENYO-1306: add silk browser detection separate from Android version, add...

### DIFF
--- a/source/dom/platform.js
+++ b/source/dom/platform.js
@@ -41,10 +41,10 @@ enyo.platform = {
 		{platform: "android", regex: /Android (\d+)/},
 		// Kindle Fire
 		// Force version to 2, (desktop mode does not list android version)
-		{platform: "android", regex: /Silk\/1./, forceVersion: 2},
+		{platform: "android", regex: /Silk\/1./, forceVersion: 2, extra: {silk: 1}},
 		// Kindle Fire HD
 		// Force version to 4
-		{platform: "android", regex: /Silk\/2./, forceVersion: 4},
+		{platform: "android", regex: /Silk\/2./, forceVersion: 4, extra: {silk: 2}},
 		// IE 8 - 10
 		{platform: "ie", regex: /MSIE (\d+)/},
 		// iOS 3 - 5
@@ -70,6 +70,9 @@ enyo.platform = {
 				v = Number(m[1]);
 			}
 			ep[p.platform] = v;
+			if (p.extra) {
+				enyo.mixin(ep, p.extra);
+			}
 			break;
 		}
 	}

--- a/source/touch/touch.js
+++ b/source/touch/touch.js
@@ -119,9 +119,10 @@ enyo.requiresWindow(function() {
 				document[e] = enyo.dispatch;
 			});
 			// use proper target finding technique based on feature detection.
-			if (enyo.platform.androidChrome <= 18) {
+			if (enyo.platform.androidChrome <= 18 || enyo.platform.silk === 2) {
 				// HACK: on Chrome for Android v18 on devices with higher density displays,
 				// document.elementFromPoint expects screen coordinates, not document ones
+				// bug also appears on Kindle Fire HD
 				this.findTarget = function(e) {
 					return document.elementFromPoint(e.screenX, e.screenY);
 				};


### PR DESCRIPTION
... workaround for Silk 2 elementFromPoint error that matches Android Chrome

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@palm.com)
