### PR TITLE
GF-33973: Assign applications an owner of enyo.root, which is a known la...

### DIFF
--- a/source/kernel/Application.js
+++ b/source/kernel/Application.js
@@ -136,6 +136,9 @@
 		//*@protected
 		_isApplication: true,
 
+		// Let events bubble to enyo.master, the top of the chain
+		owner: enyo.master,
+
 		// ...........................
 		// PUBLIC METHODS
 


### PR DESCRIPTION
...st resort for event handling from views.  Since applications aren't UiComponents but do own views, their view events should funnel here as well.

Enyo-DCO-1.1-Signed-off-by: Kevin Schaaf kevin.schaaf@lge.com
