### PR TITLE
Use a queue for all enyo.ready() calls, not just ones before DOMContentR...

### DIFF
--- a/source/boot/ready.js
+++ b/source/boot/ready.js
@@ -13,6 +13,7 @@
 	var remove;
 	var add;
 	var flush;
+	var flushScheduled = false;
 
 	//*@public
 	/**
@@ -24,11 +25,11 @@
 		asynchronously at earliest opportunity.
 	*/
 	enyo.ready = function (fn, context) {
-		if (ready) {
-			enyo.asyncMethod(context || enyo.global, fn);
-		}
-		else {
-			queue.push([fn, context]);
+		queue.push([fn, context]);
+		// schedule another queue flush if needed to run new ready calls
+		if (ready && !flushScheduled) {
+			enyo.asyncMethod(window, flush);
+			flushScheduled = true;
 		}
 	};
 
@@ -71,6 +72,7 @@
 				run.apply(scope, queue.shift());
 			}
 		}
+		flushScheduled = false;
 	};
 
 	// ok, let's hook this up

--- a/tools/test/core/tests/readyTest.js
+++ b/tools/test/core/tests/readyTest.js
@@ -17,5 +17,18 @@ enyo.kind({
 		}, this);
 		good = true;
 		// we rely on test framework timeout to catch failure if code is never run
+	},
+	// we include this a second time to verify that we can keep calling enyo.ready()
+	testAsync2: function() {
+		var good = false;
+		enyo.ready(function () {
+			if (good) {
+				this.finish();
+			} else {
+				this.finish("enyo.ready() ran call immediately instead of async");
+			}
+		}, this);
+		good = true;
+		// we rely on test framework timeout to catch failure if code is never run
 	}
 });


### PR DESCRIPTION
...eady.

This is to speed up app launch into a container when source is loaded after the initial app startup.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
