### PR TITLE
Fix typo that was preventing Binding.stop() from working.

### DIFF
--- a/source/kernel/Binding.js
+++ b/source/kernel/Binding.js
@@ -494,7 +494,7 @@
 			not call this method otherwise.
 		*/
 		stop: function () {
-			throw "binding-top";
+			throw "binding-stop";
 		},
 		//*@protected
 		initTransform: function () {


### PR DESCRIPTION
Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
