### PR TITLE
Add support for the Page Visibility API

### DIFF
--- a/samples/PageVisibilitySample.html
+++ b/samples/PageVisibilitySample.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+	<meta name="apple-mobile-web-app-capable" content="yes"/>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
+	<meta name="format-detection" content="telephone=no"/>
+	<meta name="google" value="notranslate"/>
+	<title>Page Visibility API Sample</title>
+	<!-- -->
+	<script src="../../enyo/enyo.js" type="text/javascript"></script>
+	<!-- -->
+	<script src="PageVisibilitySample.js" type="text/javascript"></script>
+	<!-- -->
+</head>
+<body>
+<script type="text/javascript">
+	new enyo.sample.PageVisibilitySample().renderInto(document.body);
+</script>
+</body>
+</html>

--- a/samples/PageVisibilitySample.js
+++ b/samples/PageVisibilitySample.js
@@ -1,0 +1,14 @@
+enyo.kind({
+	name: "enyo.sample.PageVisibilitySample",
+	components: [
+		{kind: "Signals", onvisibilitychange: "visibilitychanged"},
+		{name: "text", allowHtml: true}
+	],
+	rendered: function () {
+		this.inherited(arguments);
+		this.visibilitychanged();
+	},
+	visibilitychanged: function(){
+		this.$.text.setContent(this.$.text.content + (Date().toString()) + (enyo.hidden ? ": hidden" : ": visible") + "<br>");
+	}
+});

--- a/source/dom/package.js
+++ b/source/dom/package.js
@@ -6,6 +6,7 @@ enyo.depends(
 	"platform.js",
 	"animation.js",
 	"cordova.js",
+	"page_visibility.js",
 	"dispatcher.js",
 	"preview.js",
 	"modal.js",

--- a/source/dom/page_visibility.js
+++ b/source/dom/page_visibility.js
@@ -1,0 +1,67 @@
+/**
+	Support for the W3C Page Visibility API - http://www.w3.org/TR/page-visibility
+
+	enyo.hidden and enyo.visibilityState contain the same information as
+	document.hidden and document.visibilityState in supported browsers. The
+	visibilitychange event is channelled through the [Signals](#enyo.Signals)
+	mechanism.
+
+	Partly based on http://stackoverflow.com/a/1060034.
+
+	Example:
+
+	enyo.kind({
+		name: "App",
+		components: [
+			{kind: "Signals", onvisibilitychange: "visibilitychanged"}
+		],
+		visibilitychanged: function() {
+			if(enyo.hidden){
+				// page hidden
+			} else {
+				// page visible
+			}
+		}
+	});
+*/
+//* @protected
+enyo.ready(function(){
+	var hidden = "hidden";
+	var visibilityState = "visibilityState";
+
+	// map compatibility events to document.hidden state
+	var hiddenMap = {};
+	hiddenMap.blur = hiddenMap.focusout = hiddenMap.pagehide = true;
+	hiddenMap.focus = hiddenMap.focusin = hiddenMap.pageshow = false;
+
+	function onchange(inEvent) {
+		inEvent = inEvent || window.event;
+		enyo.hidden = (inEvent.type in hiddenMap) ? hiddenMap[inEvent.type] : document[hidden];
+		enyo.visibilityState = (inEvent.type in hiddenMap) ? (hiddenMap[inEvent.type] ? "hidden" : "visible" ) : document[visibilityState];
+		enyo.Signals.send("onvisibilitychange", enyo.mixin(inEvent, {hidden: enyo.hidden}));
+	}
+
+	// Standards:
+	if (hidden in document){
+		document.addEventListener("visibilitychange", onchange);
+	} else if ((hidden = "mozHidden") in document){
+		document.addEventListener("mozvisibilitychange", onchange);
+		visibilityState = "mozVisibilityState";
+	} else if ((hidden = "webkitHidden") in document){
+		document.addEventListener("webkitvisibilitychange", onchange);
+		visibilityState = "webkitVisibilityState";
+	} else if ((hidden = "msHidden") in document){
+		document.addEventListener("msvisibilitychange", onchange);
+		visibilityState = "msVisibilityState";
+	} else if ("onfocusin" in document){ // IE 9 and lower:
+		document.onfocusin = document.onfocusout = onchange;
+	} else { // All others:
+		window.onpageshow = window.onpagehide = window.onfocus = window.onblur = onchange;
+	}
+
+	// set inital values for enyo.hidden and enyo.visibilityState
+	// it's probably save to assume that the current document is visible when
+	// loading the page
+	enyo.hidden = typeof document[hidden] !== "undefined" ? document[hidden] : false;
+	enyo.visibilityState = typeof document[visibilityState] !== "undefined" ? document[visibilityState] : "visible";
+});


### PR DESCRIPTION
Add support for the Page Visibility API, normalizes visibilitychange events, the document.hidden and the document.visibilityState properties. Uses fallbacks to support older browsers.

Enyo-DCO-1.1-Signed-off-by: Johann Jacobsohn j.jacobsohn@satzmedia.de
