### PR TITLE
Fixed ENYO-1797

### DIFF
--- a/source/boot/boot.js
+++ b/source/boot/boot.js
@@ -40,8 +40,8 @@ enyo.machine = {
 		} else {
 			var script = document.createElement('script');
 			script.src = inSrc;
-			script.onLoad = onLoad;
-			script.onError = onError;
+			script.onload = onLoad;
+			script.onerror = onError;
 			document.getElementsByTagName('head')[0].appendChild(script);
 		}
 	},


### PR DESCRIPTION
Fixed ENYO-1797: enyo.machine.script events do not fire
Enyo-DCO-1.1-Signed-off-by: Ryan Duffy admin@tiqtech.com
