### PR TITLE
Guard call to enyo.cancelAnimationFrame in Animator

### DIFF
--- a/source/touch/ScrollMath.js
+++ b/source/touch/ScrollMath.js
@@ -197,7 +197,10 @@ enyo.kind({
 		}
 	},
 	stop: function(inFireEvent) {
-		this.job = enyo.cancelRequestAnimationFrame(this.job);
+		var job = this.job;
+		if (job) {
+			this.job = enyo.cancelRequestAnimationFrame(job);
+		}
 		if (inFireEvent) {
 			this.doScrollStop();
 		}


### PR DESCRIPTION
Micro-perf: add check to avoid calling system timer code when not needed

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
