### PR TITLE
Ajax POST body fix

### DIFF
--- a/source/ajax/Ajax.js
+++ b/source/ajax/Ajax.js
@@ -13,7 +13,7 @@
 
 	If you make changes to _enyo.Ajax_, be sure to add or update the appropriate
 	[unit tests](https://github.com/enyojs/enyo/tree/master/tools/test/ajax/tests).
-	
+
 	For more information, see the documentation on
 	[Consuming Web Services](https://github.com/enyojs/enyo/wiki/Consuming-Web-Services)
 	in the Enyo Developer Guide.
@@ -78,7 +78,7 @@ enyo.kind({
         else{
             //If inParams parameter is not a string, build a query from it
             if(inParams){
-                args.push(enyo.Ajax.objectToQuery(inParams));
+                body = enyo.Ajax.objectToQuery(inParams);
             }
         }
         //
@@ -163,7 +163,7 @@ enyo.kind({
 	fail: function(inError) {
 		// on failure, explicitly cancel the XHR to prevent
 		// further responses.  cancellation also resets the
-		// response headers & body, 
+		// response headers & body,
 		if (this.xhr) {
 			enyo.xhr.cancel(this.xhr);
 			this.xhr = null;


### PR DESCRIPTION
An ajax request with a method type of POST doesn't send post data (when not using the postBody parameter). The parameters contained in go are appended to the URL.

This can be seen using firebug or chrome inspect. The network information shows the request is being sent as a post request but the post data is empty. Instead the URL has been modified when using an object as the post data.

Example Issue Fiddles: 
http://jsfiddle.net/J2f88/ -- Uses object as query parameters
http://jsfiddle.net/J2f88/1/ -- Uses string as query parameters

Note: For the fiddle, the data will still return because the remote server doesn't care if data is in post or get.

The change on line 81 of Ajax.js fixes this issue.

Enyo-DCO-1.1-Signed-off-by: Matthew Schott glitchtechscience@gmail.com
