### PR TITLE
When the value of enyo.Input changes, only call setAttribute() if we don...

### DIFF
--- a/source/ui/Input.js
+++ b/source/ui/Input.js
@@ -94,9 +94,13 @@ enyo.kind({
 		this.bubble("onDisabledChange");
 	},
 	valueChanged: function() {
-		this.setAttribute("value", this.value);
-		if (this.getNodeProperty("value", this.value) !== this.value) {
-			this.setNodeProperty("value", this.value);
+		var node = this.hasNode();
+		if (node) {
+			if (node.value !== this.value) {
+				node.value = this.value;
+			}
+		} else {
+			this.setAttribute("value", this.value);
 		}
 	},
 	iekeyup: function(inSender, inEvent) {


### PR DESCRIPTION
...’t have a node yet; if we do have a node, set its value property instead.

This fixes a strange bug where a change event would not be fired as expected if a) the node was rendered; then b) the value of the input was set programatically; then c) the user cleared the contents of the field and pressed Enter or caused the input to be blurred.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
