### PR TITLE
ENYO-3519: fix enyo.ModelController init of model property

### DIFF
--- a/source/data/ModelController.js
+++ b/source/data/ModelController.js
@@ -102,7 +102,9 @@ enyo.kind({
 	create: enyo.inherit(function (sup) {
 		return function () {
 			sup.apply(this, arguments);
-			this.notifyObservers("model");
+			if (this.model) {
+				this.notifyObservers("model", null, this.model);
+			}
 		};
 	}),
 	constructor: enyo.inherit(function (sup) {

--- a/source/kernel/UiComponent.js
+++ b/source/kernel/UiComponent.js
@@ -68,7 +68,7 @@ enyo.kind({
 			this.layoutKindChanged();
 			// TODO-POST-2.3
 			if (this.controller) {
-				this.notifyObservers("controller");
+				this.notifyObservers("controller", null, this.controller);
 			}
 			// END-TODO-POST-2.3
 		};

--- a/tools/test/core/tests/ControllerTest.js
+++ b/tools/test/core/tests/ControllerTest.js
@@ -44,6 +44,18 @@ enyo.kind({
 			(c.get("content") != "1" && "control's content did not propagate from binding")
 		);
 	},
+	testModelSetAtCreation: function() {
+		var	c  = new enyo.Control();
+		var m  = new enyo.Model({prop1: "0"});
+		var mc = new enyo.ModelController({model: m});
+		var b  = new enyo.Binding({source: mc, from: ".prop1", target: c, to: ".content"});
+		mc.set("prop1", "1");
+		b.destroy();
+		this.finish(
+			(mc.get("prop1") != "1" && "could not retrieve the correct value from the model") ||
+			(c.get("content") != "1" && "control's content did not propagate from binding")
+		);
+	},
 	testTwoWayBinding: function () {
 		var mc = new enyo.ModelController(),
 			c  = new enyo.Control(),


### PR DESCRIPTION
enyo.ModelController.modelChanged() wasn't handling the case
where prev and model parameters were both undefined which happens
during the notifyObservers() call in enyo.ModelController.create().
Fix by making sure notifyObservers always includes those values
and optimize away that call if it's constructed with null model.

Also, fix separate potential bug in UiComponent where similar
code existed. It wasn't an issue with the current controllerChanged
method, but if it was changed in the future, it could have the same
issue.

Added test case to ControllerTest showing original bug, verified
that it failed before and passes now.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
