### PR TITLE
ENYO-2284: Overloaded methods via mixins can inject a function to other kinds

### DIFF
--- a/source/kernel/lang.js
+++ b/source/kernel/lang.js
@@ -155,7 +155,6 @@
 		which to call it.
 	*/
 	enyo.proxyMethod = function (fn, context) {
-		delete fn._inherited;
 		return function () {
 			return fn.apply(context || this, arguments);
 		};

--- a/source/kernel/mixins/MixinSupport.js
+++ b/source/kernel/mixins/MixinSupport.js
@@ -91,7 +91,7 @@
 			// if it wants
 			if (proto[key] && "function" === typeof proto[key]) {
 				fn = proto[key];
-				proto[key] = prop;
+				prop = proto[key] = enyo.proxyMethod(prop);
 				prop._inherited = fn;
 				prop.nom = name + "." + key + "()";
 			} else {


### PR DESCRIPTION
ENYO-2284: Overloaded methods via mixins can inject a function to other kinds.

Fixed.

Enyo-DCO-1.1-Signed-off-by: Cole Davis cole.davis@lge.com
