### PR TITLE
Bug with contentType: 'application/json; charset=utf-8'

### DIFF
--- a/source/ajax/Ajax.js
+++ b/source/ajax/Ajax.js
@@ -101,7 +101,7 @@ enyo.kind({
 			} else {
 				xhr_headers["Content-Type"] = this.contentType;
 				if (body instanceof Object) {
-					if (this.contentType.indexOf("application/json") === 0) {
+					if (this.contentType.match(/^application\/json(;.*)?$/) !== null) {
 						body = JSON.stringify(body);
 					} else if (this.contentType === "application/x-www-form-urlencoded") {
 						body = enyo.Ajax.objectToQuery(body);


### PR DESCRIPTION
Check if contentType **begins with** 'application/json' instead of checking if contentType **is** 'application/json'.

Otherwise it sets the post body to '[Object object]' when contentType is set to 'application/json; charset=utf-8'.

Enyo-DCO-1.1-Signed-off-by: Amjad Mohamed andhos@gmail.com
