### PR TITLE
Update fix for Firefox exception with progress AJAX event -- code was fi...

### DIFF
--- a/source/ajax/Ajax.js
+++ b/source/ajax/Ajax.js
@@ -217,13 +217,15 @@ enyo.kind({
 	//* @protected
 	//* Handler for ajax progress events.
 	updateProgress: function(event) {
+		// filter out "input" as it causes exceptions on some Firefox versions
+		// due to unimplemented internal APIs
 		var ev = {};
 		for (var k in event) {
 			if (k !== 'input') {
 				ev[k] = event[k];
 			}
 		}
-		this.sendProgress(event.loaded, 0, event.total, event);
+		this.sendProgress(event.loaded, 0, event.total, ev);
 	},
 	statics: {
 		objectToQuery: function(/*Object*/ map) {


### PR DESCRIPTION
...ltering out input correctly, but used old "event" structure instead of the filtered ev.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
