### PR TITLE
IE8 won't iterate properties named "constructor" directly, so move test ...

### DIFF
--- a/source/kernel/Oop.js
+++ b/source/kernel/Oop.js
@@ -267,16 +267,16 @@ enyo.kind.extendMethods = function(ctor, props, add) {
 	if (!proto.inherited) {
 		proto.inherited = enyo.kind.inherited;
 	}
+	// rename constructor to _constructor to work around IE8/Prototype problems
+	if (props.hasOwnProperty("constructor")) {
+		props._constructor = props.constructor;
+		delete props.constructor;
+	}
 	// decorate function properties to support inherited (do this ex post facto so that
 	// ctor.prototype is known, relies on elements in props being copied by reference)
 	for (var n in props) {
 		var p = props[n];
 		if (enyo.isInherited(p)) {
-			// handle special case where the constructor has actually been renamed
-			// but mixins or other objects for extending will use the actual name
-			if (n == "constructor") {
-				n = "_constructor";
-			}
 			// ensure that if there isn't actually a super method to call, it won't
 			// fail miserably - while this shouldn't happen often, it is a sanity
 			// check for mixin-extensions for kinds

--- a/source/kernel/mixins/MixinSupport.js
+++ b/source/kernel/mixins/MixinSupport.js
@@ -68,7 +68,13 @@
 		} else {
 			n = null;
 		}
-		enyo.kind.statics.extend(enyo.clone(m), proto);
+		var mc = enyo.clone(m);
+		// rename constructor to _constructor to work around IE8/Prototype problems
+		if (m.hasOwnProperty("constructor")) {
+			mc._constructor = m.constructor;
+			delete mc.constructor;
+		}
+		enyo.kind.statics.extend(mc, proto);
 		if (n) {
 			m.name = n;
 		}


### PR DESCRIPTION
...that property outside of the for-in loop.

Also add test to applyMixin, since enyo.clone won't preserve "constructor" on IE8

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
