### PR TITLE
Rework code that cloned events for hold/holdPulse to avoid affecting src...

### DIFF
--- a/source/dom/drag.js
+++ b/source/dom/drag.js
@@ -228,9 +228,10 @@ enyo.gesture.drag = {
 	},
 	beginHold: function(e) {
 		this.holdStart = enyo.now();
-		// clone the srcEvent to ensure it stays alive on IE upon returning to event loop
-		e.srcEvent = enyo.clone(e.srcEvent);
-		this.holdJob = setInterval(enyo.bind(this, "sendHoldPulse", e), this.holdPulseDelay);
+		// clone the event to ensure it stays alive on IE upon returning to event loop
+		var clonedEvent = enyo.clone(e);
+		clonedEvent.srcEvent = enyo.clone(e.srcEvent);
+		this.holdJob = setInterval(enyo.bind(this, "sendHoldPulse", clonedEvent), this.holdPulseDelay);
 	},
 	cancelHold: function() {
 		clearInterval(this.holdJob);


### PR DESCRIPTION
...Event on the initial event going through the tree, as this crashed code in ImageView

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
