### PR TITLE
fix for enyo.load()

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -123,8 +123,9 @@
 			}
 			for (var i in this.finishCallbacks) {
 				if (this.finishCallbacks[i]) {
-					this.finishCallbacks[i](inBlock);
+					var callback = this.finishCallbacks[i];
 					this.finishCallbacks[i] = null;
+					callback(inBlock);
 				}
 			}
 		},


### PR DESCRIPTION
After updating to enyo version 2.2.0 I noticed, that enyo.load() was broken. It loads just two first packages and stops. After applying of my changes is seems to work again.
