### PR TITLE
GF-41734 Defect Fixed Video Feedback error when changed from fastforward...

### DIFF
--- a/source/ui/Video.js
+++ b/source/ui/Video.js
@@ -152,6 +152,7 @@ enyo.kind({
 		if (!this.hasNode()) {
 			return;
 		}
+		this._speedIndex = 0;
 		this.setPlaybackRate(1);
 		this.node.play();
 		this._prevCommand = "play";
@@ -161,6 +162,7 @@ enyo.kind({
 		if (!this.hasNode()) {
 			return;
 		}
+		this._speedIndex = 0;
 		this.setPlaybackRate(1);
 		this.node.pause();
 		this._prevCommand = "pause";


### PR DESCRIPTION
... to play and again fastforward

Issue: Feedback gives wrong playbackRate in message when changed from
FastForward to play/pause (saw while solving GF-41734 issue on TV which
required to change from FF to Play) and again FastForward.
It doesn't refreshes playbackRate Index gives next playbackRate from the
playbackRateArray.
Fixes:
Updated speedIndex to 0 in when play and pause are fired in video
(video.js) to give correct playbackRate for the next time user do
FF/Rewind.

Enyo-DCO-1.1-Signed-off-by: Anugrah Saxena anugrah.saxena@lge.com
