### PR TITLE
Gf 58362 Scroll threshold has invalidate bounds when list has very small data set.

### DIFF
--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -459,7 +459,7 @@ enyo.DataList.delegates.vertical = {
 		} else {
 			threshold[upperProp] = (metrics[firstIdx][upperProp] + this.childSize(list));
 		}
-		if (lastIdx === count) {
+		if (lastIdx >= count) {
 			threshold[lowerProp] = undefined;
 		} else {
 			threshold[lowerProp] = (metrics[lastIdx][lowerProp] - fn(list) - this.childSize(list));


### PR DESCRIPTION
When DataList has very small data set, page2 does not have any controls. 
In this case, threshold lowerProp is meaningless.
Currently, we don't consider that only page 1 have controls so count could be '0'.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
