### PR TITLE
Take into account scrollbars size when resizing datalist

### DIFF
--- a/source/ui/data/DataList.js
+++ b/source/ui/data/DataList.js
@@ -540,8 +540,8 @@
 			};
 		}),
 		updateSizing: function () {
-			this.width = this.getWidth();
-			this.height = this.getHeight();
+			this.width = this.$.scroller.clientWidth;
+			this.height = this.$.scroller.clientHeight;
 		},
 		layoutPages: function () {
 			this.adjustPageSize(this.$.page1);


### PR DESCRIPTION
Currently, Datalist doesn't take into account the presence of scrollbars (on desktop, mainly) when calculating the viewport area.
