### PR TITLE
Optimize RepeaterChildSupport to avoid claiming node until necessary.  A...

### DIFF
--- a/source/ui/data/RepeaterChildSupport.js
+++ b/source/ui/data/RepeaterChildSupport.js
@@ -12,8 +12,8 @@
 		for (var i=0, t=p.tree, pr, c; (c=t[i]); ++i) {
 			pr = c.id;
 			if (!p.flyweighter) { 
-				c.generated = true; 
 				c.node = null;
+				c.generated = true; 
 			}
 			c.id = c.makeId();
 			c.idChanged(pr);
@@ -87,7 +87,7 @@
 				sup.apply(this, arguments);
 				// if we're not the flyweighter we need to grab our node now
 				if (!this.flyweighter) { 
-					this.node = document.getElementById(this.id); 
+					this.node = null; 
 					this.generated = true;
 				}
 			};


### PR DESCRIPTION
...lso fixes issue where generated flag was never on child controls claimed after flyweight generation.

Enyo-DCO-1.1-Signed-off-by: Kevin Schaaf kevin.schaaf@lge.com
