### PR TITLE
enyo.Input needs to call attributeToNode() when value changes to update ...

### DIFF
--- a/source/ui/Input.js
+++ b/source/ui/Input.js
@@ -106,6 +106,7 @@ enyo.kind({
 			// in some cases does not receive an appropriate response from the
 			// browser
 			attrs.value = this.value;
+			this.attributeToNode("value",this.value);
 		} else {
 			this.setAttribute("value", this.value);
 		}


### PR DESCRIPTION
...the tag attribute.

If it doesn't call attributeToNode, the 'value' attribute on the Input tag is not updated when the user types into the Input node or when the associated Enyo Control's 'value' property is set.

Enyo-DCO-1.1-Signed-off-by: Matthew Gidcomb matthew.gidcomb@airspringsoftware.com
