### PR TITLE
Make fast implementations of enyo.setPath/getPath that only work with lo...

### DIFF
--- a/source/kernel/Object.js
+++ b/source/kernel/Object.js
@@ -252,7 +252,7 @@ enyo.Object.addGetterSetter = function (prop, value, proto) {
 	fn = proto[get];
 	// if there isn't already a getter provided create one
 	if (!enyo.isFunction(fn)) {
-		fn = proto[get] = function () { return this.get(prop); };
+		fn = proto[get] = function () { return enyo.getPath.fast.call(this, prop); };
 		fn.overloaded = false;
 	} else if (false !== fn.overloaded) {
 		// otherwise we need to mark it as having been overloaded
@@ -262,7 +262,7 @@ enyo.Object.addGetterSetter = function (prop, value, proto) {
 	// if there isn't already a set provided, create one
 	fn = proto[set];
 	if ("function" !== typeof fn) {
-		fn = proto[set] = function () { return this.set(prop, arguments[0]); };
+		fn = proto[set] = function () { return enyo.setPath.fast.call(this, prop, arguments[0]); };
 		fn.overloaded = false;
 	} else if (false !== fn.overloaded) {
 		// otherwise we need to mark it as having been overloaded

--- a/tools/test/core/tests/KindTest.js
+++ b/tools/test/core/tests/KindTest.js
@@ -60,5 +60,40 @@ enyo.kind({
 		});
 		var d = new Derived();
 		d.pass(this);
+	},
+	testPublished: function() {
+		var K = enyo.kind({
+			published: {
+				a: 42,
+				b: "",
+				c: null
+			},
+			d: 23
+		});
+		var k = new K({a: 16});
+		try {
+			if (!enyo.isFunction(k.setA) || !enyo.isFunction(k.getA) ||
+				!enyo.isFunction(k.setB) || !enyo.isFunction(k.getB) ||
+				!enyo.isFunction(k.setC) || !enyo.isFunction(k.getC)) {
+				throw "no getter or setter defined for published property";
+			}
+			if (k.getA() !== 16) {
+				throw "getA failed";
+			}
+			k.setB("testing");
+			if (k.b !== "testing") {
+				throw "setB failed";
+			}
+			k.set("c", "hello");
+			if (k.getC() !== "hello") {
+				throw "set('c') or getC() failed";
+			}
+		}
+		finally {
+			k.destroy();
+		}
+		this.finish();
 	}
+
+
 });


### PR DESCRIPTION
...cal property names.  This isn't for public use, but allows the code generated for published properties to avoid extra tests.

Add a published property test to core tests.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
