### PR TITLE
Prepare enyo for 2.3.1 work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.3.0-rc3
+## 2.3.1-pre.1
 
 _enyo.Collection.destroyAll()_ now accepts a boolean parameter to signify it will call the record's _destroyLocal()_ method as opposed to the default of _destroy()_.
 

--- a/source/boot/version.js
+++ b/source/boot/version.js
@@ -15,5 +15,5 @@
 */
 
 enyo.version = {
-	enyo: "2.3.0-rc.2"
+	enyo: "2.3.1-pre.1"
 };


### PR DESCRIPTION
In master branch, update enyo version to
2.3.1-pre.1 and move CHANGELOG notes into 2.3.1-pre.1
section.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
