### PR TITLE
Fix this.inherited argument handling

### DIFF
--- a/source/kernel/Oop.js
+++ b/source/kernel/Oop.js
@@ -319,7 +319,21 @@ enyo.kind.inherited = function (originals, replacements) {
 	// warning to notify developers they are calling a
 	// super method that doesn't exist
 	if ("function" === typeof fn) {
-		return fn.apply(this, replacements? enyo.mixin(originals, replacements): originals);
+		var args = originals;
+		if (replacements) {
+			// combine the two arrays, with the replacements taking the first
+			// set of arguments, and originals filling up the rest.
+			args = [];
+			var i = 0, l = replacements.length;
+			for (; i < l; ++i) {
+				args[i] = replacements[i];
+			}
+			l = originals.length;
+			for (; i < l; ++i) {
+				args[i] = originals[i];
+			}
+		}
+		return fn.apply(this, args);
 	} else {
 		enyo.warn("enyo.kind.inherited: unable to find requested " +
 			"super-method from -> " + originals.callee.displayName + " in " + this.kindName);

--- a/tools/test/core/tests/KindTest.js
+++ b/tools/test/core/tests/KindTest.js
@@ -93,7 +93,27 @@ enyo.kind({
 			k.destroy();
 		}
 		this.finish();
+	},
+	testInheritedCall: function() {
+		var K = enyo.kind({
+			foo: function(a, b, c) {
+				if (a + b === c) {
+					return true;
+				}
+				return false;
+			}
+		});
+		var K2 = enyo.kind({
+			kind: K,
+			foo: function() {
+				return this.inherited(arguments, [1, 4]);
+			}
+		});
+		var k2 = new K2();
+		if (k2.foo(2, 4, 5)) {
+			this.finish();
+		} else {
+			this.finish("this.inherited didn't allow argument override");
+		}
 	}
-
-
 });


### PR DESCRIPTION
Due to a rewrite of enyo.mixin, it lost the ability to combine
two plain arrays or an array-like object and an array.  Instead,
we'll inline simple code to do that in enyo.kind.inherited to
restore old functionality.

Also, add a test to validate this to KindTest.js in core tests.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
