### PR TITLE
GF-43621: Remove `stop` call from getScrollBounds.

### DIFF
--- a/source/touch/TouchScrollStrategy.js
+++ b/source/touch/TouchScrollStrategy.js
@@ -433,12 +433,6 @@ enyo.kind({
 			return r;
 		};
 	}),
-	getScrollBounds: enyo.inherit(function (sup) {
-		return function() {
-			this.stop();
-			return sup.apply(this, arguments);
-		};
-	}),
 	// Thumb processing
 	alertThumbs: function() {
 		this.showThumbs();


### PR DESCRIPTION
This prevents the isScrolling API from properly returning true when animating, and it's not clear why the scroll math animation needs to be stopped to read the scroll bounds.  Tested List and Scroller on Chrome, Firefox, iOS, and Android, and don't see any side-effects.

DCO-1.1-Signed-Off-By: Kevin Schaaf kevin.schaaf@lge.com
