### PR TITLE
Support enyo.options.noDefer as global flag to turn off kind deferral

### DIFF
--- a/source/kernel/Oop.js
+++ b/source/kernel/Oop.js
@@ -189,6 +189,14 @@ enyo.kind.finish = function(inProps) {
 	return ctor;
 };
 
+// if we've defined an enyo.options hash and the noDefer property is set to true,
+// revert kind behavior to old setup where all kind definitions were immediately
+// processed.
+if (enyo.options && enyo.options.noDefer) {
+	enyo.kind = enyo.kind.finish;
+	enyo.kind.finish = enyo.kind;
+}
+
 //* @public
 /**
 	Creates a singleton of a given kind with a given definition.


### PR DESCRIPTION
Tested by modifying core unit tests to run both without the noDefer global flag set and with it.
Made sure code was hit in debugger, saw that tests all passed either way.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
