### PR TITLE
Added enyo.dispatcher.stopListening() to remove event listeners, as well as enyo.unmakeBubble() to remove event listening/bubbling from enyo.makeBubble()

### DIFF
--- a/source/dom/dispatcher.js
+++ b/source/dom/dispatcher.js
@@ -184,7 +184,7 @@ enyo.bubbler = "enyo.bubble(arguments[0])";
 				}
 			}, control);
 		}
-        };
+	};
 })();
 
 // FIXME: we need to create and initialize dispatcher someplace else to allow overrides


### PR DESCRIPTION
Added enyo.dispatcher.stopListening() to remove event listeners, as well as enyo.unmakeBubble() to remove event listening/bubbling from enyo.makeBubble()
