### PR TITLE
GF-7388: Provide a hook for g11n libraries to update internal state...

### DIFF
--- a/source/dom/cordova.js
+++ b/source/dom/cordova.js
@@ -48,11 +48,6 @@ enyo.ready(function(){
 				document.addEventListener(e, enyo.bind(enyo.Signals, "send", "on" + e), false);
 			}
 
-			// if enyo-ilib is present, it will trigger the localechange signal. If not, we need to take care of it.
-			if (!("enyo-ilib" in enyo.version)) {
-				document.addEventListener("localechange", enyo.bind(enyo.Signals, "send", "onlocalechange"), false);
-			}
-
 			// go ahead and broadcast the signal for the "deviceready" event
 			enyo.Signals.send("ondeviceready", inEvent);
 

--- a/source/ext/hooks.js
+++ b/source/ext/hooks.js
@@ -1,0 +1,46 @@
+// Specific hooks for extending Enyo using means other than basic
+// _enyo.kind()_-based inheritance
+
+(function(){
+	//*@public
+	/**
+		Provides a stub function for g11n string translation. This allows
+		strings to be wrapped in preparation for localization. If a g11n
+		library is not loaded, this function will return the string as is.
+
+			$L('Welcome')
+
+		If a compatible g11n library is loaded, this function will be replaced
+		by the g11n library's version, which translates wrapped strings to strings
+		from a developer-provided resource file corresponding to the current user
+		locale.
+	*/
+	window.$L = function(string) {
+		return string;
+	};
+
+	//*@protected
+	/**
+		Enyo controls may register for an `onlocalechange` signal to dynamically update
+		their presentation based on changes to the user's locale.
+
+		This feature is currently used in webOS, where Cordova for webOS listens for
+		changes to the system locales and fires a `localechange` event on the `document`
+		object. Similar functionality could be implemented on other platforms via a
+		Cordova plugin or other means.
+
+		Enyo registers an event listener for the `localechange` event and broadcasts
+		the `onlocalechange` signal when the locale has changed. Before broadcasting, Enyo
+		calls _enyo.updateLocale()_. The default implementation of _enyo.updateLocale()_ is
+		a stub, but a g11n library may override it to update its internal state before the
+		`onlocalechange` signal is broadcast.
+	*/
+	enyo.updateLocale = function() {
+		// This is a stub, to be implemented by a g11n library as needed
+	};
+	enyo.broadcastLocaleChange = function() {
+		enyo.updateLocale();
+		enyo.Signals.send("onlocalechange");
+	};
+	document.addEventListener("localechange", enyo.broadcastLocaleChange, false);
+})();

--- a/source/ext/package.js
+++ b/source/ext/package.js
@@ -1,5 +1,6 @@
 enyo.depends(
 	"macroize.js",
+	"hooks.js",
 	"InputBinding.js",
 	"BooleanBinding.js",
 	"BooleanOnlyBinding.js",

--- a/source/kernel/lang.js
+++ b/source/kernel/lang.js
@@ -931,19 +931,4 @@
 	enyo.trim = function (str) {
 		return str && str.replace? (str.replace(/^\s+|\s$/, "")): str;
 	};
-	/**
-		Provides a stub function for _g11n_ string translation. This allows
-		strings to be wrapped in preparation for localization. If the _g11n_
-		library is not loaded, this function will return the string as is.
-
-			$L('Welcome')
-
-		If the _g11n_ library is loaded, this function will be replaced by the
-		_g11n_ library version, which translates wrapped strings to strings from
-		a developer-provided resource file corresponding to the current user
-		locale.
-	*/
-	window.$L = function(string) {
-		return string;
-	};
 })();


### PR DESCRIPTION
... before Enyo broadcasts the "onlocalechange" signal. Addresses GF-7388.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
