### PR TITLE
Create __jobs hash on the instance, not on the prototype.

### DIFF
--- a/source/kernel/Component.js
+++ b/source/kernel/Component.js
@@ -91,7 +91,6 @@ enyo.kind({
 		enyo.ComponentBindingSupport
 	],
 	concat: ["handlers", "events"],
-	__jobs: {},
 	toString: function() {
 		return this.kindName;
 	},
@@ -100,6 +99,7 @@ enyo.kind({
 			// initialize instance objects
 			this._componentNameMap = {};
 			this.$ = {};
+			this.__jobs = {};
 			sup.apply(this, arguments);
 		};
 	}),


### PR DESCRIPTION
Enyo-DCO-1.1-Signed-off-by: Kevin Schaaf kevin.schaaf@lge.com
