### PR TITLE
GF-40378: don't defer enyo.Signals due to early use

### DIFF
--- a/source/kernel/Signals.js
+++ b/source/kernel/Signals.js
@@ -15,6 +15,9 @@ enyo.kind({
 	name: "enyo.Signals",
 	kind: "enyo.Component",
 	//* @protected
+	// needed because of early calls to bind DOM event listeners
+	// to the enyo.Signals.send call.
+	noDefer: true,
 	create: enyo.inherit(function (sup) {
 		return function() {
 			sup.apply(this, arguments);


### PR DESCRIPTION
Code in cordova.js binds DOM event handlers to enyo.Signals.send
during Enyo load time. This binding would work, except that the
listeners variable modified by the call is in the protectedStatics
section, so it isn't created on the kind until it's undeferred.

This kind is small, so we'll just go ahead and mark it noDefer
instead.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
