### PR TITLE
ENYO-3009: fix enyo/Application controller creation when reusing kind

### DIFF
--- a/source/kernel/Application.js
+++ b/source/kernel/Application.js
@@ -64,7 +64,7 @@
 		var idx = 0;
 		var kind;
 		for (; idx < len; ++idx) {
-			kind = kinds[idx];
+			kind = enyo.clone(kinds[idx]);
 			// we need the name of the instance whether the controller is global
 			// or app-specific
 			var name = kind.name;
@@ -117,14 +117,19 @@
 		kind: "enyo.ViewController",
 
 		//*@public
+		//* If true, call the start() method immediately after being created.
 		autoStart: true,
 
 		//*@public
+		//* If true, render the view as part of the default start() method.
 		renderOnStart: true,
 
 		//*@public
+		//* Array of controller definitions to be created along wih the application.
 		controllers: null,
 
+		//*@public
+		//* This is set to true when the associated view has been created.
 		viewReady: false,
 
 		//*@public

--- a/tools/test/core/tests/ApplicationTest.js
+++ b/tools/test/core/tests/ApplicationTest.js
@@ -1,0 +1,32 @@
+enyo.kind({
+	name: "ApplicationTest",
+	kind: enyo.TestSuite,
+	noDefer: true,
+	testControllerCreation: function() {
+		var TestApp = enyo.kind({
+			kind: 'Application',
+			renderOnStart: false,
+			controllers: [{
+				name: 'routes',
+				kind: 'enyo.Router'
+			}],
+			view: {
+				name: 'TestView',
+				kind: 'View'
+			}
+		});
+
+		var app = new TestApp();
+		if (!(app.controllers.routes instanceof enyo.Router)) {
+			this.finish("application controller not created");
+		}
+		app.destroy();
+		app = new TestApp();
+		if (!(app.controllers.routes instanceof enyo.Router)) {
+			this.finish("application controller not re-created");
+		}
+		app.destroy();
+
+		this.finish();
+	}
+});

--- a/tools/test/core/tests/package.js
+++ b/tools/test/core/tests/package.js
@@ -5,9 +5,7 @@ enyo.depends(
 	"JobsTest.js",
 	"LoaderTest.js",
 	"KindTest.js",
-	"JsonTest.js",
-	"AsyncTest.js",
-	"AjaxTest.js",
+	"ApplicationTest.js",
 	"ComponentTest.js",
 	"ComponentDispatchTest.js",
 	"ComponentHandlersTest.js",
@@ -22,5 +20,8 @@ enyo.depends(
 	"AnimatorTest.js",
 	"DataRepeaterTest.js",
 	"MultipleDispatchTest.js",
-	"ObserverAndComputedTest.js"
+	"ObserverAndComputedTest.js",
+	"JsonTest.js",
+	"AsyncTest.js",
+	"AjaxTest.js"
 );


### PR DESCRIPTION
Also added test that fails with old code, passes with new based on bug report.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
