### PR TITLE
Refactor enyo.bindSafely

### DIFF
--- a/source/data/Collection.js
+++ b/source/data/Collection.js
@@ -69,8 +69,8 @@ enyo.kind({
 		var o = opts? enyo.clone(opts): {};
 		// ensure there is a strategy for the _didFetch_ method
 		(opts = opts || {}) && (opts.strategy = opts.strategy || "add");
-		o.success = enyo.bind(this, "didFetch", this, opts);
-		o.fail = enyo.bind(this, "didFail", "fetch", this, opts);
+		o.success = enyo.bindSafely(this, "didFetch", this, opts);
+		o.fail = enyo.bindSafely(this, "didFail", "fetch", this, opts);
 		// now if we need to lets remove the records and attempt to do this
 		// while any possible asynchronous remote (not always remote...) calls
 		// are made for efficiency
@@ -432,8 +432,8 @@ enyo.kind({
 		this.length = this.records.length;
 		// we bind this method to our collection so it can be reused as an event listener
 		// for many records
-		this._recordChanged = enyo.bind(this, this._recordChanged);
-		this._recordDestroyed = enyo.bind(this, this._recordDestroyed);
+		this._recordChanged = enyo.bindSafely(this, this._recordChanged);
+		this._recordDestroyed = enyo.bindSafely(this, this._recordDestroyed);
 		this.euid = enyo.uuid();
 		// attempt to resolve the kind of model if it is a string and not a constructor
 		// for the kind

--- a/source/data/Model.js
+++ b/source/data/Model.js
@@ -288,8 +288,8 @@
 		*/
 		commit: function (opts) {
 			var o = opts? enyo.clone(opts): {};
-			o.success = enyo.bind(this, "didCommit", this, opts);
-			o.fail = enyo.bind(this, "didFail", "commit", this, opts);
+			o.success = enyo.bindSafely(this, "didCommit", this, opts);
+			o.fail = enyo.bindSafely(this, "didFail", "commit", this, opts);
 			this.store.commitRecord(this, o);
 		},
 		/**
@@ -301,8 +301,8 @@
 		*/
 		fetch: function (opts) {
 			var o = opts? enyo.clone(opts): {};
-			o.success = enyo.bind(this, "didFetch", this, opts);
-			o.fail = enyo.bind(this, "didFail", "fetch", this, opts);
+			o.success = enyo.bindSafely(this, "didFetch", this, opts);
+			o.fail = enyo.bindSafely(this, "didFail", "fetch", this, opts);
 			this.store.fetchRecord(this, o);
 		},
 		/**
@@ -316,8 +316,8 @@
 		destroy: function (opts) {
 			if (this.readOnly || this.isNew) { return this.destroyLocal(); }
 			var o = opts? enyo.clone(opts): {};
-			o.success = enyo.bind(this, "didDestroy", this, opts);
-			o.fail = enyo.bind(this, "didFail", "destroy", this, opts);
+			o.success = enyo.bindSafely(this, "didDestroy", this, opts);
+			o.fail = enyo.bindSafely(this, "didFail", "destroy", this, opts);
 			this.store.destroyRecord(this, o);
 		},
 		/**
@@ -327,7 +327,7 @@
 		*/
 		destroyLocal: function () {
 			var o = {};
-			o.success = enyo.bind(this, "didDestroy", this);
+			o.success = enyo.bindSafely(this, "didDestroy", this);
 			this.store.destroyRecordLocal(this, o);
 		},
 		/**

--- a/source/kernel/Object.js
+++ b/source/kernel/Object.js
@@ -168,26 +168,8 @@ enyo.kind({
 		subkinds.
 	*/
 	bindSafely: function(method/*, bound arguments*/) {
-		var scope = this;
-		if (enyo.isString(method)) {
-			if (this[method]) {
-				method = this[method];
-			} else {
-				throw(['enyo.Object.bindSafely: this["', method, '"] is null (this="', this, '")'].join(''));
-			}
-		}
-		if (enyo.isFunction(method)) {
-			var args = enyo.cloneArray(arguments, 1);
-			return function() {
-				if (scope.destroyed) {
-					return;
-				}
-				var nargs = enyo.cloneArray(arguments);
-				return method.apply(scope, args.concat(nargs));
-			};
-		} else {
-			throw(['enyo.Object.bindSafely: this["', method, '"] is not a function (this="', this, '")'].join(''));
-		}
+		var args = Array.prototype.concat.apply([this], arguments);
+		return enyo.bindSafely.apply(enyo, args);
 	},
 	//*@protected
 	destroy: function () {

--- a/source/kernel/lang.js
+++ b/source/kernel/lang.js
@@ -844,7 +844,7 @@
 			if (scope[method]) {
 				method = scope[method];
 			} else {
-				throw(['enyo.bind: scope["', method, '"] is null (scope="', scope, '")'].join(''));
+				throw('enyo.bind: scope["' + method + '"] is null (scope="' + scope + '")');
 			}
 		}
 		if (enyo.isFunction(method)) {
@@ -859,9 +859,39 @@
 				};
 			}
 		} else {
-			throw(['enyo.bind: scope["', method, '"] is not a function (scope="', scope, '")'].join(''));
+			throw('enyo.bind: scope["' + method + '"] is not a function (scope="' + scope + '")');
 		}
 	};
+
+	//*@public
+	/**
+		Binds a callback to a scope.  If the object has a "destroyed" property that's truthy,
+		then the callback will not be run if called.  This can be used to implement both
+		enyo.Object.bindSafely and for enyo.Object-like objects like enyo.Model and enyo.Collection.
+	*/
+	enyo.bindSafely = function(scope, method/*, bound arguments*/) {
+		if (enyo.isString(method)) {
+			if (scope[method]) {
+				method = scope[method];
+			} else {
+				throw('enyo.bindSafely: scope["' + method + '"] is null (this="' + this + '")');
+			}
+		}
+		if (enyo.isFunction(method)) {
+			var args = enyo.cloneArray(arguments, 2);
+			return function() {
+				if (scope.destroyed) {
+					return;
+				}
+				var nargs = enyo.cloneArray(arguments);
+				return method.apply(scope, args.concat(nargs));
+			};
+		} else {
+			throw('enyo.bindSafely: scope["' + method + '"] is not a function (this="' + this + '")');
+		}
+	},
+
+
 
 	/**
 		Calls method _inMethod_ on _inScope_ asynchronously.


### PR DESCRIPTION
Add enyo.bindSafely method, refactored from enyo.Object.bindSafely
Update enyo.Model and enyo.Collection to use enyo.bindSafely for callbacks

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
