### PR TITLE
ENYO-3538: fix setObject handling of unchanged props

### DIFF
--- a/source/data/Model.js
+++ b/source/data/Model.js
@@ -224,12 +224,14 @@
 				if (props) {
 					this.stopNotifications();
 					this.silence();
+					var updated = false;
 					for (var k in props) {
 						this.set(k, props[k]);
+						updated = updated || this._updated;
 					}
 					this.startNotifications();
 					this.unsilence();
-					if (this._updated) {
+					if (updated) {
 						this._updated = false;
 						this.triggerEvent("change");
 					}
@@ -433,7 +435,7 @@
 			// to avoid lingering entries
 			this.removeAllObservers();
 			this.removeAllListeners();
-			
+
 			if (opts && opts.success) {
 				opts.success(rec, opts, res);
 			}

--- a/tools/test/core/tests/DataModelingTest.js
+++ b/tools/test/core/tests/DataModelingTest.js
@@ -124,6 +124,20 @@ enyo.kind({
 			(m.attributes.prop6 !== 0 && "'0' attribute ignored unexectedly") ||
 			(m.attributes.prop7 != "prop7" && "new attribute missing")
 		);
+	},
+	testSetObject: function() {
+		// test for ENYO-3538
+		var m = new enyo.Model({ value1: 0, value2: 0});
+		var gotChange = false;
+		m.addListener("change", function() {
+			gotChange = true;
+		});
+		m.setObject({ value1: 1, value2: 0});
+		if (gotChange) {
+			this.finish();
+		} else {
+			this.finish("didn't fire change event for setObject");
+		}
 	}
 });
 


### PR DESCRIPTION
The enyo.Model.setObject code didn't correctly detect when a model
changed if the last property set from the new object was the same
as the original value, because a flag was getting overwritten for
each property change. This modifies this setObject code to notice
any change, instead of just the last one. A test is added to
core tests that fails on original code and passes now.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
