### PR TITLE
Fixed a 'duplicate record added' exception from the Store when a collection is fetchAndReplace'd multiple times

### DIFF
--- a/source/data/Store.js
+++ b/source/data/Store.js
@@ -165,6 +165,7 @@
 				c.store.removeCollection(c);
 			}
 			c.addListener("destroy", this._collectionDestroyed);
+            c.addListener("remove", this._recordRemoved, this);
 			collections[euid] = c;
 			if (!c.store) {
 				c.store = this;
@@ -179,6 +180,7 @@
 				euid        = c.euid;
 			delete collections[euid];
 			c.removeListener("destroy", this._collectionDestroyed);
+            c.removeListener("remove", this._recordRemoved);
 		},
 		/**
 			Removes the reference for the given record if it is found in the store.
@@ -514,6 +516,18 @@
 			}
 			this.addRecord(rec);
 		},
+        _recordRemoved: function(sender, event, args) {
+            var records = (args && args.records) || {},
+                keys = Object.keys(records),
+                i,
+                rec;
+            for(i = 0; i < keys.length; ++i) {
+                rec = records[keys[i]];
+                if(rec instanceof enyo.Model) {
+                    this.removeRecord(rec);
+                }
+            }
+        },
 		constructor: enyo.inherit(function (sup) {
 			return function (props) {
 				var r            = sup.apply(this, arguments);


### PR DESCRIPTION
The issue is, model instances are not removed from the Store when they are purged from a Collection with remove() or removeAll(). That causes attempts to insert duplicates into the Store when one does Collection.fetchAndReplace()(then uses the data with Collection.at()) against same remote dataset.

Why do I need to retrieve same data over again? Imagine implementation of an infinite list, based on enyo.List, backed by a Collection, which interfaces with large remote dataset A collection instance only fetches a window of that data at any given time whereby List displays that window, however, list count is set to the total number of records in the remote dataset. List's onSetupItem() is programmed in such a way, that it fetches data when needed as List is scrolled - back and forth. Which is when Collection.fetchAndReplace() may occur, retrieving previously seen data.
