### PR TITLE
GF-12275:prevent spotlight not blurred when paging

### DIFF
--- a/source/ui/data/DataList.js
+++ b/source/ui/data/DataList.js
@@ -205,6 +205,10 @@
 				this.childSize = Math.floor(($r == "v"? $p.height: $p.width) / $c);
 				this.updateMetrics();
 			}
+			var s = enyo.Spotlight.getCurrent();
+			if(s && s.container === this){
+				enyo.Spotlight.unspot();
+			}
 		},
 		add: function (i) {
 			if (this.generated && this.$.scroller.canGenerate) {


### PR DESCRIPTION
For resolving "enyo.DataGridList spotlight not blurred when
paging(GF-12275)", upspot() code is inserted

Enyo-DCO-1.1-Signed-off-by: Sungbae Cho sb.cho@lge.com
