### PR TITLE
ENYO-3237: restore sendRelease call

### DIFF
--- a/source/dom/drag.js
+++ b/source/dom/drag.js
@@ -252,6 +252,7 @@ enyo.gesture.drag = {
 		}
 		if (this.sentHold) {
 			this.sentHold = false;
+			this.sendRelease(this.holdEvent);
 		}
 	},
 	sendHoldPulse: function(inEvent) {


### PR DESCRIPTION
The this.sendRelease() call used to send the 'release' event at the
end of a 'hold' was mistakenly removed in commit 331542552a which
removed the enyo.pool code. This restores it to its place of glory.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
