### PR TITLE
Combine seperated custom events into one.

### DIFF
--- a/source/ui/Drawer.js
+++ b/source/ui/Drawer.js
@@ -22,7 +22,11 @@ enyo.kind({
 		animated: true
 	},
 	events: {
-		//* Fires when the the drawers are activated or deactived.
+		/** 
+			Fires when the the drawers are activated or deactived.
+			Handler could distinguish whether drawer is opened or not using _open_ property.
+			If this.getOpen() returns true, drawer is opened. The other hand, it is closed.
+		*/
 		onDrawerAnimationEnd: ""
 	},
 	//* @protected


### PR DESCRIPTION
Actually, status of drawer could be distinguished with this.open
property.
So, custom event do not need to be seperated into onExpand and
onCollapse.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
