### PR TITLE
Fix to use touch scroller for FirefoxOS

### DIFF
--- a/source/dom/platform.js
+++ b/source/dom/platform.js
@@ -61,6 +61,8 @@ enyo.platform = {
 		{platform: "chrome", regex: /Chrome\/(\d+)[.\d]+/},
 		// Firefox on Android
 		{platform: "androidFirefox", regex: /Android;.*Firefox\/(\d+)/},
+		// FirefoxOS
+		{platform: "firefoxOS", regex: /Mobile;.*Firefox\/(\d+)/},
 		// desktop Firefox
 		{platform: "firefox", regex: /Firefox\/(\d+)/},
 		// Blackberry 10+

--- a/source/dom/transition.js
+++ b/source/dom/transition.js
@@ -1,5 +1,5 @@
 enyo.dom.transition = (enyo.platform.ios || enyo.platform.android || enyo.platform.chrome || enyo.platform.androidChrome || enyo.platform.safari)
 	? "-webkit-transition"
-	: (enyo.platform.firefox || enyo.platform.androidFirefox)
+	: (enyo.platform.firefox || enyo.platform.firefoxOS || enyo.platform.androidFirefox)
 		? "-moz-transition"
 		: "transition";

--- a/source/touch/Scroller.js
+++ b/source/touch/Scroller.js
@@ -105,9 +105,10 @@ enyo.kind({
 			{os: "android", version: 3},
 			{os: "androidChrome", version: 18},
 			{os: "androidFirefox", version: 16},
+			{os: "firefoxOS", version: 16},
 			{os: "ios", version: 5},
 			{os: "webos", version: 1e9},
-			{os: "blackberry", version:1e9}
+			{os: "blackberry", version:1e9},
 		],
 		//* Returns true if platform should have touch events.
 		hasTouchScrolling: function() {
@@ -118,10 +119,6 @@ enyo.kind({
 			}
 			// special detection for IE10+ on touch devices
 			if (enyo.platform.ie >= 10 && enyo.platform.touch) {
-				return true;
-			}
-			// special detection for FirefoxOS
-			if (enyo.platform.firefox && enyo.platform.touch) {
 				return true;
 			}
 		},


### PR DESCRIPTION
Fix to use touch scroller for FirefoxOS

Enyo-DCO-1.1-Signed-off-by: Jason Robitaille jason@canuckcoding.ca
