### PR TITLE
Small changes to allow events to propagate our of enyo.Collections to th...

### DIFF
--- a/source/kernel/data/Collection.js
+++ b/source/kernel/data/Collection.js
@@ -482,20 +482,6 @@
 
 		//*@public
 		/**
-			Overloaded `ownerChanged` to prevent the normal handlers
-			from executing. Overload with care.
-		*/
-		ownerChanged: function(old) {
-			if (old && old.removeComponent) {
-				old.removeComponent(this);
-			}
-			if (this.owner && this.owner.addComponent) {
-				this.owner.addComponent(this);
-			}
-		},
-
-		//*@public
-		/**
 			Accepts an array of models to add to the _collection_ at creation.
 		*/
 		constructor: function (props) {

--- a/source/ui/data/DataRepeater.js
+++ b/source/ui/data/DataRepeater.js
@@ -95,21 +95,12 @@
 			}
 		},
 
-		render: function () {
-			this.reset();
-			this.inherited(arguments);
-		},
-
 		//*@public
 		add: function (rec) {
-			if (!this.generated) {
-				return;
-			}
 			var $k = this._childKind;
 			var $c = this.createComponent({kind: $k});
-			var b = this.batching;
 			$c.set("model", rec);
-			if (!b) {
+			if (this.generated && !this.batching) {
 				$c.render();
 			}
 		},


### PR DESCRIPTION
...eir owners, needed to resolve issue with enyo.DataRepeater not updating. Also, adjust enyo.DataRepeater to always add components and not reset() on render() call.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
