### PR TITLE
ENYO-2418: Adds legacy WebKit support for enyo.ready()

### DIFF
--- a/source/boot/ready.js
+++ b/source/boot/ready.js
@@ -36,8 +36,8 @@
 				flush();
 			}
 		}
-		// for an IE8 fallback and assurance
-		if ((ready = ("complete" === doc.readyState))) {
+		// for an IE8 fallback and legacy WebKit (including webOS 3.x and less) and assurance
+		if ((ready = ("complete" === doc.readyState || "loaded" === doc.readyState))) {
 			remove(event.type, init);
 			flush();
 		}


### PR DESCRIPTION
Enyo-DCO-1.1-Signed-off-by: Jason Robitaille jason.robitaille@lge.com
