### PR TITLE
GF-12302 nested group related issue

### DIFF
--- a/source/ui/Group.js
+++ b/source/ui/Group.js
@@ -32,6 +32,7 @@ enyo.kind({
 			} else {
 				this.setActive(inEvent.originator);
 			}
+			return true;
 		}
 	},
 	activeChanged: function(inOld) {


### PR DESCRIPTION
Reason:
Group control takes care of controls which are activated(only one active
at a time).To achieve this child controls trigger the "activate" event to notify
which one is activated. Thus child controls bubble up "activate" event.

However in this scenario, we have multiple group controls(Accordion)
inside Group control, and each Accordion have a "SelectableItem"
control too. So when a "SelectableItem" is selected, it will bubble up
the event("activate") to Group control. This will lead to bubbling the
events to the parent which is Accordion("ExpandableListItem") and it
will also trigger the "activate" event as the active is changed. So this
will lead to closing of Accordion.
I guess this issue will be there for all scenarios where there are
Groups within Groups.

To fix this issue:
Added "return true;" in activate event.
So as when it is triggered within the child controls, it will remain
within them and will not trigger parent event.
