### PR TITLE
GF-53487: Perform `domStylesToCssText` conversion on every `prepareTags` call.

### DIFF
--- a/source/dom/Control.js
+++ b/source/dom/Control.js
@@ -422,12 +422,12 @@ enyo.kind({
 	},
 	//* @protected
 	domStylesChanged: function() {
-		this.domCssText = enyo.Control.domStylesToCssText(this.domStyles);
+		this.invalidateStyles();
 		this.invalidateTags();
 		this.renderStyles();
 	},
 	stylesToNode: function() {
-		this.node.style.cssText = this.domCssText;
+		this.node.style.cssText = this.getDomCssText();
 	},
 	setupBodyFitting: function() {
 		enyo.dom.applyBodyFit();
@@ -769,8 +769,18 @@ enyo.kind({
 	invalidateTags: function() {
 		this.tagsValid = false;
 	},
+	invalidateStyles: function() {
+		this.stylesValid = false;
+	},
+	getDomCssText: function() {
+		if (!this.stylesValid) {
+			this.domCssText = enyo.Control.domStylesToCssText(this.domStyles);
+			this.stylesValid = true;
+		}
+		return this.domCssText;
+	},
 	prepareTags: function() {
-		var htmlStyle = this.domCssText = enyo.Control.domStylesToCssText(this.domStyles);
+		var htmlStyle = this.getDomCssText();
 		this._openTag = '<' +
 			this.tag +
 			(htmlStyle ? ' style="' + htmlStyle + '"' : "") +

--- a/source/dom/transform.js
+++ b/source/dom/transform.js
@@ -53,7 +53,9 @@
 		if (sp && cp) {
 			ds[cp] = t;
 			if (st) {
+				// Optimization: set transform directly to node when available
 				st[sp] = t;
+				inControl.invalidateStyles();
 			} else {
 				inControl.domStylesChanged();
 			}


### PR DESCRIPTION
Prevents issue where transform optimization to apply transform styles directly to node rather than calling `domStylesChanged()` aren't properly reflected in domCssText when re-rendering a node.  Removed initial `domStylesToCssText` from `initStyles` since it would now be re-run in the `prepareTags` call.

In the normal case, `prepareTags` is only called on initial render, so we're just moving the location where the domStylesToCssText conversion happens -- no runtime impact.  We add cost to the re-render case, but it's better to do it there (which should be low-frequency) than in the transform code (which is often called at high-frequency for animation).

DCO-1.1-Signed-Off-By: Kevin Schaaf kevin.schaaf@lge.com
