### PR TITLE
ENYO-2383: new flexlayout code caused enyo.Control to be .extend()'d.  T...

### DIFF
--- a/source/kernel/Oop.js
+++ b/source/kernel/Oop.js
@@ -243,7 +243,12 @@ enyo.kind.inherited = function (originals, replacements) {
 //
 enyo.kind.features.push(function(ctor, props) {
 	// install common statics
-	enyo.mixin(ctor, enyo.kind.statics);
+	if (!ctor.subclass) {
+		ctor.subclass = enyo.kind.statics.subclass;
+	}
+	if (!ctor.extend) {
+		ctor.extend = enyo.kind.statics.extend;
+	}
 	// move props statics to constructor
 	if (props.statics) {
 		enyo.mixin(ctor, props.statics);


### PR DESCRIPTION
...his caused the feature mixins to be run again which overwrote the custom subclass method.  The fix is to change the code that adds default subclass and extend features to not overwrite those properties if they already exist.

This was only seen on IE because the code that extended enyo.Control was an IE-only polyfill, but the problem could affect other situations too.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
