### PR TITLE
ENYO-2945: Fix to allow taps from children of repeater item to select as...

### DIFF
--- a/source/ui/data/RepeaterChildSupport.js
+++ b/source/ui/data/RepeaterChildSupport.js
@@ -145,8 +145,9 @@ enyo.RepeaterChildSupport = {
 	*/
 	dispatchEvent: enyo.super(function (sup) {
 		return function (name, event, sender) {
-			if (name == "ontap" && sender === this) {
+			if (name == "ontap" && !event._fromRepeaterChild) {
 				this._selectionHandler(sender, event);
+				event._fromRepeaterChild = true;
 			}
 			return sup.apply(this, arguments);
 		};


### PR DESCRIPTION
... before, while still filtering out taps from nested repeaters.

Enyo-DCO-1.1-Signed-off-by: Kevin Schaaf kevin.schaaf@lge.com
