### PR TITLE
GF-3947: remove check for webOS in determining if sync AJAX requests are...

### DIFF
--- a/source/ajax/Ajax.js
+++ b/source/ajax/Ajax.js
@@ -126,7 +126,7 @@ enyo.kind({
 				callback: this.bindSafely("receive"),
 				body: body,
 				headers: xhr_headers,
-				sync: window.PalmSystem ? false : this.sync,
+				sync: this.sync,
 				username: this.username,
 				password: this.password,
 				xhrFields: this.xhrFields,

--- a/source/ajax/AjaxProperties.js
+++ b/source/ajax/AjaxProperties.js
@@ -28,8 +28,7 @@ enyo.AjaxProperties = {
 	*/
 	contentType: "application/x-www-form-urlencoded",
 	/**
-		If true, makes a synchronous (blocking) call, if supported.  Synchronous requests
-		are not supported on HP webOS.
+		If true, makes a synchronous (blocking) call, if supported.
 	*/
 	sync: false,
 	/**


### PR DESCRIPTION
... allowed.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
