### PR TITLE
alert user if kind is created without <body> in DOM

### DIFF
--- a/source/dom/Control.js
+++ b/source/dom/Control.js
@@ -400,7 +400,12 @@ enyo.kind({
 	setupOverflowScrolling: function() {
 		if(enyo.platform.android || enyo.platform.androidChrome || enyo.platform.blackberry)
 			return;
-		document.getElementsByTagName("body")[0].className += " webkitOverflowScrolling";
+		var body = document.getElementsByTagName("body")[0];
+		if (typeof(body) === 'undefined') {
+			alert("Error: no <body> found in your html page. Main kind should be created within <body> tag") ;
+			return;
+		}
+		body.className += " webkitOverflowScrolling";
 	},
 	//
 	//


### PR DESCRIPTION
ok. I did a newbie mistake forgetting &lt;body&gt; in my HTML page. But it took
too much time to find the error. So I've added a test and an alert if
&lt;body&gt; is missing from index.html

Enyo-DCO-1.1-Signed-off-by: Dominique Dumont dominique.dumont@hp.com
