### PR TITLE
fix gesturechange event on iOS7

### DIFF
--- a/source/touch/touch.js
+++ b/source/touch/touch.js
@@ -117,11 +117,14 @@ enyo.requiresWindow(function() {
 			}
 		},
 		connect: function() {
-			enyo.forEach(['ontouchstart', 'ontouchmove', 'ontouchend', 'ongesturestart', 'ongesturechange', 'ongestureend'], function(e) {
-				document[e] = enyo.dispatch;
+			enyo.forEach(['touchstart', 'touchmove', 'touchend', 'gesturestart', 'gesturechange', 'gestureend'], function(e) {
+				if(enyo.platform.ie < 9){
+					document["on" + e] = enyo.dispatch;
+				} else {
+					// on iOS7 document.ongesturechange is never called
+					document.addEventListener(e, enyo.dispatch, false);
+				}
 			});
-			// on iOS7 document.ongesturechange is never called
-			document.addEventListener("gesturechange", enyo.dispatch, false);
 
 			if (enyo.platform.androidChrome <= 18 || enyo.platform.silk === 2) {
 				// HACK: on Chrome for Android v18 on devices with higher density displays,


### PR DESCRIPTION
The document.ongesturechange event is not fired on iOS7, which prevents the pinch-to-zoom functionality in PanZoomView and ImageView from working. There might be issues with other events as well (not tested). Tested in iPod 5 (iOS7) and iPad 1 (iOS5).
