### PR TITLE
Fix Datarepeater not rendering on collection changes

### DIFF
--- a/source/ui/data/DataRepeater.js
+++ b/source/ui/data/DataRepeater.js
@@ -366,7 +366,7 @@ enyo.kind({
 			this.reset();
 		}
 	},
-	computed: {selected: [], data: ["controller"]},
+	computed: {selected: [], data: ["collection"]},
 	noDefer: true,
 	childMixins: [enyo.RepeaterChildSupport],
 	controlParentName: "container",


### PR DESCRIPTION
The deprecation of controller makes some bindings break for the collection property. This fixes it
