### PR TITLE
Change check used to only refresh bindings to or from a controller to al...

### DIFF
--- a/source/kernel/mixins/ControllerSupport.js
+++ b/source/kernel/mixins/ControllerSupport.js
@@ -73,7 +73,7 @@ enyo.createMixin({
 		// we rebuild (rather than refresh) our bindings because
 		// they are now most likely connected to the previous controller.
 		for (var $i=0, b$; (b$=this.bindings[$i]); ++$i) {
-			if (b$.source == this || b$.from == "controller" || b$.from == ".controller") {
+			if (b$.source == this || /^\.?controller(\.*)?/.test(b$.from)) {
 				b$.rebuild();
 			}
 		}


### PR DESCRIPTION
...so look at bindings from a controller's children. This fixes some binding problems seen in internal tests after change d4914e48b43b92198cdd7a41ff37a91ec39258ee.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)

(NOTE: I know regex isn't the fastest way to do this... just wanted to start conversation about this problem)
