### PR TITLE
Fixed ENYO-1798

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -156,7 +156,7 @@
 		},
 		getPathPrefix: function(inPath) {
 			var delim = inPath.slice(0, 1);
-			if ((delim != "/") && (delim != "\\") && (delim != "$") && !inPath.test(/^https?:/i)) {
+			if ((delim != "/") && (delim != "\\") && (delim != "$") && !/^https?:/i.test(inPath)) {
 				return this.packageFolder;
 			}
 			return "";

--- a/tools/test/core/tests/PathResolverTest.js
+++ b/tools/test/core/tests/PathResolverTest.js
@@ -2,12 +2,34 @@ enyo.kind({
 	name: "PathResolverTest",
 	kind: enyo.TestSuite,
 	rewriteTest: function(inResolver, inPath, inExpected) {
-		var result = inResolver.rewrite(inPath);
+		var pf= enyo.loader.packageFolder;
+		enyo.loader.packageFolder = "./source/";
+
+		var result = enyo.loader.getPathPrefix(inPath) + inResolver.rewrite(inPath);
+
 		if (result === inExpected) {
 			this.finish();
 		} else {
 			this.finish("Expected: '" + inExpected + "' Got: '" + result + "'");
 		}
+
+		enyo.loader.packageFolder = pf;
+	},
+	testNormalPath: function() {
+		var resolver = new enyo.pathResolverFactory();
+		this.rewriteTest(resolver, "my/folder", "./source/my/folder");
+	},
+	testLeadingSlashPath: function() {
+		var resolver = new enyo.pathResolverFactory();
+		this.rewriteTest(resolver, "/my/folder", "/my/folder");
+	},
+	testRewriteHttps: function() {
+		var resolver = new enyo.pathResolverFactory();
+		this.rewriteTest(resolver, "https://my.server/file.js", "https://my.server/file.js");
+	},
+	testRewriteHttpMixedCase: function() {
+		var resolver = new enyo.pathResolverFactory();
+		this.rewriteTest(resolver, "hTtP://my.server/file.js", "hTtP://my.server/file.js");
 	},
 	testRewriteUnknown: function() {
 		var resolver = new enyo.pathResolverFactory();


### PR DESCRIPTION
Fixed ENYO-1798: enyo.loaderFactor.getPathPrefix doesn't allow https paths
Enyo-DCO-1.1-Signed-off-by: Ryan Duffy admin@tiqtech.com
