### PR TITLE
ENYO-1562: Scroller thumbs shouldn't show if vertical or horizontal is set to "hidden"

### DIFF
--- a/source/touch/TouchScrollStrategy.js
+++ b/source/touch/TouchScrollStrategy.js
@@ -401,8 +401,10 @@ enyo.kind({
 	//* Syncs and shows both the vertical and horizontal scroll indicators.
 	showThumbs: function() {
 		this.syncThumbs();
-		this.$.vthumb.show();
-		this.$.hthumb.show();
+		if (this.horizontal != "hidden")
+			this.$.hthumb.show();
+		if (this.vertical != "hidden")
+			this.$.vthumb.show();
 	},
 	//* Hides the vertical and horizontal scroll indicators.
 	hideThumbs: function() {


### PR DESCRIPTION
...et to "hidden"

Fixed it for now, but eventually the Scroller code can be optimized further to avoid doing any calculation on flick if a certain direction is set to hidden and we know that upfront. For example, if we know that the horizontal is set to hidden, why even calculate the scroll positions in that direction - simply ignore that direction altogether to achieve better performance.
