### PR TITLE
GF-58382: Dispatch all key events via Signals, regardless of input focus state

### DIFF
--- a/source/dom/dispatcher.js
+++ b/source/dom/dispatcher.js
@@ -65,7 +65,7 @@
 		//* Fires an event for Enyo to listen for.
 		dispatch: function(e) {
 			// Find the control who maps to e.target, or the first control that maps to an ancestor of e.target.
-			var c = this.findDispatchTarget(e.target) || this.findDefaultTarget(e);
+			var c = this.findDispatchTarget(e.target) || this.findDefaultTarget();
 			// Cache the original target
 			e.dispatchTarget = c;
 			// support pluggable features return true to abort immediately or set e.preventDispatch to avoid processing.

--- a/source/dom/keymap.js
+++ b/source/dom/keymap.js
@@ -18,6 +18,11 @@
 enyo.dispatcher.features.push(function(e) {
 	if ((e.type === "keydown") || (e.type === "keyup") || (e.type === "keypress")) {
 		e.keySymbol = this.keyMap[e.keyCode];
+		// Dispatch key events to be sent via Signals
+		var c = this.findDefaultTarget();
+		if (e.dispatchTarget !== c) {
+			this.dispatchBubble(e, c);
+		}
 	}
 });
 


### PR DESCRIPTION
## Issue

Key events are not sent via `Signals` when triggered from a focused input control. Certain keys need to be handled regardless of input focused state.
## Fix

All key events will now be sent via `Signals`. Additionally, an extraneous parameter has been removed in the call to `findDefaultTarget`.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
