### PR TITLE
Prevent scroll reset on keypress

### DIFF
--- a/source/ui/RichText.js
+++ b/source/ui/RichText.js
@@ -73,16 +73,16 @@ enyo.kind({
 	},
 	valueChanged: function() {
 		var val = this.get("value");
-		if (this.hasFocus()) {
+		if (this.hasFocus() && val !== this.node.innerHTML) {
 			this.selectAll();
 			this.insertAtCursor(val);
-		} else {
+		} else if(!this.hasFocus()) {
 			this.set("content", val);
 		}
 	},
 	updateValue: function() {
 		var val = this.node.innerHTML;
-		this.value = val;
+		this.set("value", val);
 	},
 	updateValueAsync: function() {
 		enyo.asyncMethod(this.bindSafely("updateValue"));


### PR DESCRIPTION
No need to replace content with content on each keypress, it resets scroller position in case of overflow.

Enyo-DCO-1.1-Signed-Off-By: Rafa Bernad (rafa.bernad@newn.es)
