### PR TITLE
Update cached position for setScrollTop/Left when hidden

### DIFF
--- a/source/touch/Scroller.js
+++ b/source/touch/Scroller.js
@@ -229,9 +229,9 @@ enyo.kind({
 		if (this.cachedPosition) {
 			var cp = this.cachedPosition;
 			if (cp.top || cp.left) {
+				this.cachedPosition = null;
 				this.setScrollLeft(cp.left);
 				this.setScrollTop(cp.top);
-				this.cachedPosition = null;
 			}
 		}
 	},
@@ -246,11 +246,17 @@ enyo.kind({
 	//* Sets scroll position along horizontal axis.
 	setScrollLeft: function(inLeft) {
 		this.scrollLeft = inLeft;
+		if (this.cachedPosition) {
+			this.cachedPosition.left = inLeft;
+		}
 		this.$.strategy.setScrollLeft(this.scrollLeft);
 	},
 	//* Sets scroll position along vertical axis.
 	setScrollTop: function(inTop) {
 		this.scrollTop = inTop;
+		if (this.cachedPosition) {
+			this.cachedPosition.top = inTop;
+		}
 		this.$.strategy.setScrollTop(inTop);
 	},
 	//* Gets scroll position along horizontal axis.


### PR DESCRIPTION
enyo.Scroller caches the scroll position when the scroller is
hidden or re-rendered.  Currently, API-level changes to the
scroll position made when the scroller is hidden are lost.
This change updates enyo.Scroller.setScrollTop/Left to update
the cache if it exists.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
