### PR TITLE
ENYO-2045:Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,19 +1,26 @@
 {
-    "name": "enyo",
+    "name": "enyojs",
     "filename": "enyo.js",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "description":"Enyo is an open source object-oriented JavaScript framework emphasizing encapsulation and modularity. Enyo contains everything you need to create a fast, scalable mobile or web application.",
     "homepage": "http://enyojs.com/",
+    "bugs": "http://jira.enyojs.com/",
     "keywords": [ "framework", "toolkit", "components", "mobile", "webOS" ],
     "maintainers": [{
-        "name": "Enyo JS Framework Team (HP)",
+        "name": "Enyo JS Framework Team",
         "web": "http://enyojs.com/"
     }],
     "licenses": [{
         "type": "Apache-2.0", "url": "http://www.apache.org/licenses/LICENSE-2.0"
     }],
     "bugs": "https://jira.enyojs.com/",
-    "repositories": [{
+    "repository": {
         "type": "git", "url": "http://github.com/enyojs/enyo"
-    }]
+    },
+    "dependencies": [
+        {"less": "1.3.0"},
+        {"uglify-js": "1.3.2"},
+        {"shelljs": "0.0.8"},
+        {"nopt": "2.0.0"}
+    ]
 }


### PR DESCRIPTION
ENYO-2045: Went through https://npmjs.org/doc/json.html and updated it to include our dependencies and fix the repository link.  Will need to check to see how npm installs this, as I suspect that all the node modules will now be off the top-level, meaning tools scripts will need changes.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
