### PR TITLE
Fix bad invocation of new operator in ViewController.js -- was trying to...

### DIFF
--- a/source/kernel/ViewController.js
+++ b/source/kernel/ViewController.js
@@ -155,7 +155,8 @@
 			// retrieve the constructor for the view and immediately
 			// instance it while also updating the _view_ property to
 			// the reference for this new view
-			this.set("view", new this.get("_view_kind"));
+			var Ctor = this.get("_view_kind");
+			this.set("view", new Ctor());
 		},
 
 		//*@protected


### PR DESCRIPTION
... new "this.get" instead of what this.get(...) returned.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
