### PR TITLE
Unbreak TransitionScrollStrategy

### DIFF
--- a/source/touch/TouchScrollStrategy.js
+++ b/source/touch/TouchScrollStrategy.js
@@ -188,13 +188,19 @@ enyo.kind({
 		this.hideThumbs();
 	},
 	intervalChanged: function() {
-		this.$.scrollMath.interval = this.interval;
+		if (this.$.scrollMath) {
+			this.$.scrollMath.interval = this.interval;
+		}
 	},
 	fixedTimeChanged: function() {
-		this.$.scrollMath.fixedTime = this.fixedTime;
+		if (this.$.scrollMath) {
+			this.$.scrollMath.fixedTime = this.fixedTime;
+		}
 	},
 	frameChanged: function() {
-		this.$.scrollMath.frame = this.frame;
+		if (this.$.scrollMath) {
+			this.$.scrollMath.frame = this.frame;
+		}
 	},
 	stop: function() {
 		if (this.isScrolling()) {


### PR DESCRIPTION
This was broken by the change that added fixedTime and frame
properties to TouchScrollStrategy; the observers for those
properties assumed that scrollMath always existed, but it doesn't
for TransitionScrollStrategy, so we'll guard those calls.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
