### PR TITLE
Fixes an issue with enyo.dispatcher.capture().

### DIFF
--- a/source/dom/modal.js
+++ b/source/dom/modal.js
@@ -27,7 +27,7 @@ enyo.dispatcher.features.push(function(e) {
 //	be called on _enyo.dispatcher_, and not on the plug-in itself.
 //
 enyo.mixin(enyo.dispatcher, {
-	noCaptureEvents: {load: 1, unload:1, error: 1},
+	noCaptureEvents: {load: 1, unload:1, error: 1, transitionend: 1, animationend: 1},
 	autoForwardEvents: {leave: 1, resize: 1},
 	captures: [],
 	//* Capture events for `inTarget` and optionally forward them


### PR DESCRIPTION
The capture() API has historically been used exclusively for popups (at least within the framework). It allows the popup to examine and optionally suppress DOM events targeting elements outside the popup, which is useful for dismissing the popup on an external click (for example) or implementing modal behavior. However, if a transition or animation happened to be in progress when a modal popup was shown, that popup would gobble up the transitionend or animationend events, preventing the rightful owners of those events from acting on them.

In this fix, we are globally blacklisting transitionend and animationend, as it seems you probably never want to capture those in current (popup-related) use cases. That said, the capture() API might be more generally useful if you could specify precisely which events you do and don't want to capture at the time that you register to capture. I filed an issue at https://enyojs.atlassian.net/browse/ENYO-3552 to track this idea.

This fix resolves issue GF-45488 in the internal LGE JIRA.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
