### PR TITLE
Fix enyo.constructorForKind for enyo.getPath changes

### DIFF
--- a/source/kernel/Oop.js
+++ b/source/kernel/Oop.js
@@ -480,7 +480,7 @@ enyo.constructorForKind = function(inKind) {
 	//
 	// Note that kind "Foo" will resolve to enyo.Foo before resolving to global "Foo".
 	// This is important so "Image" will map to built-in Image object, instead of enyo.Image control.
-	ctor = enyo.Theme[inKind] || enyo[inKind] || enyo.getPath.call(enyo, inKind, true) || window[inKind] || enyo.getPath(inKind);
+	ctor = enyo.Theme[inKind] || enyo[inKind] || enyo.getPath("enyo." + inKind) || window[inKind] || enyo.getPath(inKind);
 
 	// if this is a deferred kind, run the follow-up code then refetch the kind's constructor
 	if (ctor && ctor._finishKindCreation) {


### PR DESCRIPTION
enyo.getPath now treats "enyo" as the same as the global scope for lookups.  This caused a kind
lookup of "canvas.Control" to fail, since it was checking window.canvas.Control, not enyo.canvas.Control.
To fix, we change the logic so it does a string prepend of "enyo." to the kind string before calling
enyo.getPath instead of trying to scope to enyo object.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
