### PR TITLE
Fixes ENYO-2475 by adding call to inherited() in constructor

### DIFF
--- a/source/ajax/Async.js
+++ b/source/ajax/Async.js
@@ -28,6 +28,7 @@ enyo.kind({
 	failed: false,
 	context: null,
 	constructor: function() {
+		this.inherited(arguments);
 		this.responders = [];
 		this.errorHandlers = [];
 		this.progressHandlers = [];


### PR DESCRIPTION
Enyo-DCO-1.1-Signed-off-by: Ryan Duffy ryan@tiqtech.com
