### PR TITLE
Add option to defeat default container resizing behavior

### DIFF
--- a/source/ui/Drawer.js
+++ b/source/ui/Drawer.js
@@ -19,7 +19,12 @@ enyo.kind({
 		*/
 		orient : "v",
 		//* If true, the opening/closing transition will be animated
-		animated : true
+		animated : true,
+		/**
+			If true, Drawer will resize it's container as it's animating, which is useful
+			when placed inside of a FittableLayout
+		*/
+		resizeContainer: true
 	},
 	events: {
 		/**
@@ -99,7 +104,7 @@ enyo.kind({
 			var o = (this.open ? inSender.endValue : inSender.startValue);
 			cn.style[p] = this.$.client.domStyles[p] = (inSender.value - o) + "px";
 		}
-		if (this.container) {
+		if (this.container && this.resizeContainer) {
 			this.container.resized();
 		}
 		this.doDrawerAnimationStep();
@@ -125,7 +130,7 @@ enyo.kind({
 				this.node.style[d] = this.domStyles[d] = null;
 			}
 		}
-		if (this.container) {
+		if (this.container && this.resizeContainer) {
 			this.container.resized();
 		}
 		this.doDrawerAnimationEnd();


### PR DESCRIPTION
This helps fix a widget regression where a widget was attempting to avoid container resizing by checking isAnimating() in the container's resizeHandler.  With a recent enyo.Animator change to call cancel() before firing onEnd, isAnimating() no longer returns true in the context of the onEnd event (which seems correct, since the animation has finished), so there's no longer an external way to defeat resizing; much cleaner to make it an API of Drawer itself.

Enyo-DCO-1.1-Signed-off-by: Kevin Schaaf kevin.schaaf@lge.com
