### PR TITLE
Make enyo.Scroller provide bounds in events

### DIFF
--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -292,9 +292,9 @@ enyo.DataList.delegates.vertical = {
 		too many functions whenever this event is propagated.
 	*/
 	didScroll: function (list, event) {
-		var sc = list.$.scroller,
+		var sb = event.scrollBounds,
 			pr = list.previousScrollPos,
-			cr = (list.previousScrollPos=this.getScrollPosition(list)),
+			cr = (list.previousScrollPos = sb.top),
 			p1 = list.$.page1,
 			p2 = list.$.page2,
 			sp = list.psizeProp,
@@ -362,7 +362,7 @@ enyo.DataList.delegates.vertical = {
 			if (cr === 0) {
 				// we need to reset to origin
 				this.reset(list);
-			} else if (cr === (sc.getScrollBounds()[sp]-this[sp](list))) {
+			} else if (cr === (sb[sp]-this[sp](list))) {
 				// this is at the bottom so we need to generate bottom up from
 				// the second page
 				pc = this.pageCount(list);


### PR DESCRIPTION
While developing the new DataList, we saw a problem that the call get getScrollBounds
would cause animation to stop with the touch scroller.  Rather than change the behavior,
we'll instead use an internal method of the scroll strategies to get current bounds
and attach that structure to the onScroll, onScrollStart, and onScrollEnd events so users
of those events don't have to make calls back to the scroller.

Updated VerticalDelegate to use that info.  This is the only code where I directly saw
this problem in our current set of active libraries.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
