### PR TITLE
humanized dependencies in packages.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
     "repository": {
         "type": "git", "url": "http://github.com/enyojs/enyo"
     },
-    "dependencies": [
-        {"less": "1.3.3"},
-        {"uglify-js": "2.2.5"},
-        {"shelljs": "0.2.6"},
-        {"nopt": "2.1.2"}
-    ]
+    "dependencies": {
+        "less": "1.3.3",
+        "uglify-js": "2.2.5",
+        "shelljs": "0.2.6",
+        "nopt": "2.1.2",
+    }
 }


### PR DESCRIPTION
Hi, i just noticed that dependencies in package.json was not structured as npm documentation says:
"Dependencies are specified with a simple **hash** of package name to version range."

 -https://diigo.com/01cjhh

I re-wrote dependencies as valid hash-map; now it should be fine again.
