### PR TITLE
GF-54909: Fixed bug with jumpForward not working properly.

### DIFF
--- a/source/ui/Video.js
+++ b/source/ui/Video.js
@@ -277,7 +277,7 @@ enyo.kind({
 		}
 
 		this.setPlaybackRate(1);
-		node.currentTime += this.jumpSec;
+		node.currentTime += parseInt(this.jumpSec, 10);
 		this._prevCommand = "jumpForward";
 
 		this.doJumpForward(enyo.mixin(this.createEventData(), {jumpSize: this.jumpSec}));


### PR DESCRIPTION
## Issue

After the `Video` control is initialized, if the `jumpSec` value is set to a number in string format, the `jumpForward` method no longer works.
## Fix

The `jumpForward` method is expecting `jumpSec` as an integer, but it is not uncommon for `jumpSec` to be passed in as a string, if it is being derived from an input field. We now run `parseInt` on `jumpSec` when jumping forward.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
