### PR TITLE
ENYO-2301: fix XHR code to only apply cache-control code for iOS 6, not ...

### DIFF
--- a/source/ajax/xhr.js
+++ b/source/ajax/xhr.js
@@ -16,6 +16,11 @@ enyo.xhr = {
 		- _password_: The optional password to use for authentication purposes.
 		- _xhrFields_: Optional object containing name/value pairs to mix directly into the generated xhr object.
 		- _mimeType_: Optional string to override the MIME-Type.
+
+		Note: on iOS 6, we will explicity add a "cache-control: no-cache"
+		header for any non-GET requests to workaround a system bug that caused
+		non-cachable requests to be cached. To disable this, use the _header_
+		property to specify an object where "cache-control" is set to null.
 	*/
 	request: function(inParams) {
 		var xhr = this.getXMLHttpRequest(inParams);
@@ -37,10 +42,9 @@ enyo.xhr = {
 		}
 		//
 		inParams.headers = inParams.headers || {};
-		// work around iOS 6 bug where non-GET requests are cached
+		// work around iOS 6.0 bug where non-GET requests are cached
 		// see http://www.einternals.com/blog/web-development/ios6-0-caching-ajax-post-requests
-		// not sure (yet) wether this will be required for later ios releases
-		if (method !== "GET" && enyo.platform.ios && enyo.platform.ios >= 6) {
+		if (method !== "GET" && enyo.platform.ios && enyo.platform.ios == 6) {
 			if (inParams.headers["cache-control"] !== null) {
 				inParams.headers["cache-control"] = inParams.headers['cache-control'] || "no-cache";
 			}


### PR DESCRIPTION
...6+. Clarify comments to note this behavior.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
