### PR TITLE
Exclude .git dir when copying entire library in deploy.js

### DIFF
--- a/tools/deploy.js
+++ b/tools/deploy.js
@@ -217,7 +217,7 @@ function deployLib(lib) {
 				throw new Error("*** Not a file: '" + script + "'");
 			run([script, libOutdir]);
 		} catch(e2) {
-			// no deploy.(js|bat|sh): copy everything (then remove ".git" dir, if any)
+			// no deploy.(js|bat|sh): copy everything (then remove ".git", if any)
 			shell.cp('-r', path.join(sourceDir, 'lib', lib), path.join(outDir, 'lib'));
 			shell.rm('-rf', path.join(outDir, 'lib', lib, '.git'));
 		}


### PR DESCRIPTION
I noticed a problem with the copying of libs that don't have their own deploy.js or deploy.sh/.bat script…  The "catch(e2)" code in function deployLib(lib) simply does a "cp -r" of the entire lib directory to the outDir.  Unfortunately that ALSO copies the .git directory if there happens to be one.  We should not be deploying the .git directory of any included libs.

Enyo-DCO-1.1-Signed-off-by: Steve Lemke steve.lemke@palm.com
