### PR TITLE
Fix XHR sync test failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,5 @@ script:
   jshint . &&
   echo -e "\x1b\x5b35;1m*** Running core tests with phantomjs\x1b\x5b0m" &&
   phantomjs tools/test/core/phantomjs-test.js &&
-  echo -e "\x1b\x5b35;1m*** Running ajax tests with phantomjs (failures ignored)\x1b\x5b0m" &&
-  (phantomjs tools/test/ajax/phantomjs-test.js || true)
+  echo -e "\x1b\x5b35;1m*** Running ajax tests with phantomjs\x1b\x5b0m" &&
+  phantomjs tools/test/ajax/phantomjs-test.js

--- a/source/ajax/xhr.js
+++ b/source/ajax/xhr.js
@@ -94,19 +94,20 @@ enyo.xhr = {
 				inCallback.apply(null, [data, inXhr]);
 				inXhr = null;
 			};
-		}
-		inXhr.onreadystatechange = function() {
-			if (inXhr.readyState == 4) {
-				var data;
-				if (inXhr.responseType === "arraybuffer") {
-					data = inXhr.response;
-				} else if (typeof inXhr.responseText === "string") {
-					data = inXhr.responseText;
+		} else {
+			inXhr.onreadystatechange = function() {
+				if (inXhr && inXhr.readyState == 4) {
+					var data;
+					if (inXhr.responseType === "arraybuffer") {
+						data = inXhr.response;
+					} else if (typeof inXhr.responseText === "string") {
+						data = inXhr.responseText;
+					}
+					inCallback.apply(null, [data, inXhr]);
+					inXhr = null;
 				}
-				inCallback.apply(null, [data, inXhr]);
-				inXhr = null;
-			}
-		};
+			};
+		}
 	},
 	inOrigin: function(inUrl) {
 		var a = document.createElement("a"), result = false;


### PR DESCRIPTION
We had a workaround for sync XHRs where we would explicitly call the
onreadystatechange handler, apparently to work around old Firefox bugs.
So, modify the handler to check inXhr before using it. This avoids the
test failure and crash.  Also, renable the travis checking of Ajax tests
now that it seems more stable.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
