### PR TITLE
ENYO-2987: Change enyo.super to enyo.inherit to avoid clash with ES3 res...

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -3,6 +3,7 @@
         "enyo": false,
         "$L": false
     },
+    "es3": true,
     "evil": false,
     "regexdash": true,
     "browser": true,

--- a/source/ajax/Ajax.js
+++ b/source/ajax/Ajax.js
@@ -25,7 +25,7 @@ enyo.kind({
 	//* published by _enyo.Ajax_.
 	published: enyo.AjaxProperties,
 	//* @protected
-	constructor: enyo.super(function (sup) {
+	constructor: enyo.inherit(function (sup) {
 		return function(inParams) {
 			enyo.mixin(this, inParams);
 			sup.apply(this, arguments);
@@ -162,7 +162,7 @@ enyo.kind({
 			}
 		}
 	},
-	fail: enyo.super(function (sup) {
+	fail: enyo.inherit(function (sup) {
 		return function(inError) {
 			// on failure, explicitly cancel the XHR to prevent
 			// further responses.  cancellation also resets the

--- a/source/ajax/Async.js
+++ b/source/ajax/Async.js
@@ -27,7 +27,7 @@ enyo.kind({
 	//* @protected
 	failed: false,
 	context: null,
-	constructor: enyo.super(function (sup) {
+	constructor: enyo.inherit(function (sup) {
 		return function() {
 			sup.apply(this, arguments);
 			this.responders = [];

--- a/source/ajax/Jsonp.js
+++ b/source/ajax/Jsonp.js
@@ -87,7 +87,7 @@ enyo.kind({
 			script.parentNode.removeChild(script);
 		}
 	},
-	constructor: enyo.super(function (sup) {
+	constructor: enyo.inherit(function (sup) {
 		return function(inParams) {
 			enyo.mixin(this, inParams);
 			sup.apply(this, arguments);

--- a/source/dom/Control.js
+++ b/source/dom/Control.js
@@ -97,7 +97,7 @@ enyo.kind({
 	node: null,
 	generated: false,
 	kindStyle: "",
-	create: enyo.super(function (sup) {
+	create: enyo.inherit(function (sup) {
 		return function() {
 			if (this.tag == null) {
 				// initially set to true, but if this is not a renderable
@@ -123,14 +123,14 @@ enyo.kind({
 		};
 	}),
 	//*@protected
-	constructor: enyo.super(function (sup) {
+	constructor: enyo.inherit(function (sup) {
 		return function () {
 			this.attributes = enyo.clone(this.ctor.prototype.attributes);
 			sup.apply(this, arguments);
 		};
 	}),
 	//*@public
-	destroy: enyo.super(function (sup) {
+	destroy: enyo.inherit(function (sup) {
 		return function() {
 			this.removeFromRoots();
 			this.removeNodeFromDom();
@@ -151,7 +151,7 @@ enyo.kind({
 		}
 	},
 	//*@protected
-	dispatchEvent: enyo.super(function (sup) {
+	dispatchEvent: enyo.inherit(function (sup) {
 		return function (inEventName, inEvent, inSender) {
 			// prevent dispatch and bubble of events that are strictly internal (e.g. enter/leave)
 			if (this.strictlyInternalEvents[inEventName] && this.isInternalEvent(inEvent)) {
@@ -173,13 +173,13 @@ enyo.kind({
 		sup.apply(this, arguments);
 	},
 	*/
-	addChild: enyo.super(function (sup) {
+	addChild: enyo.inherit(function (sup) {
 		return function(inControl) {
 			inControl.addClass(this.controlClasses);
 			sup.apply(this, arguments);
 		};
 	}),
-	removeChild: enyo.super(function (sup) {
+	removeChild: enyo.inherit(function (sup) {
 		return function(inControl) {
 			sup.apply(this, arguments);
 			inControl.removeClass(this.controlClasses);
@@ -530,7 +530,7 @@ enyo.kind({
 	/**
 		Override this method to perform tasks that require access to the DOM node.
 
-			rendered: enyo.super(function (sup) {
+			rendered: enyo.inherit(function (sup) {
 				return function() {
 					sup.apply(this, arguments);
 					// do some task

--- a/source/kernel/Application.js
+++ b/source/kernel/Application.js
@@ -124,7 +124,7 @@
 
 		//*@public
 		controllers: null,
-		
+
 		viewReady: false,
 
 		//*@public
@@ -155,7 +155,7 @@
 		// PROTECTED METHODS
 
 		//*@protected
-		constructor: enyo.super(function (sup) {
+		constructor: enyo.inherit(function (sup) {
 			return function (props) {
 				if (props && enyo.exists(props.name)) {
 					enyo.setPath(props.name, this);
@@ -172,7 +172,7 @@
 		}),
 
 		//*@protected
-		constructed: enyo.super(function (sup) {
+		constructed: enyo.inherit(function (sup) {
 			return function () {
 				// we need to make sure that the controllers are already initialized
 				// before we create our view according to the view controller's API
@@ -184,8 +184,8 @@
 				}
 			};
 		}),
-		
-		render: enyo.super(function (sup) {
+
+		render: enyo.inherit(function (sup) {
 			return function () {
 				sup.apply(this, arguments);
 				if (this.view && this.view.generated) {
@@ -214,7 +214,7 @@
 		},
 
 		//*@protected
-		destroy: enyo.super(function (sup) {
+		destroy: enyo.inherit(function (sup) {
 			return function () {
 				// release/destroy all controllers associated with
 				// this instance of the application

--- a/source/kernel/Component.js
+++ b/source/kernel/Component.js
@@ -94,7 +94,7 @@ enyo.kind({
 	toString: function() {
 		return this.kindName;
 	},
-	constructor: enyo.super(function (sup) {
+	constructor: enyo.inherit(function (sup) {
 		return function(props) {
 			// initialize instance objects
 			this._componentNameMap = {};
@@ -103,7 +103,7 @@ enyo.kind({
 			sup.apply(this, arguments);
 		};
 	}),
-	constructed: enyo.super(function (sup) {
+	constructed: enyo.inherit(function (sup) {
 		return function(inProps) {
 			// perform initialization
 			this.create(inProps);
@@ -142,7 +142,7 @@ enyo.kind({
 		property. Usually, the component will be suitable for garbage collection
 		after being destroyed, unless user code keeps a reference to it.
 	*/
-	destroy: enyo.super(function (sup) {
+	destroy: enyo.inherit(function (sup) {
 		return function() {
 			this.destroyComponents();
 			this.setOwner(null);
@@ -643,7 +643,7 @@ enyo.concatHandler("events", function (proto, props) {
 });
 
 enyo.Component.overrideComponents = function(components, overrides, defaultKind) {
-	var fn = function (k, v) { return !(enyo.isFunction(v) || enyo.isSuper(v)); };
+	var fn = function (k, v) { return !(enyo.isFunction(v) || enyo.isInherited(v)); };
 	components = enyo.clone(components);
 	for (var i=0; i<components.length; i++) {
 		var c = enyo.clone(components[i]);

--- a/source/kernel/Oop.js
+++ b/source/kernel/Oop.js
@@ -25,7 +25,7 @@
 		concatenated). If the value is an array with no special needs, it will be
 		handled automatically. If it is not an array, or needs inspection, a handler
 		should be registered for the property via _enyo.concatHandler()_.
-	
+
 		This is required (as opposed to using subclassing) because of the nature of
 		extending a kind and extending an instance. These special handlers need to
 		be invoked on all occasions, not just when subclassing. This is a normalized
@@ -271,7 +271,7 @@ enyo.kind.extendMethods = function(ctor, props, add) {
 	// ctor.prototype is known, relies on elements in props being copied by reference)
 	for (var n in props) {
 		var p = props[n];
-		if (enyo.isSuper(p)) {
+		if (enyo.isInherited(p)) {
 			// handle special case where the constructor has actually been renamed
 			// but mixins or other objects for extending will use the actual name
 			if (n == "constructor") {
@@ -330,16 +330,31 @@ enyo.kind.inherited = function (originals, replacements) {
 // dcl inspired super-inheritance
 (function (enyo) {
 
-	var Super = function (fn) {
+	//* @protected
+	var Inherited = function (fn) {
 		this.fn = fn;
 	};
-	
-	enyo.super = function (fn) {
-		return new Super(fn);
+
+	//* @public
+	/**
+		When defining a method that overrides an existing method in a kind,
+		you can wrap the definition in this function and it will decorate it
+		appropriately for inheritance to work. The _fn_ argument must be a
+		function that takes a single argument, usually named _sup_, and that
+		returns a function where _sup.apply(this, arguments)_ is used as a
+		mechanism to make the super-call.
+
+		The older _this.inherited(arguments)_ method still works, but this
+		version results in much faster code and is the only one supported for
+		kind mixins.
+	*/
+	enyo.inherit = function (fn) {
+		return new Inherited(fn);
 	};
-	
-	enyo.isSuper = function (fn) {
-		return fn && (fn instanceof Super);
+
+	//* @protected
+	enyo.isInherited = function (fn) {
+		return fn && (fn instanceof Inherited);
 	};
 
 })(enyo);
@@ -399,7 +414,7 @@ enyo.kind.statics = {
 		var ctor = this,
 			exts = enyo.isArray(props)? props: [props],
 			proto, fn;
-		fn = function (k, v) { return !(enyo.isFunction(v) || enyo.isSuper(v)); };
+		fn = function (k, v) { return !(enyo.isFunction(v) || enyo.isInherited(v)); };
 		if (!target && ctor._deferred) {
 			ctor = enyo.checkConstructor(ctor);
 		}

--- a/source/kernel/Router.js
+++ b/source/kernel/Router.js
@@ -358,7 +358,7 @@
 		// PROTECTED METHODS
 
 		//*@protected
-		constructor: enyo.super(function (sup) {
+		constructor: enyo.inherit(function (sup) {
 			return function () {
 				this._staticRoutes = {};
 				this._dynamicRoutes = [];
@@ -369,7 +369,7 @@
 		}),
 
 		//*@protected
-		create: enyo.super(function (sup) {
+		create: enyo.inherit(function (sup) {
 			return function () {
 				sup.apply(this, arguments);
 				// make sure to initialize our routes prior
@@ -392,7 +392,7 @@
 		}),
 
 		//*@protected
-		destroy: enyo.super(function (sup) {
+		destroy: enyo.inherit(function (sup) {
 			return function () {
 				var idx = enyo.indexOf(this, listeners);
 				if (!~idx) {

--- a/source/kernel/Signals.js
+++ b/source/kernel/Signals.js
@@ -16,13 +16,13 @@ enyo.kind({
 	name: "enyo.Signals",
 	kind: "enyo.Component",
 	//* @protected
-	create: enyo.super(function (sup) {
+	create: enyo.inherit(function (sup) {
 		return function() {
 			sup.apply(this, arguments);
 			enyo.Signals.addListener(this);
 		};
 	}),
-	destroy: enyo.super(function (sup) {
+	destroy: enyo.inherit(function (sup) {
 		return function() {
 			enyo.Signals.removeListener(this);
 			sup.apply(this, arguments);

--- a/source/kernel/UiComponent.js
+++ b/source/kernel/UiComponent.js
@@ -44,7 +44,7 @@ enyo.kind({
 	protectedStatics: {
 		_resizeFlags: {showingOnly: true} // don't waterfall these events into hidden controls
 	},
-	create: enyo.super(function (sup) {
+	create: enyo.inherit(function (sup) {
 		return function() {
 			this.controls = [];
 			this.children = [];
@@ -55,7 +55,7 @@ enyo.kind({
 			this.notifyObservers("model");
 		};
 	}),
-	destroy: enyo.super(function (sup) {
+	destroy: enyo.inherit(function (sup) {
 		return function() {
 			// Destroys all non-chrome controls (regardless of owner).
 			this.destroyClientControls();
@@ -73,7 +73,7 @@ enyo.kind({
 			}
 		};
 	}),
-	importProps: enyo.super(function (sup) {
+	importProps: enyo.inherit(function (sup) {
 		return function(inProps) {
 			sup.apply(this, arguments);
 			if (!this.owner) {
@@ -88,7 +88,7 @@ enyo.kind({
 	//
 	// We could call _discoverControlParent_ in _addComponent_, but it would
 	// cause a lot of useless checking.
-	createComponents: enyo.super(function (sup) {
+	createComponents: enyo.inherit(function (sup) {
 		return function() {
 			var results = sup.apply(this, arguments);
 			this.discoverControlParent();
@@ -98,7 +98,7 @@ enyo.kind({
 	discoverControlParent: function() {
 		this.controlParent = this.$[this.controlParentName] || this.controlParent;
 	},
-	adjustComponentProps: enyo.super(function (sup) {
+	adjustComponentProps: enyo.inherit(function (sup) {
 		return function(inProps) {
 			// Components we create have us as a container by default.
 			inProps.container = inProps.container || this;

--- a/source/kernel/ViewController.js
+++ b/source/kernel/ViewController.js
@@ -46,7 +46,7 @@
 
 		// ...........................
 		// COMPUTED PROPERTIES
-		
+
 		computed: {
 			_viewKind: [{cached: true}],
 			_renderTarget: ["renderTarget", {cached: true}]
@@ -164,7 +164,7 @@
 		// PROTECTED METHODS
 
 		//*@protected
-		constructed: enyo.super(function (sup) {
+		constructed: enyo.inherit(function (sup) {
 			return function () {
 				sup.apply(this, arguments);
 				// ensure we have created the view instance, note that

--- a/source/kernel/data/Collection.js
+++ b/source/kernel/data/Collection.js
@@ -38,7 +38,7 @@
 
 		//*@public
 		/**
-			Like an _enyo.Model_, an _enyo.Collection_ has several possible _status_ 
+			Like an _enyo.Model_, an _enyo.Collection_ has several possible _status_
 			values, which will be set depending on the current action. The following
 			values are possible:
 
@@ -116,7 +116,7 @@
 			property may be set directly, but doing so will automatically replace all
 			of the current content. Use [add()](#enyo.Collection::add) if you want to
 			extend (not replace) the current dataset.
-			
+
 			This computed property may be overloaded in more complex scenarios
 			involving filtering and conditionally supplied datasets.
 		*/
@@ -487,7 +487,7 @@
 			Overloaded setter that accepts an object literal and
 			applies all keys and values to the collection.
 		*/
-		set: enyo.super(function (sup) {
+		set: enyo.inherit(function (sup) {
 			return function (prop, val) {
 				if (enyo.isObject(prop)) {
 					this.stopNotifications();
@@ -525,7 +525,7 @@
 		/**
 			Accepts an array of models to add to the collection at creation.
 		*/
-		constructor: enyo.super(function (sup) {
+		constructor: enyo.inherit(function (sup) {
 			return function (props) {
 				this.__dirtyModels = [];
 				sup.apply(this, arguments);
@@ -584,13 +584,13 @@
 				}
 			}
 		},
-		
+
 		addDirtyModel: function (r) {
 			if (!~enyo.indexOf(r, this.__dirtyModels)) {
 				this.__dirtyModels.push(r);
 			}
 		},
-		
+
 		removeDirtyModel: function (r) {
 			var $i = enyo.indexOf(r, this.__dirtyModels);
 			if (!!~$i) {
@@ -655,7 +655,7 @@
 				}
 			}
 		},
-		
+
 		observers: {
 			__relationChanged: ["relation"],
 			__statusChanged: ["status"]

--- a/source/kernel/data/Model.js
+++ b/source/kernel/data/Model.js
@@ -352,7 +352,7 @@
 			enyo.pool.releaseObject($o);
 		}
 	});
-	
+
 	//*@protected
 	var isRemoteKey = function (k) {
 		var $a = this.__attributes;
@@ -513,7 +513,7 @@
 		_type_ and when data is retrieved/added for this key, it will be passed to
 		the constructor for the named _type_. This may be a constructor or a String
 		placeholder for a constructor.
-		
+
 		If the _type_ is a custom kind that requires more work than simply supplying
 		the data to the constructor, you will have to use the typeWrangler schema
 		option for type coercion. Note that if a _type_ is specified but coercion
@@ -538,9 +538,9 @@
 		just the useful information. This method must return the desired data. If a
 		typeWrangler exists for this schema option, the _formatter_ will be executed
 		first.
-		
+
 		The function takes the form
-		
+
         function (key, value, action, payload)
 
 		where
@@ -729,7 +729,7 @@
 			primary key for this model. The default is _"id"_.
 		*/
 		primaryKey: "id",
-		
+
 		//*@public
 		noFetchId: true,
 
@@ -740,7 +740,7 @@
 			set to true. The default is false.
 		*/
 		noUrl: false,
-		
+
 		//*@public
 		/**
 			For cases in which the _url_ is arbitrarily set and must be used as-is,
@@ -748,7 +748,7 @@
 			property.
 		*/
 		rawUrl: false,
-		
+
 		//*@public
 		/**
 			In cases where the commit body should be a subset of the attributes
@@ -785,7 +785,7 @@
 
 		//*@public
 		statics: STATES,
-		
+
 		//*@public
 		/**
 			Assigned by an _enyo.Store_ at model instantiation. A unique identifier
@@ -1132,7 +1132,7 @@
 			This is a specially overloaded version of _enyo.Object.set()_. It accepts
 			either a hash or a string and value combined as its parameters.
 		*/
-		set: enyo.super(function (sup) {
+		set: enyo.inherit(function (sup) {
 			return function (prop, val) {
 				if (enyo.isObject(prop)) {
 					this.silence();
@@ -1178,7 +1178,7 @@
 			If there is no schema defined and no initial _values_ are passed in,
 			much of its functionality will not work as intended.
 		*/
-		constructor: enyo.super(function (sup) {
+		constructor: enyo.inherit(function (sup) {
 			return function (values) {
 				var $v = values || enyo.pool.claimObject(true);
 				var $t = enyo.pool.claimObject();
@@ -1218,14 +1218,14 @@
 				enyo.pool.releaseObject($v, $d, $t);
 			};
 		}),
-		
-		constructed: enyo.super(function (sup) {
+
+		constructed: enyo.inherit(function (sup) {
 			return function () {
 				sup.apply(this, arguments);
 				enyo.models.queue(this);
 			};
 		}),
-		
+
 		//*@public
 		/**
 			Attempts to generate a schema implicitly from a data structure.
@@ -1362,7 +1362,7 @@
 				}
 			}
 		},
-		
+
 		observers: {
 			__statusChanged: ["status"],
 			__attributeSpy: ["*"]

--- a/source/kernel/data/ModelController.js
+++ b/source/kernel/data/ModelController.js
@@ -5,17 +5,17 @@ enyo.kind({
 
 	//*@public
 	name: "enyo.ModelController",
-	
+
 	//*@public
 	kind: "enyo.Controller",
-	
-	create: enyo.super(function (sup) {
+
+	create: enyo.inherit(function (sup) {
 		return function () {
 			sup.apply(this, arguments);
 			this.notifyObservers("model");
 		};
 	}),
-	
+
 	// ...........................
 	// PUBLIC METHODS
 
@@ -25,7 +25,7 @@ enyo.kind({
 	},
 
 	//*@public
-	get: enyo.super(function (sup) {
+	get: enyo.inherit(function (sup) {
 		return function (prop) {
 			if (!this.isAttribute(prop)) {
 				sup.apply(this, arguments);
@@ -35,7 +35,7 @@ enyo.kind({
 	}),
 
 	//*@public
-	set: enyo.super(function (sup) {
+	set: enyo.inherit(function (sup) {
 		return function (prop, val) {
 			if (!this.isAttribute(prop)) {
 				return sup.apply(this, arguments);

--- a/source/kernel/data/Source.js
+++ b/source/kernel/data/Source.js
@@ -258,7 +258,7 @@
 			}
 		},
 
-		constructor: enyo.super(function (sup) {
+		constructor: enyo.inherit(function (sup) {
 			return function () {
 				sup.apply(this, arguments);
 				this.defaultOptions = this.defaultOptions || {};

--- a/source/kernel/data/Store.js
+++ b/source/kernel/data/Store.js
@@ -274,7 +274,7 @@
 			// an id via sequence, etc.
 			$options.success(model.euuid);
 		},
-		constructor: enyo.super(function (sup) {
+		constructor: enyo.inherit(function (sup) {
 			return function () {
 				// there can only be one store executing at a time
 				if (enyo.store) {

--- a/source/kernel/mixins/ApplicationSupport.js
+++ b/source/kernel/mixins/ApplicationSupport.js
@@ -12,13 +12,13 @@ enyo.ApplicationSupport = {
 		_enyo.Component_ was created in the scope of an _enyo.Application_.
 	*/
 	app: null,
-	adjustComponentProps: enyo.super(function (sup) {
+	adjustComponentProps: enyo.inherit(function (sup) {
 		return function (props) {
 			props.app = this.app;
 			sup.apply(this, arguments);
 		};
 	}),
-	destroy: enyo.super(function (sup) {
+	destroy: enyo.inherit(function (sup) {
 		return function () {
 			// release the reference to the application
 			this.app = null;

--- a/source/kernel/mixins/BindingSupport.js
+++ b/source/kernel/mixins/BindingSupport.js
@@ -152,7 +152,7 @@ enyo.BindingSupport = {
 			bs = this.bindings;
 		if (b) {
 			var i = enyo.indexOf(b, bs);
-			if (!!~i) { 
+			if (!!~i) {
 				bs.splice(i, 1);
 				if (b._rebuildTarget) {
 					this.removeObserver(b._targetPath, b._rebuildTarget);
@@ -199,7 +199,7 @@ enyo.BindingSupport = {
 			}
 		}
 	},
-	constructor: enyo.super(function (sup) {
+	constructor: enyo.inherit(function (sup) {
 		return function () {
 			// ensure we have at least an empty array here during
 			// normal initialization
@@ -208,7 +208,7 @@ enyo.BindingSupport = {
 			return sup.apply(this, arguments);
 		};
 	}),
-	constructed: enyo.super(function (sup) {
+	constructed: enyo.inherit(function (sup) {
 		return function () {
 			// now we go ahead and create the bindings, knowing that they
 			// will register for missing targets/sources if they become
@@ -217,7 +217,7 @@ enyo.BindingSupport = {
 			sup.apply(this, arguments);
 		};
 	}),
-	destroy: enyo.super(function (sup) {
+	destroy: enyo.inherit(function (sup) {
 		return function () {
 			// destroy all bindings that belong to us
 			var bs = this.bindings;
@@ -288,13 +288,13 @@ enyo.ComponentBindingSupport = {
 		for inlined bindings -- their owner is the component they are nested on
 		but the transform will most likely exist on the instance owner.
 	*/
-	adjustComponentProps: enyo.super(function (sup) {
+	adjustComponentProps: enyo.inherit(function (sup) {
 		return function (props) {
 			sup.apply(this, arguments);
 			props._bindingTransformOwner = props._bindingTransformOwner || this.getInstanceOwner();
 		};
 	}),
-	constructed: enyo.super(function (sup) {
+	constructed: enyo.inherit(function (sup) {
 		return function () {
 			this._bindingSyncAllowed = false;
 			this.initBindings();

--- a/source/kernel/mixins/ComputedSupport.js
+++ b/source/kernel/mixins/ComputedSupport.js
@@ -1,5 +1,5 @@
 (function (enyo) {
-	
+
 	//*@protected
 	enyo.concat.push("computed");
 	/**
@@ -33,7 +33,7 @@
 		functions, but be aware	that you cannot call any setter method for a
 		computed property. Also note that for any observers of a computed property,
 		there will never be a _previous_ value unless it is cached.
-	
+
 		Just as with [ObserverSupport](#enyo/source/kernel/mixins/ObserverSupport.js),
 		you can specify that a method is a computed property by including it within a
 		_computed_ block.
@@ -45,7 +45,7 @@
 					maxHours: []
 				}
 			})
- 
+
 		Another feature of computed properties is the ability to add configurable
 		options. Options are found in the computed property's array of dependencies.
 		Look at the defaults for options of computed properties to see what options
@@ -58,7 +58,7 @@
 		*/
 		computed: null,
 		//*@protected
-		get: enyo.super(function (sup) {
+		get: enyo.inherit(function (sup) {
 			return function (path) {
 				if (this._isComputed(path)) {
 					return this._getComputed(path);
@@ -66,7 +66,7 @@
 				return sup.apply(this, arguments);
 			};
 		}),
-		set: enyo.super(function (sup) {
+		set: enyo.inherit(function (sup) {
 			return function (path, value) {
 				if (this._isComputed(path)) {
 					// there is no support for setting a value for a computed
@@ -84,7 +84,7 @@
 			it has the opportunity to flush the queue, so we will be mindful to
 			never allow the same computed property into the queue more than once.
 		*/
-		notifyObservers: enyo.super(function (sup) {
+		notifyObservers: enyo.inherit(function (sup) {
 			return function (path, prev, value) {
 				var map = this._computedMap, n;
 				if ((n = map[path])) {
@@ -161,7 +161,7 @@
 				this.notifyObservers(k, q[k], this._getComputed(k));
 			}
 		},
-		constructor: enyo.super(function (sup) {
+		constructor: enyo.inherit(function (sup) {
 			return function () {
 				// we do not clone this object because, once instanced, we should not need it
 				// anymore, as it has been converted to a map

--- a/source/kernel/mixins/MixinSupport.js
+++ b/source/kernel/mixins/MixinSupport.js
@@ -19,10 +19,10 @@
 
 		An _enyo.Mixin_ is _not a kind_. It is simply a named collection of methods
 		and properties that may be reused with multiple kinds.
-	
+
 		To create an _enyo.Mixin_, simply create a hash of methods and properties,
 		and assign it to a referenceable namespace.
-	
+
 		To apply an _enyo.Mixin_ to a kind, simply add its name or a reference to it
 		in the special _mixins_ property in the kind definition. Alternatively, you
 		may call _extend()_ on the constructor for the kind, passing in the mixin
@@ -90,7 +90,7 @@
 		proto.mixins = enyo.merge(proto.mixins, props.mixins);
 	});
 	enyo.kind.extendMethods(enyo.kind.statics, {
-		extend: enyo.super(function (sup) {
+		extend: enyo.inherit(function (sup) {
 			return function (props, target) {
 				var proto = target || this.prototype;
 				if (props.mixins) {
@@ -122,7 +122,7 @@
 			has already been evaluated and it is being initialized as an instance.
 			However, if a mixin applies more mixins at runtime, it will have no effect.
 		*/
-		importProps: enyo.super(function (sup) {
+		importProps: enyo.inherit(function (sup) {
 			return function (props) {
 				if (props) { mixinsFeature(this, props); }
 				sup.apply(this, arguments);

--- a/source/kernel/mixins/MultipleDispatchSupport.js
+++ b/source/kernel/mixins/MultipleDispatchSupport.js
@@ -28,7 +28,7 @@ enyo.MultipleDispatchSupport = {
 		}
 	},
 	//*@protected
-	bubbleUp: enyo.super(function (sup) {
+	bubbleUp: enyo.inherit(function (sup) {
 		return function (name, event, sender) {
 			if (this._dispatchDefaultPath) {
 				sup.apply(this, arguments);
@@ -41,27 +41,27 @@ enyo.MultipleDispatchSupport = {
 			}
 		};
 	}),
-	bubbleDelegation: enyo.super(function (sup) {
+	bubbleDelegation: enyo.inherit(function (sup) {
 		return function (delegate, prop, name, event, sender) {
 			if (this._dispatchDefaultPath) {
 				return sup.apply(this, arguments);
 			}
 		};
 	}),
-	ownerChanged: enyo.super(function (sup) {
+	ownerChanged: enyo.inherit(function (sup) {
 		return function () {
 			sup.apply(this, arguments);
 			var o = this.owner;
 			this._dispatchDefaultPath = !! o;
 		};
 	}),
-	constructor: enyo.super(function (sup) {
+	constructor: enyo.inherit(function (sup) {
 		return function () {
 			this._dispatchTargets = [];
 			return sup.apply(this, arguments);
 		};
 	}),
-	destroy: enyo.super(function (sup) {
+	destroy: enyo.inherit(function (sup) {
 		return function () {
 			this._dispatchTargets = null;
 			sup.apply(this, arguments);

--- a/source/kernel/mixins/ObserverSupport.js
+++ b/source/kernel/mixins/ObserverSupport.js
@@ -253,7 +253,7 @@
 				}
 			}
 		},
-		constructor: enyo.super(function (sup) {
+		constructor: enyo.inherit(function (sup) {
 			return function () {
 				// we need an instance-specific observer table so runtime modifications
 				// are unique to the instance and not the kind, also note that once the
@@ -269,7 +269,7 @@
 				return sup.apply(this, arguments);
 			};
 		}),
-		destroy: enyo.super(function (sup) {
+		destroy: enyo.inherit(function (sup) {
 			return function () {
 				this.removeAllObservers();
 				sup.apply(this, arguments);

--- a/source/touch/ScrollMath.js
+++ b/source/touch/ScrollMath.js
@@ -60,7 +60,7 @@ enyo.kind({
 	x: 0,
 	y0: 0,
 	y: 0,
-	destroy: enyo.super(function (sup) {
+	destroy: enyo.inherit(function (sup) {
 		return function() {
 			this.stop();
 			sup.apply(this, arguments);

--- a/source/touch/ScrollStrategy.js
+++ b/source/touch/ScrollStrategy.js
@@ -46,7 +46,7 @@ enyo.kind({
 		onmove: "move",
 		onmousewheel: "mousewheel"
 	},
-	create: enyo.super(function (sup) {
+	create: enyo.inherit(function (sup) {
 		return function() {
 			sup.apply(this, arguments);
 			this.horizontalChanged();
@@ -54,14 +54,14 @@ enyo.kind({
 			this.maxHeightChanged();
 		};
 	}),
-	rendered: enyo.super(function (sup) {
+	rendered: enyo.inherit(function (sup) {
 		return function() {
 			sup.apply(this, arguments);
 			enyo.makeBubble(this.container, "scroll");
 			this.scrollNode = this.calcScrollNode();
 		};
 	}),
-	teardownRender: enyo.super(function (sup) {
+	teardownRender: enyo.inherit(function (sup) {
 		return function() {
 			sup.apply(this, arguments);
 			this.scrollNode = null;

--- a/source/touch/Scroller.js
+++ b/source/touch/Scroller.js
@@ -144,7 +144,7 @@ enyo.kind({
 		}
 	},
 	controlParentName: "strategy",
-	create: enyo.super(function (sup) {
+	create: enyo.inherit(function (sup) {
 		return function() {
 			sup.apply(this, arguments);
 			this.horizontalChanged();
@@ -152,7 +152,7 @@ enyo.kind({
 			this.useMouseWheelChanged();
 		};
 	}),
-	importProps: enyo.super(function (sup) {
+	importProps: enyo.inherit(function (sup) {
 		return function(inProps) {
 			sup.apply(this, arguments);
 			// allow global overriding of strategy kind
@@ -161,19 +161,19 @@ enyo.kind({
 			}
 		};
 	}),
-	initComponents: enyo.super(function (sup) {
+	initComponents: enyo.inherit(function (sup) {
 		return function() {
 			this.strategyKindChanged();
 			sup.apply(this, arguments);
 		};
 	}),
-	teardownChildren: enyo.super(function (sup) {
+	teardownChildren: enyo.inherit(function (sup) {
 		return function() {
 			this.cacheScrollPosition();
 			sup.apply(this, arguments);
 		};
 	}),
-	rendered: enyo.super(function (sup) {
+	rendered: enyo.inherit(function (sup) {
 		return function() {
 			sup.apply(this, arguments);
 			this.restoreScrollPosition();
@@ -202,7 +202,7 @@ enyo.kind({
 	maxHeightChanged: function() {
 		this.$.strategy.setMaxHeight(this.maxHeight);
 	},
-	showingChanged: enyo.super(function (sup) {
+	showingChanged: enyo.inherit(function (sup) {
 		return function() {
 			if (!this.showing) {
 				this.cacheScrollPosition();

--- a/source/touch/Thumb.js
+++ b/source/touch/Thumb.js
@@ -17,7 +17,7 @@ enyo.kind({
 	//* Size of the corners of the indicator
 	cornerSize: 6,
 	classes: "enyo-thumb",
-	create: enyo.super(function (sup) {
+	create: enyo.inherit(function (sup) {
 		return function() {
 			sup.apply(this, arguments);
 			var v = this.axis == "v";

--- a/source/touch/TouchScrollStrategy.js
+++ b/source/touch/TouchScrollStrategy.js
@@ -77,7 +77,7 @@ enyo.kind({
 	],
 	// flag telling us whether the list is currently reordering
 	listReordering: false,
-	create: enyo.super(function (sup) {
+	create: enyo.inherit(function (sup) {
 		return function() {
 			sup.apply(this, arguments);
 			this.transform = enyo.dom.canTransform();
@@ -99,19 +99,19 @@ enyo.kind({
 			this.translation = this.accel ? "translate3d" : "translate";
 		};
 	}),
-	initComponents: enyo.super(function (sup) {
+	initComponents: enyo.inherit(function (sup) {
 		return function() {
 			this.createChrome(this.tools);
 			sup.apply(this, arguments);
 		};
 	}),
-	destroy: enyo.super(function (sup) {
+	destroy: enyo.inherit(function (sup) {
 		return function() {
 			this.container.removeClass("enyo-touch-strategy-container");
 			sup.apply(this, arguments);
 		};
 	}),
-	rendered: enyo.super(function (sup) {
+	rendered: enyo.inherit(function (sup) {
 		return function() {
 			sup.apply(this, arguments);
 			enyo.makeBubble(this.$.client, "scroll");
@@ -193,34 +193,34 @@ enyo.kind({
 		this.stop();
 		this.$.scrollMath.scrollTo(inX, inY || inY === 0 ? inY : null);
 	},
-	scrollIntoView: enyo.super(function (sup) {
+	scrollIntoView: enyo.inherit(function (sup) {
 		return function() {
 			this.stop();
 			sup.apply(this, arguments);
 		};
 	}),
 	//* Sets the left scroll position within the scroller.
-	setScrollLeft: enyo.super(function (sup) {
+	setScrollLeft: enyo.inherit(function (sup) {
 		return function() {
 			this.stop();
 			sup.apply(this, arguments);
 		};
 	}),
 	//* Sets the top scroll position within the scroller.
-	setScrollTop: enyo.super(function (sup) {
+	setScrollTop: enyo.inherit(function (sup) {
 		return function() {
 			this.stop();
 			sup.apply(this, arguments);
 		};
 	}),
 	//* Gets the left scroll position within the scroller.
-	getScrollLeft: enyo.super(function (sup) {
+	getScrollLeft: enyo.inherit(function (sup) {
 		return function() {
 			return this.isScrolling() ? this.scrollLeft : sup.apply(this, arguments);
 		};
 	}),
 	//* Gets the top scroll position within the scroller.
-	getScrollTop: enyo.super(function (sup) {
+	getScrollTop: enyo.inherit(function (sup) {
 		return function() {
 			return this.isScrolling() ? this.scrollTop : sup.apply(this, arguments);
 		};
@@ -402,14 +402,14 @@ enyo.kind({
 			overtop: Math.min(m.topBoundary - m.y, 0) || Math.max(m.bottomBoundary - m.y, 0)
 		};
 	},
-	_getScrollBounds: enyo.super(function (sup) {
+	_getScrollBounds: enyo.inherit(function (sup) {
 		return function() {
 			var r = sup.apply(this, arguments);
 			enyo.mixin(r, this.getOverScrollBounds());
 			return r;
 		};
 	}),
-	getScrollBounds: enyo.super(function (sup) {
+	getScrollBounds: enyo.inherit(function (sup) {
 		return function() {
 			this.stop();
 			return sup.apply(this, arguments);

--- a/source/touch/TransitionScrollStrategy.js
+++ b/source/touch/TransitionScrollStrategy.js
@@ -110,13 +110,13 @@ enyo.kind({
 	//* @protected
 
 	// apply initial transform so we're always composited
-	create: enyo.super(function (sup) {
+	create: enyo.inherit(function (sup) {
 		return function() {
 			sup.apply(this, arguments);
 			enyo.dom.transformValue(this.$.client, this.translation, "0,0,0");
 		};
 	}),
-	destroy: enyo.super(function (sup) {
+	destroy: enyo.inherit(function (sup) {
 		return function() {
 			this.clearCSSTransitionInterval();
 			sup.apply(this, arguments);

--- a/source/touch/TranslateScrollStrategy.js
+++ b/source/touch/TranslateScrollStrategy.js
@@ -23,7 +23,7 @@ enyo.kind({
 			{name: "client"}
 		]}
 	],
-	rendered: enyo.super(function (sup) {
+	rendered: enyo.inherit(function (sup) {
 		return function() {
 			sup.apply(this, arguments);
 			enyo.makeBubble(this.$.clientContainer, "scroll");
@@ -33,7 +33,7 @@ enyo.kind({
 		var n = this.$.client.hasNode();
 		return {width: n ? n.scrollWidth : 0, height: n ? n.scrollHeight : 0};
 	},
-	create: enyo.super(function (sup) {
+	create: enyo.inherit(function (sup) {
 		return function() {
 			sup.apply(this, arguments);
 			// apply initial transform so we're always composited
@@ -49,7 +49,7 @@ enyo.kind({
 		this.$.client.applyStyle("max-height", this.maxHeight);
 		this.$.clientContainer.addRemoveClass("enyo-scrollee-fit", !this.maxHeight);
 	},
-	shouldDrag: enyo.super(function (sup) {
+	shouldDrag: enyo.inherit(function (sup) {
 		return function(inSender, inEvent) {
 			// stop and update drag info before checking drag status
 			this.stop();
@@ -57,7 +57,7 @@ enyo.kind({
 			return sup.apply(this, arguments);
 		};
 	}),
-	syncScrollMath: enyo.super(function (sup) {
+	syncScrollMath: enyo.inherit(function (sup) {
 		return function() {
 			if (!this.translateOptimized) {
 				sup.apply(this, arguments);
@@ -66,7 +66,7 @@ enyo.kind({
 	}),
 	//* @public
 	//* Sets the left scroll position within the scroller.
-	setScrollLeft: enyo.super(function (sup) {
+	setScrollLeft: enyo.inherit(function (sup) {
 		return function(inLeft) {
 			this.stop();
 			if (this.translateOptimized) {
@@ -79,7 +79,7 @@ enyo.kind({
 		};
 	}),
 	//* Sets the top scroll position within the scroller.
-	setScrollTop: enyo.super(function (sup) {
+	setScrollTop: enyo.inherit(function (sup) {
 		return function(inTop) {
 			this.stop();
 			if (this.translateOptimized) {
@@ -92,19 +92,19 @@ enyo.kind({
 		};
 	}),
 	//* Gets the left scroll position within the scroller.
-	getScrollLeft: enyo.super(function (sup) {
+	getScrollLeft: enyo.inherit(function (sup) {
 		return function() {
 			return this.translateOptimized ? this.scrollLeft: sup.apply(this, arguments);
 		};
 	}),
 	//* Gets the top scroll position within the scroller.
-	getScrollTop: enyo.super(function (sup) {
+	getScrollTop: enyo.inherit(function (sup) {
 		return function() {
 			return this.translateOptimized ? this.scrollTop : sup.apply(this, arguments);
 		};
 	}),
 	//* @protected
-	scrollMathStart: enyo.super(function (sup) {
+	scrollMathStart: enyo.inherit(function (sup) {
 		return function(inSender) {
 			sup.apply(this, arguments);
 			this.scrollStarting = true;

--- a/source/ui/Anchor.js
+++ b/source/ui/Anchor.js
@@ -15,7 +15,7 @@ enyo.kind({
 		title: ""
 	},
 	//* @protected
-	create: enyo.super(function (sup) {
+	create: enyo.inherit(function (sup) {
 		return function() {
 			sup.apply(this, arguments);
 			this.hrefChanged();

--- a/source/ui/Animator.js
+++ b/source/ui/Animator.js
@@ -45,13 +45,13 @@ enyo.kind({
 		onStop: ""
 	},
 	//* @protected
-	constructed: enyo.super(function (sup) {
+	constructed: enyo.inherit(function (sup) {
 		return function() {
 			sup.apply(this, arguments);
 			this._next = this.bindSafely("next");
 		};
 	}),
-	destroy: enyo.super(function (sup) {
+	destroy: enyo.inherit(function (sup) {
 		return function() {
 			this.stop();
 			sup.apply(this, arguments);

--- a/source/ui/Button.js
+++ b/source/ui/Button.js
@@ -23,7 +23,7 @@ enyo.kind({
 		disabled: false
 	},
 	//* @protected
-	create: enyo.super(function (sup) {
+	create: enyo.inherit(function (sup) {
 		return function() {
 			sup.apply(this, arguments);
 			this.disabledChanged();

--- a/source/ui/Checkbox.js
+++ b/source/ui/Checkbox.js
@@ -24,7 +24,7 @@ enyo.kind({
 		onchange: "change",
 		onclick: "click"
 	},
-	rendered: enyo.super(function (sup) {
+	rendered: enyo.inherit(function (sup) {
 		return function() {
 			sup.apply(this, arguments);
 			if (this.active) {

--- a/source/ui/DragAvatar.js
+++ b/source/ui/DragAvatar.js
@@ -3,7 +3,7 @@ enyo.kind({
 	name: "enyo._DragAvatar",
 	style: "position: absolute; z-index: 10; pointer-events: none; cursor: move;",
 	showing: false,
-	showingChanged: enyo.super(function (sup) {
+	showingChanged: enyo.inherit(function (sup) {
 		return function() {
 			sup.apply(this, arguments);
 			document.body.style.cursor = this.showing ? "move" : null;
@@ -54,7 +54,7 @@ enyo.kind({
 		offsetY: 30
 	},
 	//* @protected
-	initComponents: enyo.super(function (sup) {
+	initComponents: enyo.inherit(function (sup) {
 		return function() {
 			this.avatarComponents = this.components;
 			this.components = null;

--- a/source/ui/Drawer.js
+++ b/source/ui/Drawer.js
@@ -42,14 +42,14 @@ enyo.kind({
 		{kind: "Animator", onStep: "animatorStep", onEnd: "animatorEnd"},
 		{name: "client", style: "position: relative;", classes: "enyo-border-box"}
 	],
-	create: enyo.super(function (sup) {
+	create: enyo.inherit(function (sup) {
 		return function() {
 			sup.apply(this, arguments);
 			this.animatedChanged();
 			this.openChanged();
 		};
 	}),
-	initComponents: enyo.super(function (sup) {
+	initComponents: enyo.inherit(function (sup) {
 		return function() {
 			this.createChrome(this.tools);
 			sup.apply(this, arguments);

--- a/source/ui/FloatingLayer.js
+++ b/source/ui/FloatingLayer.js
@@ -4,7 +4,7 @@
 	The FloatingLayer singleton can be set as a control's parent to have the
 	control float above an application, e.g.:
 
-		create: enyo.super(function (sup) {
+		create: enyo.inherit(function (sup) {
 			return function() {
 				sup.apply(this, arguments);
 				this.setParent(enyo.floatingLayer);
@@ -17,14 +17,14 @@
 enyo.kind({
 	name: "enyo.FloatingLayer",
 	//* @protected
-	create: enyo.super(function (sup) {
+	create: enyo.inherit(function (sup) {
 		return function() {
 			sup.apply(this, arguments);
 			this.setParent(null);
 		};
 	}),
 	// detect when node is detatched due to document.body being stomped
-	hasNode: enyo.super(function (sup) {
+	hasNode: enyo.inherit(function (sup) {
 		return function() {
 			sup.apply(this, arguments);
 			if (this.node && !this.node.parentNode) {
@@ -33,7 +33,7 @@ enyo.kind({
 			return this.node;
 		};
 	}),
-	render: enyo.super(function (sup) {
+	render: enyo.inherit(function (sup) {
 		return function() {
 			this.parentNode = document.body;
 			return sup.apply(this, arguments);

--- a/source/ui/GroupItem.js
+++ b/source/ui/GroupItem.js
@@ -18,7 +18,7 @@ enyo.kind({
 		active: false
 	},
 	//* @protected
-	rendered: enyo.super(function (sup) {
+	rendered: enyo.inherit(function (sup) {
 		return function() {
 			sup.apply(this, arguments);
 			this.activeChanged();

--- a/source/ui/Image.js
+++ b/source/ui/Image.js
@@ -18,7 +18,7 @@ enyo.kind({
 		// (Boolean _false_ would remove the attribute)
 		draggable: "false"
 	},
-	create: enyo.super(function (sup) {
+	create: enyo.inherit(function (sup) {
 		return function() {
 			if (this.noEvents) {
 				delete this.attributes.onload;
@@ -31,7 +31,7 @@ enyo.kind({
 	altChanged: function() {
 		this.setAttribute("alt", this.alt);
 	},
-	rendered: enyo.super(function (sup) {
+	rendered: enyo.inherit(function (sup) {
 		return function() {
 			sup.apply(this, arguments);
 			enyo.makeBubble(this, "load", "error");

--- a/source/ui/Input.js
+++ b/source/ui/Input.js
@@ -50,7 +50,7 @@ enyo.kind({
 		onclear: "clear",
 		ondragstart: "dragstart"
 	},
-	create: enyo.super(function (sup) {
+	create: enyo.inherit(function (sup) {
 		return function() {
 			if (enyo.platform.ie) {
 				this.handlers.onkeyup = "iekeyup";
@@ -67,7 +67,7 @@ enyo.kind({
 			this.valueChanged();
 		};
 	}),
-	rendered: enyo.super(function (sup) {
+	rendered: enyo.inherit(function (sup) {
 		return function() {
 			sup.apply(this, arguments);
 

--- a/source/ui/Media.js
+++ b/source/ui/Media.js
@@ -1,5 +1,5 @@
 /**
-	_enyo.Media_ implements an HTML 5 Media element. It is not intended to 
+	_enyo.Media_ implements an HTML 5 Media element. It is not intended to
 	be used directly, but serves as the base kind for [enyo.Audio](#enyo.Audio)
 	and [enyo.Video](#enyo.Video).
 */
@@ -115,7 +115,7 @@ enyo.kind({
 		onvolumechange: "_volumeChange",
 		onwaiting: "_waiting"
 	},
-	create: enyo.super(function (sup) {
+	create: enyo.inherit(function (sup) {
 		return function() {
 			sup.apply(this, arguments);
 			this.autoplayChanged();
@@ -125,7 +125,7 @@ enyo.kind({
 			this.srcChanged();
 		};
 	}),
-	rendered: enyo.super(function (sup) {
+	rendered: enyo.inherit(function (sup) {
 		return function() {
 			sup.apply(this, arguments);
 			enyo.makeBubble(this, "abort");

--- a/source/ui/Popup.js
+++ b/source/ui/Popup.js
@@ -59,13 +59,13 @@ enyo.kind({
 	tools: [
 		{kind: "Signals", onKeydown: "keydown"}
 	],
-	create: enyo.super(function (sup) {
+	create: enyo.inherit(function (sup) {
 		return function() {
 			sup.apply(this, arguments);
 			this.canGenerate = !this.floating;
 		};
 	}),
-	render: enyo.super(function (sup) {
+	render: enyo.inherit(function (sup) {
 		return function() {
 			if (this.floating) {
 				if (!enyo.floatingLayer.hasNode()) {
@@ -76,7 +76,7 @@ enyo.kind({
 			sup.apply(this, arguments);
 		};
 	}),
-	destroy: enyo.super(function (sup) {
+	destroy: enyo.inherit(function (sup) {
 		return function() {
 			if (this.showing) {
 				this.release();
@@ -85,7 +85,7 @@ enyo.kind({
 		};
 	}),
 
-	reflow: enyo.super(function (sup) {
+	reflow: enyo.inherit(function (sup) {
 		return function() {
 			this.updatePosition();
 			sup.apply(this, arguments);
@@ -171,7 +171,7 @@ enyo.kind({
 			this.addStyles( "top: " + Math.max( ( ( d.height - b.height ) / 2 ), 0 ) + "px; left: " + Math.max( ( ( d.width - b.width ) / 2 ), 0 ) + "px;" );
 		}
 	},
-	showingChanged: enyo.super(function (sup) {
+	showingChanged: enyo.inherit(function (sup) {
 		return function() {
 			// auto render when shown.
 			if (this.floating && this.showing && !this.hasNode()) {

--- a/source/ui/Repeater.js
+++ b/source/ui/Repeater.js
@@ -40,14 +40,14 @@ enyo.kind({
 		*/
 		onSetupItem: ""
 	},
-	create: enyo.super(function (sup) {
+	create: enyo.inherit(function (sup) {
 		return function() {
 			sup.apply(this, arguments);
 			this.countChanged();
 		};
 	}),
 	//* @protected
-	initComponents: enyo.super(function (sup) {
+	initComponents: enyo.inherit(function (sup) {
 		return function() {
 			this.itemComponents = this.components || this.kindComponents;
 			this.components = this.kindComponents = null;
@@ -94,7 +94,7 @@ enyo.kind({
 enyo.kind({
 	name: "enyo.OwnerProxy",
 	tag: null,
-	decorateEvent: enyo.super(function (sup) {
+	decorateEvent: enyo.inherit(function (sup) {
 		return function(inEventName, inEvent, inSender) {
 			if (inEvent) {
 				// preserve an existing index property.
@@ -117,7 +117,7 @@ enyo.kind({
 		};
 	}),
 	// extending enyo.Component.delegateEvent
-	delegateEvent: enyo.super(function (sup) {
+	delegateEvent: enyo.inherit(function (sup) {
 		return function(inDelegate, inName, inEventName, inEvent, inSender) {
 			if (inDelegate == this) {
 				inDelegate = this.owner.owner;

--- a/source/ui/RichText.js
+++ b/source/ui/RichText.js
@@ -58,7 +58,7 @@ enyo.kind({
 		oninput: null
 	},
 	// create RichText as a div if platform has contenteditable attribute, otherwise create it as a textarea
-	create: enyo.super(function (sup) {
+	create: enyo.inherit(function (sup) {
 		return function() {
 			this.setTag(enyo.RichText.hasContentEditable()?"div":"textarea");
 			sup.apply(this, arguments);

--- a/source/ui/Select.js
+++ b/source/ui/Select.js
@@ -35,7 +35,7 @@ enyo.kind({
 	},
 	tag: "select",
 	defaultKind: "enyo.Option",
-	rendered: enyo.super(function (sup) {
+	rendered: enyo.inherit(function (sup) {
 		return function() {
 			sup.apply(this, arguments);
 			//Trick to force IE8 onchange event bubble
@@ -54,7 +54,7 @@ enyo.kind({
 	change: function() {
 		this.selected = this.getSelected();
 	},
-	render: enyo.super(function (sup) {
+	render: enyo.inherit(function (sup) {
 		return function() {
 			// work around IE bug with innerHTML setting of <select>, rerender parent instead
 			// http://support.microsoft.com/default.aspx?scid=kb;en-us;276228
@@ -85,7 +85,7 @@ enyo.kind({
 	},
 	//* @protected
 	tag: "option",
-	create: enyo.super(function (sup) {
+	create: enyo.inherit(function (sup) {
 		return function() {
 			sup.apply(this, arguments);
 			this.valueChanged();
@@ -108,7 +108,7 @@ enyo.kind({
 	//* @protected
 	tag: "optgroup",
 	defaultKind: "enyo.Option",
-	create: enyo.super(function (sup) {
+	create: enyo.inherit(function (sup) {
 		return function() {
 			sup.apply(this, arguments);
 			this.labelChanged();

--- a/source/ui/Selection.js
+++ b/source/ui/Selection.js
@@ -66,7 +66,7 @@ enyo.kind({
 		onChange: ""
 	},
 	//* @protected
-	create: enyo.super(function (sup) {
+	create: enyo.inherit(function (sup) {
 		return function() {
 			this.clear();
 			sup.apply(this, arguments);

--- a/source/ui/TextArea.js
+++ b/source/ui/TextArea.js
@@ -13,7 +13,7 @@ enyo.kind({
 	tag: "textarea",
 	classes: "enyo-textarea",
 	// textarea does use value attribute; needs to be kicked when rendered.
-	rendered: enyo.super(function (sup) {
+	rendered: enyo.inherit(function (sup) {
 		return function() {
 			sup.apply(this, arguments);
 			this.valueChanged();

--- a/source/ui/data/DataGridList.js
+++ b/source/ui/data/DataGridList.js
@@ -8,16 +8,16 @@
 		a paginated scrolling scheme to enhance performance with larger datasets.
 	*/
 	enyo.kind({
-		
+
 		//*@public
 		name: "enyo.DataGridList",
-		
+
 		//*@public
 		kind: "enyo.DataList",
-		
+
 		//*@public
 		classes: "enyo-data-grid-list",
-		
+
 		//*@public
 		/**
 			The spacing (in pixels) between elements in the grid list. It should be an
@@ -25,23 +25,23 @@
 			This is the exact spacing to be allocated on all sides of each item.
 		*/
 		spacing: 10,
-		
+
 		//*@public
 		/**
 			The minimum width (in pixels) for each grid item. Grid items will not be
 			collapsed beyond this size, but they may be proportionally expanded.
 		*/
 		minWidth: 100,
-		
+
 		//*@public
 		/**
 			The minimum height (in pixels) for each grid item. Grid items will not be
 			collapsed beyond this size, but they may be proportionally expanded.
 		*/
 		minHeight: 100,
-		
+
 		//*@protected
-		initComponents: enyo.super(function (sup) {
+		initComponents: enyo.inherit(function (sup) {
 			return function () {
 				sup.apply(this, arguments);
 				var d = this.defaultProps,
@@ -49,7 +49,7 @@
 				d.classes = (d.classes || "") + c;
 			};
 		}),
-		create: enyo.super(function (sup) {
+		create: enyo.inherit(function (sup) {
 			return function () {
 				sup.apply(this, arguments);
 				// currently we don't allow anything else
@@ -105,13 +105,13 @@
 				p.rows = r$ + 1;
 			}
 		},
-		generatePage: enyo.super(function (sup) {
+		generatePage: enyo.inherit(function (sup) {
 			return function (p, n) {
 				sup.apply(this, arguments);
 				this.adjustPageSize(p);
 			};
 		}),
-		getHeight: enyo.super(function (sup) {
+		getHeight: enyo.inherit(function (sup) {
 			return function (n) {
 				if (n && (n.name == "page1" || n.name == "page2")) {
 					/*jshint boss:true*/
@@ -132,7 +132,7 @@
 			}
 			return 0;
 		},
-		updateSizing: enyo.super(function (sup) {
+		updateSizing: enyo.inherit(function (sup) {
 			return function () {
 				sup.apply(this, arguments);
 				var $w = this.width,
@@ -248,7 +248,7 @@
 				this.startJob("layoutPages", this.layoutPages, 100);
 			}
 		},
-		didScroll: enyo.super(function (sup) {
+		didScroll: enyo.inherit(function (sup) {
 			return function (sender, event) {
 				if (!this._noScroll) {
 					return sup.apply(this, arguments);

--- a/source/ui/data/DataList.js
+++ b/source/ui/data/DataList.js
@@ -61,7 +61,7 @@
 		controlParentName: "page1",
 		containerName: "scroller",
 		debugPageBoundaries: false,
-		create: enyo.super(function (sup) {
+		create: enyo.inherit(function (sup) {
 			return function () {
 				sup.apply(this, arguments);
 				this.orientation = this.orientation[0] == "v"? "v": "h";
@@ -475,10 +475,10 @@
 			}
 		},
 		left: function () {
-			
+
 		},
 		right: function () {
-			
+
 		},
 		positionPageAfter: function (p) {
 			var $r = this.orientation,
@@ -512,7 +512,7 @@
 				this._lastPage = $b;
 			}
 		},
-		initContainer: enyo.super(function (sup) {
+		initContainer: enyo.inherit(function (sup) {
 			return function () {
 				var $o = enyo.clone(this.get("containerOptions")),
 					$s = this.get("scrollerOptions");
@@ -530,7 +530,7 @@
 				this.$.scroller.rendered();
 			}
 		},
-		resizeHandler: enyo.super(function (sup) {
+		resizeHandler: enyo.inherit(function (sup) {
 			return function () {
 				sup.apply(this, arguments);
 				this.updateSizing();

--- a/source/ui/data/DataRepeater.js
+++ b/source/ui/data/DataRepeater.js
@@ -100,13 +100,13 @@
 				d.mixins = d.mixins? d.mixins.concat(this.childMixins): this.childMixins;
 			}
 		},
-		constructor: enyo.super(function (sup) {
+		constructor: enyo.inherit(function (sup) {
 			return function () {
 				this._selection = [];
 				sup.apply(this, arguments);
 			};
 		}),
-		create: enyo.super(function (sup) {
+		create: enyo.inherit(function (sup) {
 			return function () {
 				sup.apply(this, arguments);
 				this.selectionChanged();
@@ -316,9 +316,9 @@
 		selected: function() {
 			return this.multipleSelection ? this._selection : this._selection[0];
 		}
-		
+
 	});
-	
+
 	//*@protected
 	enyo.concatHandler("_repeaterKinds", function (proto, props) {
 		var rk = proto._repeaterKinds || (proto._repeaterKinds = []),

--- a/source/ui/data/RepeaterChildSupport.js
+++ b/source/ui/data/RepeaterChildSupport.js
@@ -5,7 +5,7 @@
 */
 enyo.RepeaterChildModelSupport = {
 	name: "RepeaterChildModelSupport",
-	constructed: enyo.super(function (sup) {
+	constructed: enyo.inherit(function (sup) {
 		return function () {
 			// prior to create running which will begin the init components
 			// path, we check to make sure we know what level we are -- if
@@ -20,7 +20,7 @@ enyo.RepeaterChildModelSupport = {
 			sup.apply(this, arguments);
 		};
 	}),
-	destroy: enyo.super(function (sup) {
+	destroy: enyo.inherit(function (sup) {
 		return function () {
 			var mo = this._modelOwner;
 			if (mo !== this) {
@@ -31,7 +31,7 @@ enyo.RepeaterChildModelSupport = {
 			sup.apply(this, arguments);
 		};
 	}),
-	adjustComponentProps: enyo.super(function (sup) {
+	adjustComponentProps: enyo.inherit(function (sup) {
 		return function (props) {
 			// we need to not apply this to children if the children are of kind
 			// DataRepeater or sub-kinds so special handling had to be put here to ensure
@@ -102,7 +102,7 @@ enyo.RepeaterChildSupport = {
 	*/
 	selected: false,
 	//*@protected
-	selectedChanged: enyo.super(function (sup) {
+	selectedChanged: enyo.inherit(function (sup) {
 		return function () {
 			if (this.repeater.selection) {
 				this.addRemoveClass(this.selectedClass || "selected", this.selected);
@@ -117,7 +117,7 @@ enyo.RepeaterChildSupport = {
 			sup.apply(this, arguments);
 		};
 	}),
-	decorateEvent: enyo.super(function (sup) {
+	decorateEvent: enyo.inherit(function (sup) {
 		return function (sender, event) {
 			event.model = this.model;
 			event.child = this;
@@ -135,7 +135,7 @@ enyo.RepeaterChildSupport = {
 		control so that there are no name collisions in the instance owner, and also
 		so that bindings will correctly map to names.
 	*/
-	createClientComponents: enyo.super(function () {
+	createClientComponents: enyo.inherit(function () {
 		return function (components) {
 			this.createComponents(components, {owner: this});
 		};
@@ -143,7 +143,7 @@ enyo.RepeaterChildSupport = {
 	/**
 		Used so that we don't stomp on any built-in handlers for the _ontap_ event.
 	*/
-	dispatchEvent: enyo.super(function (sup) {
+	dispatchEvent: enyo.inherit(function (sup) {
 		return function (name, event, sender) {
 			if (name == "ontap" && !event._fromRepeaterChild) {
 				this._selectionHandler(sender, event);
@@ -152,7 +152,7 @@ enyo.RepeaterChildSupport = {
 			return sup.apply(this, arguments);
 		};
 	}),
-	create: enyo.super(function (sup) {
+	create: enyo.inherit(function (sup) {
 		return function () {
 			sup.apply(this, arguments);
 			var r = this.repeater,
@@ -165,7 +165,7 @@ enyo.RepeaterChildSupport = {
 			}
 		};
 	}),
-	destroy: enyo.super(function (sup) {
+	destroy: enyo.inherit(function (sup) {
 		return function () {
 			if (this._selectionBindingId) {
 				var b$ = enyo.Binding.find(this._selectionBindingId);

--- a/tools/test/core/tests/KindTest.js
+++ b/tools/test/core/tests/KindTest.js
@@ -48,7 +48,7 @@ enyo.kind({
 		});
 		var Derived = enyo.kind({
 			kind: Base,
-			pass: enyo.super(function(sup) {
+			pass: enyo.inherit(function(sup) {
 				return (function(ctx) {
 					if (sup.apply(this, arguments) === "base") {
 						ctx.finish();


### PR DESCRIPTION
...erved work
- Restore .jshintrc to check es3: true now that we're not using super.
- Add inline docs for enyo.inherit()

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
