### PR TITLE
Fixed 'call to undefined method addToRoots()'

### DIFF
--- a/source/kernel/ViewController.js
+++ b/source/kernel/ViewController.js
@@ -129,8 +129,6 @@
 			in the DOM).
 		*/
 		renderInto: function (target) {
-			enyo.Control.prototype.addToRoots.call(this);
-
 			// update the render target for the controller
 			this.set("renderTarget", target);
 			// now we render as usual


### PR DESCRIPTION
At the moment, ViewController does not inherit from Control, however, tries to make use of Control's addToRoots() method directly, which understandably causes 'no such method' exception thrown when trying to renderInto. 
