### PR TITLE
Add documentation for enyo.ready and provide guarantee that all callback...

### DIFF
--- a/source/boot/ready.js
+++ b/source/boot/ready.js
@@ -1,4 +1,4 @@
-(function (scope) {
+(function (scope, enyo) {
 
 	// we need to register appropriately to know when
 	// the document is officially ready, to ensure that
@@ -14,15 +14,25 @@
 	var add;
 	var flush;
 
+	//*@public
+	/**
+		Register a callback (and optional "this" context) to run
+		after all the enyo and library code has loaded and the DOMContentLoaded
+		(or equivalent on older browsers) event has been sent.
+
+		If called after system is in a ready state, run the supplied code
+		asynchronously at earliest opportunity.
+	*/
 	enyo.ready = function (fn, context) {
 		if (ready) {
-			run(fn, context);
+			enyo.asyncMethod(context || enyo.global, fn);
 		}
 		else {
 			queue.push([fn, context]);
 		}
 	};
 
+	//*@protected
 	run = function (fn, context) {
 		fn.call(context || enyo.global);
 	};

--- a/tools/test/ajax/index.html
+++ b/tools/test/ajax/index.html
@@ -12,9 +12,7 @@
 		<script src="../core/test.js" type="text/javascript"></script>
 		<script src="tests/package.js" type="text/javascript"></script>
 	</head>
-	<body style="font-size: medium">
-		<script type="text/javascript">
-			new enyo.TestRunner({fit: false}).renderInto(document.body);
-		</script>
+	<body>
+	<!-- move render call into test.js using enyo.ready to test that feature -->
 	</body>
 </html>

--- a/tools/test/core/index.html
+++ b/tools/test/core/index.html
@@ -13,8 +13,6 @@
 		<script src="tests/package.js" type="text/javascript"></script>
 	</head>
 	<body>
-		<script type="text/javascript">
-			new enyo.TestRunner({fit: false}).renderInto(document.body);
-		</script>
+	<!-- move render call into test.js using enyo.ready to test that feature -->
 	</body>
 </html>

--- a/tools/test/core/test.js
+++ b/tools/test/core/test.js
@@ -311,3 +311,7 @@ enyo.kind({
 		info.setClasses("enyo-testcase-" + (results.passed ? "passed" : "failed"));
 	}
 });
+
+enyo.ready(function() {
+	new enyo.TestRunner({fit: false}).renderInto(document.body);
+});

--- a/tools/test/core/tests/package.js
+++ b/tools/test/core/tests/package.js
@@ -1,4 +1,5 @@
 enyo.depends(
+	"readyTest.js",
 	"langTest.js",
 	"JobTest.js",
 	"JobsTest.js",

--- a/tools/test/core/tests/readyTest.js
+++ b/tools/test/core/tests/readyTest.js
@@ -1,0 +1,21 @@
+enyo.kind({
+	name: "readyTest",
+	kind: enyo.TestSuite,
+	noDefer: true,
+	testRunning: function() {
+		// this test always succeeds.  If enyo.ready() were borked, this test wouldn't run
+		this.finish();
+	},
+	testAsync: function() {
+		var good = false;
+		enyo.ready(function () {
+			if (good) {
+				this.finish();
+			} else {
+				this.finish("enyo.ready() ran call immediately instead of async");
+			}
+		}, this);
+		good = true;
+		// we rely on test framework timeout to catch failure if code is never run
+	}
+});


### PR DESCRIPTION
...s are async by using enyo.asyncMethod.

Add tests for enyo.ready by modifying test runner to use it to start things.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
