### PR TITLE
Pulled (unused) mozTransitionEnd event from dispatcher.

### DIFF
--- a/source/dom/dispatcher.js
+++ b/source/dom/dispatcher.js
@@ -8,7 +8,7 @@ enyo.dispatcher = {
 	// these events come from window
 	windowEvents: ["resize", "load", "unload", "message"],
 	// these events come from css
-	cssEvents: ["webkitTransitionEnd", "mozTransitionEnd", "transitionend"],
+	cssEvents: ["webkitTransitionEnd", "transitionend"],
 	// feature plugins (aka filters)
 	features: [],
 	connect: function() {


### PR DESCRIPTION
Enyo-DCO-1.1-Signed-off-by: Chris Patalano chris.patalano@palm.com
