### PR TITLE
Replace replace() calls with enyo.trim()

### DIFF
--- a/source/data/Model.js
+++ b/source/data/Model.js
@@ -59,7 +59,7 @@
 		The events in _enyo.Model_ differ from those in
 		[enyo.Component](#enyo.Component). Instead of _bubbled_ or _waterfall_
 		events, _enyo.Model_ has _change_ and _destroy_ events.
-		
+
 		To work with these events, use [addListener()](#enyo.Model::addListener),
 		[removeListener()](#enyo.Model::removeListener), and
 		[triggerEvent()](#enyo.Model::triggerEvent).
@@ -178,7 +178,7 @@
 				if (this.computedMap) {
 					if ((en=this.computedMap[prop])) {
 						if (typeof en == "string") {
-							en = this.computedMap[prop] = en.replace(/^\s+|\s+$/, "").split(" ");
+							en = this.computedMap[prop] = enyo.trim(en).split(" ");
 						}
 						ch = {};
 						for (var i=0, p; (p=en[i]); ++i) {
@@ -189,7 +189,7 @@
 						}
 					}
 				}
-				
+
 				this.changed[prop] = this.attributes[prop] = value;
 				this.notifyObservers(prop, rv, value);
 				// if this is a dependent of a computed property we mark that
@@ -222,7 +222,7 @@
 					if (this.computedMap) {
 						if ((en=this.computedMap[k])) {
 							if (typeof en == "string") {
-								en = this.computedMap[k] = en.replace(/^\s+|\s+$/, "").split(" ");
+								en = this.computedMap[k] = enyo.trim(en).split(" ");
 							}
 							for (var i=0, p; (p=en[i]); ++i) {
 								this.attributes[k] = rv;
@@ -275,7 +275,7 @@
 		//*@protected
 		importProps: function (p) {
 			if (p) {
-				if (p.defaults || p.attributes || p.computed) { 
+				if (p.defaults || p.attributes || p.computed) {
 					enyo.concatHandler(this, p);
 				}
 				for (var k in p) { k != "parse" && (this[k] = p[k]); }

--- a/source/dom/Control.js
+++ b/source/dom/Control.js
@@ -1035,7 +1035,7 @@ enyo.kind({
 					text += n + ': ' + v + '; ';
 				}
 			}
-			return text.replace(/^\s+|\s+$/g, "");
+			return enyo.trim(text);
 		},
 		stylesToHtml: function(inStyleHash) {
 			var cssText = enyo.Control.domStylesToCssText(inStyleHash);
@@ -1060,7 +1060,7 @@ enyo.kind({
 			return h;
 		},
 		normalizeCssStyleString: function (inText) {
-			return (inText + ";").replace(/;;+/g, ";").replace(/^\s*?;/, "").replace(/;\s*(?!$)/g, "; ").replace(/:\s*/g, ": ").replace(/^\s+|\s+$/, "");
+			return enyo.trim((inText + ";").replace(/;;+/g, ";").replace(/^\s*?;/, "").replace(/;\s*(?!$)/g, "; ").replace(/:\s*/g, ": "));
 		}
 	}
 });
@@ -1071,9 +1071,9 @@ enyo.Control.concat = function (ctor, props, instance) {
 	var p = ctor.prototype || ctor;
 	if (props.classes) {
 		if (instance) {
-			p.classes = ((p.classes? (p.classes + " "): "") + props.classes).replace(/^\s+|\s+$/, "");
+			p.classes = enyo.trim((p.classes? (p.classes + " "): "") + props.classes);
 		} else {
-			p.kindClasses = ((p.kindClasses? p.kindClasses: "") + (p.classes? (" " + p.classes): "")).replace(/^\s+|\s+$/, "");
+			p.kindClasses = enyo.trim((p.kindClasses? p.kindClasses: "") + (p.classes? (" " + p.classes): ""));
 			p.classes = props.classes;
 		}
 		delete props.classes;

--- a/source/kernel/lang.js
+++ b/source/kernel/lang.js
@@ -951,8 +951,15 @@
 		without modification.
 	*/
 	enyo.trim = function (str) {
-		return str && str.replace? (str.replace(/^\s+|\s+$/, "")): str;
+		return str && str.replace? (str.replace(/^\s+|\s+$/g, "")): str;
 	};
+
+	// use built-in .trim when available in JS runtime
+	if (String.prototype.trim) {
+		enyo.trim = function(str) {
+			return str && str.trim? str.trim() : str;
+		};
+	}
 
 	//*@public
 	/**

--- a/source/kernel/mixins/ComputedSupport.js
+++ b/source/kernel/mixins/ComputedSupport.js
@@ -1,5 +1,5 @@
 (function (enyo) {
-		
+
 	//*@protected
 	// this is called when we need an instance-specific computed table so
 	// runtime modifications are unique to the instance and not the kind, also
@@ -82,7 +82,7 @@
 				var map = _instanceMap(this, "computedMap"), n;
 				if ((n = map[path])) {
 					if (typeof n == "string") {
-						n = map[path] = n.replace(/^\s+|\s+$/, "").split(" ");
+						n = map[path] = enyo.trim(n).split(" ");
 					}
 					for (var i=0, p; (p=n[i]); ++i) {
 						// this is a dependency of one of our computed properties
@@ -188,18 +188,18 @@
 			}
 			for (var k in props.computed) {
 				p.computed[k] = (p.computed[k] || "");
-				var ss = (typeof props.computed[k] == "string"? props.computed[k].replace(/^\s+|\s+$/, "").split(" "): props.computed[k]);
+				var ss = (typeof props.computed[k] == "string"? enyo.trim(props.computed[k]).split(" "): props.computed[k]);
 				for (var i=0, s; (s=ss[i]); ++i) {
 					if (typeof s == "object" && s.cached) {
 						p.computedCached[k] = true;
 					} else {
 						if (!~p.computed[k].indexOf(s)) {
 							p.computed[k] += (" " + s);
-							p.computedMap[s] = ((p.computedMap[s] || "") + " " + k).replace(/^\s+|\s+$/, "").replace(/\s+/g, " ");
+							p.computedMap[s] = enyo.trim((p.computedMap[s] || "") + " " + k).replace(/\s+/g, " ");
 						}
 					}
 				}
-				p.computed[k] = p.computed[k].replace(/^\s+|\s+$/, "").replace(/\s+/g, " ");
+				p.computed[k] = enyo.trim(p.computed[k]).replace(/\s+/g, " ");
 			}
 			delete props.computed;
 		}

--- a/source/kernel/mixins/ObserverSupport.js
+++ b/source/kernel/mixins/ObserverSupport.js
@@ -72,7 +72,7 @@
 				i  = enyo.uid("__observer__"), o;
 			if ((o = ma[prop])) {
 				if (typeof o == "string") {
-					o = ma[prop] = o.replace(/^\s+|\s+$/, "").split(" ");
+					o = ma[prop] = enyo.trim(o).split(" ");
 				}
 				o.push(i);
 			} else {
@@ -94,7 +94,7 @@
 			var ma = _instanceMap(this), o;
 			if ((o = ma[prop])) {
 				if (typeof o == "string") {
-					o = ma[prop] = o.replace(/^\s+|\s+$/, "").split(" ");
+					o = ma[prop] = enyo.trim(o).split(" ");
 				}
 				for (var i=0, i$; (i$=o[i]); ++i) {
 					if (this[i$] === fn) {
@@ -135,11 +135,11 @@
 				var o = ma[prop],
 					a = this.observerNotificationsEnabled;
 				if (typeof o == "string") {
-					o = ma[prop] = o.replace(/^\s+|\s+$/, "").split(" ");
+					o = ma[prop] = enyo.trim(o).split(" ");
 				}
 				if (ma["*"]) {
 					if (typeof ma["*"] == "string") {
-						ma["*"] = ma["*"].replace(/^\s+|\s+$/, "").split(" ");
+						ma["*"] = enyo.trim(ma["*"]).split(" ");
 					}
 					o = o? o.concat(ma["*"]): ma["*"];
 				}
@@ -301,15 +301,15 @@
 			}
 			for (var k in props.observers) {
 				p.observers[k] = (p.observers[k] || "");
-				var ss = (typeof props.observers[k] == "string"? props.observers[k].replace(/^\s+|\s+$/, "").split(" "): props.observers[k]);
+				var ss = (typeof props.observers[k] == "string"? enyo.trim(props.observers[k]).split(" "): props.observers[k]);
 				for (var i=0, s; (s=ss[i]); ++i) {
 					// if we have not seen this entry before we will add it
 					if (!~p.observers[k].indexOf(s)) {
 						p.observers[k] += (" " + s);
-						p.observerMap[s] = ((p.observerMap[s] || "") + " " + k).replace(/^\s+|\s+$/, "").replace(/\s+/g, " ");
+						p.observerMap[s] = enyo.trim((p.observerMap[s] || "") + " " + k).replace(/\s+/g, " ");
 					}
 				}
-				p.observers[k] = p.observers[k].replace(/^\s+|\s+$/, "").replace(/\s+/g, " ");
+				p.observers[k] = enyo.trim(p.observers[k]).replace(/\s+/g, " ");
 			}
 			delete props.observers;
 		}


### PR DESCRIPTION
The new observer and computed code uses strings of space-delimited
names instead of arrays for speed and memory savings, but the code
requires frequent operations to strip off spaces that may have
accumulated at the start and end.  ES5 provides a trim() method for
this, and tests using jsperf show it's twice the speed of the
equivalent replace() call in V8 and JSCore.

This also fixes latent bugs, as many of the replace() calls were
missing the global operator to strip off spaces both at start and
end.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
