### PR TITLE
ENYO-1396: Defeat use of -webkit-overflow-scrolling:touch on blackberry

### DIFF
--- a/source/dom/Control.js
+++ b/source/dom/Control.js
@@ -390,9 +390,11 @@ enyo.kind({
 		the css rule -webkit-overflow-scrolling: touch, as it is
 		not supported in Android and leads to overflow issues
 		(ENYO-900 and ENYO-901)
+		Similarly, BB10 has issues repainting out-of-viewport content
+		when -webkit-overflow-scrolling is used (ENYO-1396)
 	*/
 	setupOverflowScrolling: function() {
-		if(enyo.platform.android || enyo.platform.androidChrome)
+		if(enyo.platform.android || enyo.platform.androidChrome || enyo.platform.blackberry)
 			return;
 		document.getElementsByTagName("body")[0].className += " webkitOverflowScrolling";
 	},

--- a/source/dom/platform.js
+++ b/source/dom/platform.js
@@ -59,7 +59,9 @@ enyo.platform = {
 		// Firefox on Android
 		{platform: "androidFirefox", regex: /Android;.*Firefox\/(\d+)/},
 		// desktop Firefox
-		{platform: "firefox", regex: /Firefox\/(\d+)/}
+		{platform: "firefox", regex: /Firefox\/(\d+)/},
+		// Blackberry 10+
+		{platform: "blackberry", regex: /BB1\d;.*Version\/(\d+\.\d+)/}
 	];
 	for (var i = 0, p, m, v; p = platforms[i]; i++) {
 		m = p.regex.exec(ua);

--- a/source/touch/Scroller.js
+++ b/source/touch/Scroller.js
@@ -102,7 +102,8 @@ enyo.kind({
 			{os: "androidChrome", version: 18},
 			{os: "androidFirefox", version: 16},
 			{os: "ios", version: 5},
-			{os: "webos", version: 1e9}
+			{os: "webos", version: 1e9},
+			{os: "blackberry", version:1e9}
 		],
 		//* Returns true if platform should have touch events.
 		hasTouchScrolling: function() {


### PR DESCRIPTION
ENYO-1396: Defeat use of -webkit-overflow-scrolling:touch on blackberry (has issues repainting out-of-viewport content), and instead use JavaScript scroller (TouchScrollStrategy).

Enyo-DCO-1.1-Signed-Off-By: Kevin Schaaf (kevin.schaaf@palm.com)
