### PR TITLE
ENYO-2227: Add platform detection for Blackberry playbook

### DIFF
--- a/source/dom/platform.js
+++ b/source/dom/platform.js
@@ -71,6 +71,8 @@ enyo.platform = {
 		{platform: "firefoxOS", regex: /Mobile;.*Firefox\/(\d+)/},
 		// desktop Firefox
 		{platform: "firefox", regex: /Firefox\/(\d+)/},
+		// Blackberry Playbook
+		{platform: "blackberry", regex: /PlayBook/i, forceVersion: 2},
 		// Blackberry 10+
 		{platform: "blackberry", regex: /BB1\d;.*Version\/(\d+\.\d+)/},
 		// Tizen


### PR DESCRIPTION
Thanks to Olivier Salamin for the fix

Enyo=DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
