### PR TITLE
ENYO-3552: Update capture API again: eliminate the need to pass a callba...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 ## 2.3.0-rc1
 
-_enyo.dispatcher.capture_ API no longer bubbles captured events through the normal event chain, but
-rather notifies the captureTarget through a callback passed as a parameter to the `capture` API.
-The `capture` API also now requires a whitelist of events to capture, rather than the previous
-behavior of capturing (nearly) all events.
+_enyo.dispatcher.capture_ API no longer bubbles all captured events through the normal event chain, but
+rather notifies the captureTarget when specific events occur through a map of callbacks passed as a parameter 
+to the `capture` API.  This is a breaking change to the enyo.dispatcher.capture API, however it is a very
+unpublicized (and fairly difficult-to-use) feature that was only used in enyo.Popup among Enyo-team developed 
+controls, so we assume it will have low impact on the general public.
 
 ## 2.3.0-pre.12
 

--- a/source/ui/Popup.js
+++ b/source/ui/Popup.js
@@ -46,7 +46,10 @@ enyo.kind({
 		onRequestHide: "requestHide"
 	},
 	captureEvents: true,
-	eventsToCapture: { down:1, tap:1 },
+	eventsToCapture: { 
+		ondown: "capturedDown", 
+		ontap: "capturedTap" 
+	},
 	//* @public
 	events: {
 		//* Fires after the popup is shown.
@@ -203,21 +206,10 @@ enyo.kind({
 		};
 	}),
 	capture: function() {
-		enyo.dispatcher.capture(this, this.eventsToCapture, enyo.bind(this, "capturedEvent"));
+		enyo.dispatcher.capture(this, this.eventsToCapture);
 	},
 	release: function() {
 		enyo.dispatcher.release(this);
-	},
-	capturedEvent: function(inEventName, inSender, inEvent) {
-		switch (inEventName) {
-			case "down":
-				this.capturedDown(inSender, inEvent);
-				break;
-			case "tap":
-				this.capturedTap(inSender, inEvent);
-				break;
-		}
-		return this.modal;
 	},
 	capturedDown: function(inSender, inEvent) {
 		//record the down event to verify in tap
@@ -227,6 +219,7 @@ enyo.kind({
 		if (this.modal) {
 			inEvent.preventDefault();
 		}
+		return this.modal;
 	},
 	capturedTap: function(inSender, inEvent) {
 		// dismiss on tap if property is set and click started & ended outside the popup
@@ -235,6 +228,7 @@ enyo.kind({
 			this.downEvent = null;
 			this.hide();
 		}
+		return this.modal;
 	},
 	// if a drag event occurs outside a popup, hide
 	dragstart: function(inSender, inEvent) {


### PR DESCRIPTION
...ck, and instead use inEvents as a map of event names to handler names on the captureTarget.

DCO-1.1-Signed-Off-By: Kevin Schaaf kevin.schaaf@lge.com
