### PR TITLE
ENYO-3552: Update capture API: eliminate should forward flag, and instea...

### DIFF
--- a/source/dom/dispatcher.js
+++ b/source/dom/dispatcher.js
@@ -197,6 +197,7 @@
 					// but note the tap event will fire first
 					var cp = enyo.clone(e);
 					cp.type = "tap";
+					cp.preventDefault = enyo.nop;
 					enyo.dispatch(cp);
 				}
 			}

--- a/source/ui/Popup.js
+++ b/source/ui/Popup.js
@@ -203,12 +203,12 @@ enyo.kind({
 		};
 	}),
 	capture: function() {
-		enyo.dispatcher.capture(this, this.eventsToCapture, enyo.bind(this, "capturedEvent"), !this.modal);
+		enyo.dispatcher.capture(this, this.eventsToCapture, enyo.bind(this, "capturedEvent"));
 	},
 	release: function() {
 		enyo.dispatcher.release(this);
 	},
-	capturedEvent: function(inEventName, inEvent, inSender) {
+	capturedEvent: function(inEventName, inSender, inEvent) {
 		switch (inEventName) {
 			case "down":
 				this.capturedDown(inSender, inEvent);
@@ -217,6 +217,7 @@ enyo.kind({
 				this.capturedTap(inSender, inEvent);
 				break;
 		}
+		return this.modal;
 	},
 	capturedDown: function(inSender, inEvent) {
 		//record the down event to verify in tap


### PR DESCRIPTION
...d use return value from the callback.  Reorder callback params to match normal enyo event handler order.  Add dummy preventDefault to simulated tap event.

DCO-1.1-Signed-Off-By: Kevin Schaaf kevin.schaaf@lge.com
