### PR TITLE
Clean up XHR refs to avoid possible circular refs

### DIFF
--- a/source/ajax/Ajax.js
+++ b/source/ajax/Ajax.js
@@ -31,6 +31,13 @@ enyo.kind({
 			sup.apply(this, arguments);
 		};
 	}),
+	destroy: enyo.inherit(function (sup) {
+		return function() {
+			// explicilty release any XHR refs
+			this.xhr = null;
+			sup.apply(this, arguments);
+		};
+	}),
 	//* @public
 	/**
 	Sends the Ajax request with parameters _inParams_. _inParams_ values may be

--- a/source/ajax/Async.js
+++ b/source/ajax/Async.js
@@ -35,6 +35,15 @@ enyo.kind({
 			this.progressHandlers = [];
 		};
 	}),
+	destroy: enyo.inherit(function (sup) {
+		return function() {
+			if (this.timeoutJob) {
+				this.clearTimeout();
+			}
+			sup.apply(this, arguments);
+		};
+	}),
+
 	accumulate: function(inArray, inMethodArgs) {
 		var fn = (inMethodArgs.length < 2) ? inMethodArgs[0] : enyo.bind(inMethodArgs[0], inMethodArgs[1]);
 		inArray.push(fn);

--- a/source/ajax/xhr.js
+++ b/source/ajax/xhr.js
@@ -92,6 +92,7 @@ enyo.xhr = {
 					data = inXhr.responseText;
 				}
 				inCallback.apply(null, [data, inXhr]);
+				inXhr = null;
 			};
 		}
 		inXhr.onreadystatechange = function() {
@@ -103,6 +104,7 @@ enyo.xhr = {
 					data = inXhr.responseText;
 				}
 				inCallback.apply(null, [data, inXhr]);
+				inXhr = null;
 			}
 		};
 	},


### PR DESCRIPTION
Also adds destroy() methods for enyo.Async and enyo.Ajax to
clean up a XHR reference and a timer reference that could be
orphaned.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
