### PR TITLE
Fix for: GF-45822

### DIFF
--- a/source/ui/data/DataList.js
+++ b/source/ui/data/DataList.js
@@ -110,12 +110,12 @@ enyo.kind({
 			this.delegate = this.ctor.delegates[this.orientation] || this.base.delegates.vertical;
 			// if we can, we use transitions
 			this.allowTransitionsChanged();
-			sup.apply(this, arguments);
 			// if the delegate has an initialization routine execute it now before the
 			// container and children are rendered
 			if (this.delegate.initList) {
 				this.delegate.initList(this);
 			}
+			sup.apply(this, arguments);
 			// initialize the _pages_ array and add the pages to it
 			this.pages = [this.$.page1, this.$.page2];
 		};

--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -15,12 +15,6 @@ enyo.DataList.delegates.vertical = {
 		by other delegates that wish to share some basic functionality.
 	*/
 	initList: function (list) {
-		if (list.$.scroller.addScrollListener) {
-			list.usingScrollListener = true;
-			list.$.scroller.addScrollListener(
-				enyo.bindSafely(this, "scrollHandler", list)
-			);
-		}
 		list.upperProp = "top";
 		list.lowerProp = "bottom";
 		list.psizeProp = "height";
@@ -95,6 +89,12 @@ enyo.DataList.delegates.vertical = {
 		and apply them to our pages individually.
 	*/
 	rendered: function (list) {
+		if (list.$.scroller.addScrollListener) {
+			list.usingScrollListener = true;
+			list.$.scroller.addScrollListener(
+				enyo.bindSafely(this, "scrollHandler", list)
+			);
+		}
 		// get our initial sizing cached now since we should actually have
 		// bounds at this point
 		this.updateBounds(list);
@@ -412,13 +412,14 @@ enyo.DataList.delegates.vertical = {
 			lastIdx   = pos.lastPage.index,
 			count     = this.pageCount(list)-1,
 			lowerProp = list.lowerProp,
-			upperProp = list.upperProp;
+			upperProp = list.upperProp,
+			fn        = upperProp == "top"? this.height: this.width;
 		// now to update the properties the scroller will use to determine
 		// when we need to be notified of position changes requiring paging
 		if (firstIdx === 0) {
 			threshold[upperProp] = undefined;
 		} else {
-			threshold[upperProp] = metrics[lastIdx][upperProp] - this.height(list);
+			threshold[upperProp] = metrics[lastIdx][upperProp] - fn(list);
 		}
 		if (lastIdx === count) {
 			threshold[lowerProp] = undefined;


### PR DESCRIPTION
...to properly update properties as expected; in horizontal orientation the wrong method was being called when deriving the scrolling threshold

Enyo-DCO-1.1-Signed-off-by: Cole Davis cole.davis@lge.com
