### PR TITLE
GF-6106: add Enyo platform check for webOS 4 / Open webOS, indicated by WebA...

### DIFF
--- a/source/dom/platform.js
+++ b/source/dom/platform.js
@@ -57,6 +57,8 @@ enyo.platform = {
 		{platform: "ios", regex: /iP(?:hone|ad;(?: U;)? CPU) OS (\d+)/},
 		// webOS 1 - 3
 		{platform: "webos", regex: /(?:web|hpw)OS\/(\d+)/},
+		// webOS 4 / OpenWebOS
+		{platform: "webos", regex: /WebAppManager|Isis/, forceVersion: 4},
 		// desktop Safari
 		{platform: "safari", regex: /Version\/(\d+)[.\d]+\s+Safari/},
 		// desktop Chrome


### PR DESCRIPTION
...ppManager or Isis in UA string

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
