### PR TITLE
GF-57635: Determine showing status of list based on getAbsoluteShowing()

### DIFF
--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -241,7 +241,7 @@ enyo.DataList.delegates.vertical = {
 	pageHeight: function (list, page) {
 		var h = page.node.offsetHeight;
 		var m = list.metrics.pages[page.index];
-		if (h === 0 && list.length) {
+		if (!page.getAbsoluteShowing(true) && list.length) {
 			list.heightNeedsUpdate = true;
 			// attempt to reuse the last known height for this page
 			h = m? m.height: 0;
@@ -254,7 +254,7 @@ enyo.DataList.delegates.vertical = {
 	pageWidth: function (list, page) {
 		var w = page.node.offsetWidth;
 		var m = list.metrics.pages[page.index];
-		if (w === 0 && list.length) {
+		if (!page.getAbsoluteShowing(true) && list.length) {
 			list.widthNeedsUpdate = true;
 			// attempt to reuse the last known width for this page
 			w = m? m.width: 0;


### PR DESCRIPTION
When data set is too small, it could not fill page2 at all.
In this case page2 has '0' width and height but it is visible.
Due to '0' value of metric, VerticalDelegate makes NeedsUpdate flag to true and didScroll() calls refresh() everytime.
This is the reason of performance damage.

To compensate this logic fault, use getAbsoluteShowing().

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
