### PR TITLE
ENYO-1836: Update enyo.design with missing components and components to ignore in the palette's designer of Ares

### DIFF
--- a/source/enyo.design
+++ b/source/enyo.design
@@ -179,6 +179,15 @@
                     "config": {
                         "kind": "enyo.ToolDecorator"
                     }
+                },
+                {
+                    "name": "enyo.Video",
+                    "description": "A video stream",
+                    "config": {
+                        "kind": "enyo.Video",
+                        "src": "http://www.w3schools.com/html/movie.mp4",
+                        "showControls": true
+                    }
                 }
             ]
         },


### PR DESCRIPTION
Related JIRA: https://enyojs.atlassian.net/browse/ENYO-1836, https://enyojs.atlassian.net/browse/ENYO-3290

ENYO-1836: Update enyo.design with missing components and components to ignore in the designer's palette of Ares Lighten components description, management
ENYO-3290: Add 'Empty Kind' component

Must be reviewed (first) by @yves-del-medico and is related to other PRs:
- https://github.com/enyojs/ares-project/pull/632
- https://github.com/enyojs/layout/pull/61
- https://github.com/enyojs/onyx/pull/183

Enyo-DCO-1.1-Signed-off-by: Vincent HERILIER vincent.herilier@hp.com
