### PR TITLE
Fixed Async.failed state being retained between calls to Ajax.go()'

### DIFF
--- a/source/ajax/Ajax.js
+++ b/source/ajax/Ajax.js
@@ -53,6 +53,7 @@ enyo.kind({
 	are case-insensitive.
 	*/
 	go: function(inParams) {
+		this.failed = false;
 		this.startTimer();
 		this.request(inParams);
 		return this;


### PR DESCRIPTION
If same Ajax object is used to perform multiple requests, the state, kept in Async.failed is not reset, especially when one of previous requests fail for whatever reason.
