### PR TITLE
Make enyo.Scroller non-deferred for API compat

### DIFF
--- a/source/touch/Scroller.js
+++ b/source/touch/Scroller.js
@@ -97,6 +97,8 @@ enyo.kind({
 	*/
 	preventScrollPropagation: true,
 	//* @protected
+	// needed to allow global mods to enyo.Scroller.touchScrolling
+	noDefer: true,
 	handlers: {
 		onscroll: "domScroll",
 		onScrollStart: "scrollStart",


### PR DESCRIPTION
We've documented that app developers can modify enyo.Scroller.touchScrolling
to change the default behavior, so we need to ensure this kind exists in its
final form from definition time.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
