### PR TITLE
Add _bubble_target setting to enyo.ViewController, matching override use...

### DIFF
--- a/source/kernel/ViewController.js
+++ b/source/kernel/ViewController.js
@@ -156,7 +156,7 @@
 			// instance it while also updating the _view_ property to
 			// the reference for this new view
 			var Ctor = this.get("_view_kind");
-			this.set("view", new Ctor());
+			this.set("view", new Ctor({_bubble_target: this}));
 		},
 
 		//*@protected


### PR DESCRIPTION
...d by enyo.Application to allow events to bubble up from owned view.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
