### PR TITLE
Fixed scrollTo() for TransitionScrollStrategy, and updated the webkitTransitionEnd check to be more specific.

### DIFF
--- a/source/touch/TransitionScrollStrategy.js
+++ b/source/touch/TransitionScrollStrategy.js
@@ -247,7 +247,6 @@ enyo.kind({
 	// Apply transform to scroll the scroller
 	effectScroll: function() {
 		var o = (-1*this.scrollLeft) + "px, " + (-1*this.scrollTop) + "px" + (this.accel ? ", 0" : "");
-		this.log(o);
 		enyo.dom.transformValue(this.$.client, this.translation, o);
 	},
 	// On touch, stop transition by setting transform values to current computed style, and


### PR DESCRIPTION
Enyo-DCO-1.1-Signed-off-by: Chris Patalano chris.patalano@palm.com
