### PR TITLE
GF-9695 AjaxSample Update

### DIFF
--- a/samples/AjaxSample.js
+++ b/samples/AjaxSample.js
@@ -35,9 +35,6 @@ enyo.kind({
 	processError: function(inSender, inResponse) {
 		var errorLog = "Error" + ": " + inResponse + "! " + (JSON.parse(inSender.xhrResponse.body)).error.description;
 		this.$.textArea.setValue(JSON.stringify(inSender.xhrResponse, null, 2));
-		this.showPopup(errorLog);
-	},
-	showPopup: function(errorLog) {
 		this.$.basicPopup.setContent(errorLog);
 		this.$.basicPopup.show();
 	}


### PR DESCRIPTION
Issue: Yahoo API upcoming.events has been removed which was giving the
error message.
Fixes:
1) Used other working Yahoo APIs, e.g., weather.forecast and geo.places
APIs.
2) Used "onyx.Popup" to show failed scenarios. Provided proper error
message.
3) Refreshed textArea.

Enyo-DCO-1.1-Signed-off-by: Anugrah Saxena anugrah.saxena@lge.com
