### PR TITLE
ENYO-3250: fix file-URL xhr code for webOS 3

### DIFF
--- a/source/ajax/xhr.js
+++ b/source/ajax/xhr.js
@@ -129,7 +129,7 @@ enyo.xhr = {
 		if (a.protocol === "file:" ||
 			a.protocol === ":" && window.location.protocol === "file:") {
 			// leave off search and hash parts of the URL
-			return a.protocol + '//' + a.host + a.pathname;
+			return a.protocol + '//' + a.pathname;
 		} else if (a.protocol === ":" && window.location.protocol === "x-wmapp0:") {
 			// explicitly return absolute URL for Windows Phone 8, as an absolute path is required for local files
 			return window.location.protocol + "//" + window.location.pathname.split('/')[0] + "/" + a.host + a.pathname;


### PR DESCRIPTION
enyo.xhr.request was running file URLs through simplification logic
that triggered a weird behavior on webOS 3 -- window.location.host isn't
set to "" like on other file-protocol using setups, but instead
maps to a app-specific string. Unfortunately, the URL lookup didn't
actually allow using that host name to load files.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
