### PR TITLE
ENYO-3074: Fixed issue with tap event being sent after dragfinish event

### DIFF
--- a/source/dom/drag.js
+++ b/source/dom/drag.js
@@ -144,11 +144,10 @@ enyo.gesture.drag = {
 	sendDragFinish: function(e) {
 		//enyo.log("dragfinish");
 		var synth = this.makeDragEvent("dragfinish", this.dragEvent.target, e, this.dragEvent.dragInfo);
-		synth.preventTap = function() {
-			if (e.preventTap) {
-				e.preventTap();
-			}
-		};
+		// always prevent tap event when dragfinish event occurs in the dragging context
+		if (e.preventTap) {
+			e.preventTap();
+		}
 		enyo.dispatch(synth);
 	},
 	sendDragOut: function(e) {

--- a/source/touch/ScrollStrategy.js
+++ b/source/touch/ScrollStrategy.js
@@ -178,7 +178,6 @@ enyo.kind({
 	dragfinish: function(inSender, inEvent) {
 		if (this.dragging) {
 			this.dragging = false;
-			inEvent.preventTap();
 		}
 	},
 	// avoid allowing scroll when starting at a vertical boundary to prevent ios from window scrolling.

--- a/source/touch/TouchScrollStrategy.js
+++ b/source/touch/TouchScrollStrategy.js
@@ -335,7 +335,6 @@ enyo.kind({
 	},
 	dragfinish: function(inSender, inEvent) {
 		if (this.dragging) {
-			inEvent.preventTap();
 			this.$.scrollMath.dragFinish();
 			this.dragging = false;
 			if (this.scrim) {

--- a/source/touch/TransitionScrollStrategy.js
+++ b/source/touch/TransitionScrollStrategy.js
@@ -400,7 +400,6 @@ enyo.kind({
 	// When user releases the drag, set this.dragging to false, bounce overflow back, and hide scrim.
 	dragfinish: function(inSender, inEvent) {
 		if (this.dragging) {
-			inEvent.preventTap();
 			this.dragging = false;
 			if(!this.isScrolling()) {
 				this.correctOverflow();


### PR DESCRIPTION
## Issue

A `tap` event will be sent after a `dragfinish` event in a dragging context.
## Fix

The synthesized `dragfinish` event provides a `preventTap` method, but only `enyo.Scroller` controls were utilizing this method. The `dragfinish` synthesizer code now always initiates a `preventTap` directly, as this will only be triggered in a dragging context. As a result, `dragfinish` no longer provides a `preventTap` method and calls to `preventTap` have been removed from subsequent handlers i.e. `enyo.Scroller`'s own `dragfinish` handler.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
