### PR TITLE
ENYO-2389: event bubbling fails when going through a non-UIComponent. Ad...

### DIFF
--- a/source/kernel/UiComponent.js
+++ b/source/kernel/UiComponent.js
@@ -275,7 +275,7 @@ enyo.kind({
 		}
 	},
 	getBubbleTarget: function() {
-		return this._bubble_target || this.parent;
+		return this._bubble_target || this.parent || this.owner;
 	}
 });
 


### PR DESCRIPTION
...ding this.owner, to the return of the getBubbleTarget function, solves the problem.

Enyo-DCO-1.1-Signed-off-by: Marc Dominjon marc.dominjon@hp.com
