### PR TITLE
ENYO-2229: modify enyo.dom.getComputedBoxValue with workaround for IE8

### DIFF
--- a/source/dom/dom.js
+++ b/source/dom/dom.js
@@ -189,7 +189,7 @@ enyo.dom = {
 	_pxMatch: /px/i,
 	getComputedBoxValue: function(inNode, inProp, inBoundary, inComputedStyle) {
 		var s = inComputedStyle || this.getComputedStyle(inNode);
-		if (s) {
+		if (s && (!enyo.platform.ie || enyo.platform.ie >= 9)) {
 			var p = s.getPropertyValue(inProp + "-" + inBoundary);
 			return p === "auto" ? 0 : parseInt(p, 10);
 		} else if (inNode && inNode.currentStyle) {


### PR DESCRIPTION
Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
