### PR TITLE
Fix core code so IE8 will once again pass core tests/LoaderTest.js

### DIFF
--- a/source/kernel/Oop.js
+++ b/source/kernel/Oop.js
@@ -56,7 +56,7 @@ enyo.kind = function(inProps) {
 	if (name && !inProps.noDefer && !inProps.statics) {
 		// make a deferred constructor to avoid a lot of kind
 		// processing if we're never used
-		var ctor = function DeferredCtor() {
+		var DeferredCtor = function() {
 			var FinalCtor;
 			// check for cached final constructor first, used mainly when
 			// developers directly use kind names in their components instead of
@@ -73,22 +73,22 @@ enyo.kind = function(inProps) {
 			FinalCtor.apply(obj, arguments);
 			return obj;
 		};
-		ctor._finishKindCreation = function() {
-			ctor._finishKindCreation = undefined;
+		DeferredCtor._finishKindCreation = function() {
+			DeferredCtor._finishKindCreation = undefined;
 			enyo.setPath(name, undefined);
 			var FinalCtor = enyo.kind.finish(inProps);
-			ctor._FinalCtor = FinalCtor;
+			DeferredCtor._FinalCtor = FinalCtor;
 			inProps = null;
 			return FinalCtor;
 		};
 		if ((name && !enyo.getPath(name)) || enyo.kind.allowOverride) {
-			enyo.setPath(name, ctor);
+			enyo.setPath(name, DeferredCtor);
 		}
 		else if (name) {
 			enyo.error("enyo.kind: " + name + " is already in use by another " +
 				"kind, all kind definitions must have unique names.");
 		}
-		return ctor;
+		return DeferredCtor;
 	} else {
 		// create anonymous kinds immediately
 		return enyo.kind.finish(inProps);
@@ -193,8 +193,8 @@ enyo.singleton = function(conf, context) {
 
 //* @protected
 enyo.kind.makeCtor = function() {
-	return function ctor() {
-		if (!(this instanceof ctor)) {
+	var enyoConstructor = function() {
+		if (!(this instanceof enyoConstructor)) {
 			throw "enyo.kind: constructor called directly, not using 'new'";
 		}
 
@@ -219,6 +219,7 @@ enyo.kind.makeCtor = function() {
 			return result;
 		}
 	};
+	return enyoConstructor;
 };
 
 // classes referenced by name can omit this namespace (e.g. "Button" instead of "enyo.Button")

--- a/source/kernel/lang.js
+++ b/source/kernel/lang.js
@@ -373,7 +373,8 @@
 
 	//* Returns true if the argument is an object.
 	enyo.isObject = Object.isObject || function (it) {
-		return toString.call(it) === "[object Object]";
+		// explicit null/undefined check for IE8 compatibility
+		return (it != null) && (toString.call(it) === "[object Object]");
 	};
 
 	//* Returns true if the argument is true.

--- a/source/ui/fullscreen.js
+++ b/source/ui/fullscreen.js
@@ -1,7 +1,7 @@
 enyo.fullscreen = {
-	
+
 	//* @protected
-	
+
 	//* Reference to the current fs control
 	fullscreenControl: null,
 	//* Reference to the current fs element (fallback for platforms w/o native support)
@@ -26,9 +26,9 @@ enyo.fullscreen = {
 		("mozCancelFullScreen" in document) ? "mozCancelFullScreen" :
 		("webkitCancelFullScreen" in document) ? "webkitCancelFullScreen" :
 		null,
-	
+
 	//* @public
-	
+
 	//* Return true if platform supports all of the fullscreen API
 	nativeSupport: function() {
 		return (this.elementAccessor !== null && this.requestAccessor !== null && this.cancelAccessor !== null);
@@ -66,9 +66,9 @@ enyo.fullscreen = {
 			this.fallbackCancelFullscreen();
 		}
 	},
-	
+
 	//* @protected
-	
+
 	//* Fallback support for setting fullscreen element (done by browser on platforms with native support)
 	setFullscreenElement: function(inNode) {
 		this.fullscreenElement = inNode;
@@ -80,7 +80,7 @@ enyo.fullscreen = {
 	//* Fallback fullscreen request for platforms without fullscreen support
 	fallbackRequestFullscreen: function() {
 		var control = this.requestor;
-		
+
 		if (!control) {
 			return;
 		}
@@ -141,9 +141,12 @@ enyo.fullscreen = {
 
 //* Normalize platform-specific fs change events
 enyo.ready(function() {
-	document.addEventListener("webkitfullscreenchange", enyo.bind(enyo.fullscreen, "detectFullscreenChangeEvent"), false);
-	document.addEventListener("mozfullscreenchange",    enyo.bind(enyo.fullscreen, "detectFullscreenChangeEvent"), false);
-	document.addEventListener("fullscreenchange",       enyo.bind(enyo.fullscreen, "detectFullscreenChangeEvent"), false);
+	// no need for IE8 fallback, since it won't ever send this event
+	if (document.addEventListener) {
+		document.addEventListener("webkitfullscreenchange", enyo.bind(enyo.fullscreen, "detectFullscreenChangeEvent"), false);
+		document.addEventListener("mozfullscreenchange",    enyo.bind(enyo.fullscreen, "detectFullscreenChangeEvent"), false);
+		document.addEventListener("fullscreenchange",       enyo.bind(enyo.fullscreen, "detectFullscreenChangeEvent"), false);
+	}
 });
 
 //* If this platform doesn't have native support for fullscreen, add an escape handler to mimic native behavior

--- a/tools/test/core/tests/LoaderTest.js
+++ b/tools/test/core/tests/LoaderTest.js
@@ -1,54 +1,59 @@
-enyo.kind({
-	name: "LoaderTest",
-	kind: enyo.TestSuite,
-	noDefer: true,
-	testSingleLoad: function() {
-		enyo.load("tests/loader/loader1.js",
-			this.bindSafely(function() {
-				if (window.LOADER_TEST === "loader1") {
-					this.finish();
+// LoaderTest will fail on IE8 -- we don't support file loading
+// on that platform due to limits on the number of script and
+// CSS files that you can pull into a single webpage.
+if (!enyo.platform.ie || enyo.platform.ie >= 9) {
+	enyo.kind({
+		name: "LoaderTest",
+		kind: enyo.TestSuite,
+		noDefer: true,
+		testSingleLoad: function() {
+			enyo.load("tests/loader/loader1.js",
+				this.bindSafely(function() {
+					if (window.LOADER_TEST === "loader1") {
+						this.finish();
+					}
+					else {
+						this.finish("callback called before load complete");
+					}
 				}
-				else {
-					this.finish("callback called before load complete");
+			));
+		},
+		testMultipleLoad: function() {
+			enyo.load(["tests/loader/loader2a.js", "tests/loader/loader2b.js"],
+				this.bindSafely(function() {
+					if (window.LOADER_TEST === "loader2b") {
+						this.finish();
+					}
+					else {
+						this.finish("callback called before load complete");
+					}
 				}
-			}
-		));
-	},
-	testMultipleLoad: function() {
-		enyo.load(["tests/loader/loader2a.js", "tests/loader/loader2b.js"],
-			this.bindSafely(function() {
-				if (window.LOADER_TEST === "loader2b") {
-					this.finish();
+			));
+		},
+		testMultipleLoadWith404: function() {
+			enyo.load(["tests/loader/loader2b.js", "tests/loader/loader2a.js", "tests/loader/anotherfilethatdoesnotexist.js"],
+				this.bindSafely(function(block) {
+					if (window.LOADER_TEST === "loader2a" && block.failed.length === 1 && block.failed[0] === "./tests/loader/anotherfilethatdoesnotexist.js") {
+						this.finish();
+					}
+					else {
+						this.finish("callback called before load complete");
+					}
 				}
-				else {
-					this.finish("callback called before load complete");
+			));
+		},
+		testPackageLoad: function() {
+			// added a new folder (loader) with a package.js looking for a file setting window.PACKAGE_TEST and a file that doesn't exist
+			enyo.load(["tests/loader"],
+				this.bindSafely(function(block) {
+					if (window.PACKAGE_TEST === "loaded" && block.failed.length === 1 && block.failed[0] === "./tests/loader/nothere.js") {
+						this.finish();
+					}
+					else {
+						this.finish("callback called before load complete");
+					}
 				}
-			}
-		));
-	},
-	testMultipleLoadWith404: function() {
-		enyo.load(["tests/loader/loader2b.js", "tests/loader/loader2a.js", "tests/loader/anotherfilethatdoesnotexist.js"],
-			this.bindSafely(function(block) {
-				if (window.LOADER_TEST === "loader2a" && block.failed.length === 1 && block.failed[0] === "./tests/loader/anotherfilethatdoesnotexist.js") {
-					this.finish();
-				}
-				else {
-					this.finish("callback called before load complete");
-				}
-			}
-		));
-	},
-	testPackageLoad: function() {
-		// added a new folder (loader) with a package.js looking for a file setting window.PACKAGE_TEST and a file that doesn't exist
-		enyo.load(["tests/loader"],
-			this.bindSafely(function(block) {
-				if (window.PACKAGE_TEST === "loaded" && block.failed.length === 1 && block.failed[0] === "./tests/loader/nothere.js") {
-					this.finish();
-				}
-				else {
-					this.finish("callback called before load complete");
-				}
-			}
-		));
-	}
-});
+			));
+		}
+	});
+}

--- a/tools/test/core/tests/langTest.js
+++ b/tools/test/core/tests/langTest.js
@@ -54,6 +54,60 @@ enyo.kind({
 		var index = enyo.indexOf("foo", [null, null, null, null,"foo"], 10);
 		this.finish(index !== -1 ? "if fromIndex is greater then array length, should return -1" : false);
 	},
+	testIsObject: function() {
+		if (!enyo.isObject({})) {
+			this.finish("enyo.isObject failed on object");
+			return;
+		}
+		if (enyo.isObject(undefined)) {
+			this.finish("enyo.isObject failed on undefined");
+			return;
+		}
+		if (enyo.isObject(null)) {
+			this.finish("enyo.isObject failed on null");
+			return;
+		}
+		if (enyo.isObject([1,2,3])) {
+			this.finish("enyo.isObject failed on array");
+			return;
+		}
+		if (enyo.isObject(42)) {
+			this.finish("enyo.isObject failed on number");
+			return;
+		}
+		if (enyo.isObject("forty-two")) {
+			this.finish("enyo.isObject failed on string");
+			return;
+		}
+		this.finish();
+	},
+	testIsArray: function() {
+		if (enyo.isArray({})) {
+			this.finish("enyo.isArray failed on object");
+			return;
+		}
+		if (enyo.isArray(undefined)) {
+			this.finish("enyo.isArray failed on undefined");
+			return;
+		}
+		if (enyo.isArray(null)) {
+			this.finish("enyo.isArray failed on null");
+			return;
+		}
+		if (!enyo.isArray([1,2,3])) {
+			this.finish("enyo.isArray failed on array");
+			return;
+		}
+		if (enyo.isArray(42)) {
+			this.finish("enyo.isArray failed on number");
+			return;
+		}
+		if (enyo.isArray("forty-two")) {
+			this.finish("enyo.isArray failed on string");
+			return;
+		}
+		this.finish();
+	},
 	// test the various configurations of enyo.mixin
 	testMixin: function () {
 		var $t = {}, $s = {one:"one",two:"two"};


### PR DESCRIPTION
- Oop.js: change code to not use function names, but instead a variable holding function ref in the closure to avoid IE8 scoping problems
- lang.js: update enyo.isObject to explicitly check for null/undefined, as those identify as "{object Object]" in IE8
- fullscreen.js: guard calls to addEventListener; they won't be made on IE8
- Add core tests for enyo.isObject and enyo.isArray
- Modifiy LoaderTest.js to do nothing on IE8, since we don't support loader there

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
