### PR TITLE
Fix for GF-51349: revert pilot-11 change to bindings removing _stop()_ and the ability to ...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.3.0-pre.13
+
+Needed to revert the change to _enyo.Binding_ from 2.3.0-pre.11. Re-implemented the _stop()_ method
+for interrupting transform propagation (as was still indicated by the API docs) and note that bindings
+will again propagate `undefined` values to ensure bindings clear when expected.
+
 ## 2.3.0-pre.12
 
 _enyo.DataList_ no longer has the _controlsPerPage_ property but instead has a _pageSizeMultiplier_ value
@@ -20,9 +26,9 @@ Removed the _modelChanged()_ and deprecated _controllerChanged()_ base methods f
 thus any developer code currently calling `this.inherited(arguments)` from within an overloaded
 _modelChanged()_ method will fail and needs to be removed. This is a feature change required by ENYO-3339.
 
-Removed the _stop()_ method from _enyo.Binding_ as required by ENYO-3338. Instead of
+~~Removed the _stop()_ method from _enyo.Binding_ as required by ENYO-3338. Instead of
 calling that method via the binding reference in a transform return `undefined`
-(or nothing since `undefined` is the default) to achieve the same behavior.
+(or nothing since `undefined` is the default) to achieve the same behavior.~~
 
 Instances of _enyo.Binding_ will no longer propagate `undefined`; instead use `null`.
 

--- a/source/kernel/Binding.js
+++ b/source/kernel/Binding.js
@@ -191,9 +191,7 @@
 					if (fn && typeof fn == "function") {
 						value = fn.call(this.owner || this, value, "source", this);
 					}
-					if (value !== undefined) {
-						this.setTargetValue(value);		
-					}
+					this.setTargetValue(value);		
 				}
 				this.synchronizing = false;
 			}
@@ -207,9 +205,7 @@
 					if (fn && typeof fn == "function") {
 						value = fn.call(this.owner || this, value, "target", this);
 					}
-					if (value !== undefined) {
-						this.setSourceValue(value);
-					}
+					this.setSourceValue(value);
 				}
 				this.synchronizing = false;
 			}
@@ -417,7 +413,11 @@
 					this.destroy();
 					return;
 				}
-				source.set(this.sourceProp, value, !_force.test(typeof value));
+				if (!this.stop) {
+					source.set(this.sourceProp, value, !_force.test(typeof value));
+				} else {
+					this.stop = false;
+				}
 			}
 		},
 		setTargetValue: function (value) {
@@ -427,7 +427,11 @@
 					this.destroy();
 					return;
 				}
-				target.set(this.targetProp, value, !_force.test(typeof value));
+				if (!this.stop) {
+					target.set(this.targetProp, value, !_force.test(typeof value));
+				} else {
+					this.stop = false;
+				}
 			}
 		},
 		//*@public
@@ -485,6 +489,7 @@
 			a reference to the binding.
 		*/
 		refresh: function () {
+			this.stop = false;
 			this.resolve();
 			if (this.autoConnect) {
 				this.connect();
@@ -499,11 +504,19 @@
 			this.disconnect();
 			enyo.mixin(this, this.originals);
 			this.building         = true;
+			this.stop             = false;
 			this.sourceRegistered = false;
 			this.targetRegistered = false;
 			this.registeredSource = null;
 			this.registeredTarget = null;
 			return this;
+		},
+		/**
+			Will cause a single propagation attempt to fail. Typically not called
+			outside the scope of a transform.
+		*/
+		stop: function () {
+			this.stop = true;
 		},
 		/**
 			Rebuilds the entire binding. Will synchronize if it is able to connect and


### PR DESCRIPTION
...return `undefined`

Enyo-DCO-1.1-Signed-Off-By: Cole Davis (cole.davis@lge.com)
