### PR TITLE
ENYO-3534: fix touch events in IE10

### DIFF
--- a/source/touch/msevents.js
+++ b/source/touch/msevents.js
@@ -26,7 +26,8 @@
 			e.srcEvent = inEvent;
 			// normalize "mouse button" info
 			// 1: left, 2: right, 3: both left & right, 4: center
-			e.which = inEvent.buttons;
+			// on IE10, inEvents.buttons may be 0 for touch, so map 0 to 1
+			e.which = inEvent.buttons || 1;
 			return e;
 		};
 
@@ -71,11 +72,12 @@
 			handlers.MSPointerOut = handlers.pointerout;
 		}
 
+		// tell Enyo to listen for these events
 		enyo.forEach(pointerEvents, function(e) {
 			enyo.dispatcher.listen(document, e);
 		});
 
-		// add our own pointerEvents event handler
+		// add our transform methods to the dispatcher features list
 		enyo.dispatcher.features.push(function(e) {
 			if (handlers[e.type] && e.isPrimary) {
 				handlers[e.type](e);


### PR DESCRIPTION
MSPointerEvents events on IE10 on WinPhone8 have the buttons field set to 0.
Before, we hard coded the "which" value of the Enyo event to 1 and it worked
on the devices, but a PR to address ENYO-2993 made in August 2013 fixed desktop
issues but broke touch handling.  This was all masked when we added proper
pointer event support for IE11, but it left IE10 in the broken state.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
