### PR TITLE
GF-57004: Re generate pages when childSize is updated.

### DIFF
--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -158,7 +158,11 @@ enyo.DataList.delegates.vertical = {
 		metrics.height = this.pageHeight(list, page);
 		metrics.width  = this.pageWidth(list, page);
 		// update the childSize value now that we have measurements
-		this.childSize(list);
+		var childSize = list.childSize;
+		if (childSize != this.childSize(list)) {
+			list._updatedControlsPerPage = undefined;
+			this.generatePage(list, page, index);
+		}
 	},
 	/**
 		Generates a child size for the given list.


### PR DESCRIPTION
When DataList is instanced, pages are generated with default childSize (100px).
After page1 is rendered with default value, we can know the actual childSize.
If actual childSize is not same with default value, that means initial page does not have proper controls in it.
So we should re generate pages.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
