### PR TITLE
ENYO-1563: allow to force-disable `cache-control` header

### DIFF
--- a/source/ajax/Ajax.js
+++ b/source/ajax/Ajax.js
@@ -130,7 +130,8 @@ enyo.kind({
 				username: this.username,
 				password: this.password,
 				xhrFields: this.xhrFields,
-				mimeType: this.mimeType
+				mimeType: this.mimeType,
+				noCacheControl: this.noCacheControl
 			});
 		}
 		catch (e) {

--- a/source/ajax/xhr.js
+++ b/source/ajax/xhr.js
@@ -16,6 +16,7 @@ enyo.xhr = {
 		- _password_: The optional password to use for authentication purposes.
 		- _xhrFields_: Optional object containing name/value pairs to mix directly into the generated xhr object.
 		- _mimeType_: Optional string to override the MIME-Type.
+		- _noCacheControl_: Optional string to *not* set the `cache-control: no-cache` HTTP header in non-GET requests.  This especially useful when dealing with servers whose CORS settings disallow this header.
 	*/
 	request: function(inParams) {
 		var xhr = this.getXMLHttpRequest(inParams);
@@ -41,7 +42,7 @@ enyo.xhr = {
 		}
 		// work around iOS 6 bug where non-GET requests are cached
 		// see http://www.einternals.com/blog/web-development/ios6-0-caching-ajax-post-requests
-		if (method !== "GET") {
+		if (method !== "GET" && !inParams.noCacheControl) {
 			xhr.setRequestHeader("cache-control", "no-cache");
 		}
 		//

--- a/tools/test/ajax/php/test4.php
+++ b/tools/test/ajax/php/test4.php
@@ -9,8 +9,14 @@ switch ($method) {
 }
 
 function post() {
-	$c = @$_SERVER["CONTENT_TYPE"];
-	$result = array('status' => "post", 'ctype' => $c);
+	$ctype = @$_SERVER["CONTENT_TYPE"];
+	$cacheCtrl = @$_SERVER["HTTP_CACHE_CONTROL"];
+	$result = array('status' => "post" , 'ctype' => $ctype , 'cacheCtrl' => $cacheCtrl);
 	echo json_encode($result);
+
+	# useful for test setup...
+	#foreach ($_SERVER as $name => $value) {
+	#	echo "$name: $value\n";
+	#}
 }
 ?>

--- a/tools/test/ajax/tests/AjaxTest.js
+++ b/tools/test/ajax/tests/AjaxTest.js
@@ -83,6 +83,26 @@ enyo.kind({
 			return inValue.ctype == contentType;
 		});
 	},
+	testCacheControlOn: function() {
+		var contentType = "application/x-www-form-urlencoded";
+		this._testAjax({url: "php/test4.php", method: "POST", postBody: "data"}, null, function(inValue) {
+			var status = inValue.cacheCtrl && (inValue.cacheCtrl.indexOf('no-cache') === 0);
+			if (!status) {
+				enyo.log("Bad Cache-Control: " + inValue.cacheCtrl + " expected: " + "no-cache");
+			}
+			return status;
+		});
+	},
+	testCacheControlOff: function() {
+		var contentType = "application/x-www-form-urlencoded";
+		this._testAjax({url: "php/test4.php", method: "POST", postBody: "data", noCacheControl: true }, null, function(inValue) {
+			var status = (inValue.cacheCtrl === null);
+			if (!status) {
+				enyo.log("Bad Cache-Control: " + inValue.cacheCtrl + " expected: " + undefined);
+			}
+			return status;
+		});
+	},
 	testContentTypeDefault: function() {
 		var contentType = "application/x-www-form-urlencoded";
 		this._testAjax({url: "php/test4.php", method: "POST", postBody: "data"}, null, function(inValue) {


### PR DESCRIPTION
- Some web-services (eg. DropBox) disallow the `cache-control` header
- This commit is _ONE WAY_ to fix the issue, as it allows the
  developer to force-remove this header.  _However_ wouldn't it be
  wiser to _NOT_ add this header _UNLESS_ ( running on iOS6 _AND_ the
  developer has _NOT_ already set it to another value) ?

Enyo-DCO-1.1-Signed-off-by: Francois-Xavier KOWALSKI francois-xavier.kowalski@hp.com
