### PR TITLE
Add support for localized enyo signals

### DIFF
--- a/samples/SignalsSample.css
+++ b/samples/SignalsSample.css
@@ -1,0 +1,7 @@
+.signals-sample{
+	float: left;
+	width: 300px;
+	margin: 1em;
+	height: 100px;
+	border: 1px solid #666;
+}

--- a/samples/SignalsSample.html
+++ b/samples/SignalsSample.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+	<meta name="apple-mobile-web-app-capable" content="yes"/>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
+	<meta name="format-detection" content="telephone=no"/>
+	<meta name="google" value="notranslate"/>
+	<title>Signals Sample</title>
+	<!-- -->
+	<script src="../../enyo/enyo.js" type="text/javascript"></script>
+	<script src="../../lib/layout/package.js" type="text/javascript"></script>
+	<!-- -->
+	<link href="SignalsSample.css" rel="stylesheet">
+	<script src="SignalsSample.js" type="text/javascript"></script>
+	<!-- -->
+</head>
+<body>
+	<div class="client"></div>
+	<div class="client"></div>
+	<div class="client"></div>
+	<div class="client"></div>
+	<div class="client"></div>
+	<div class="client"></div>
+	<script type="text/javascript">
+		var clients = document.getElementsByClassName("client");
+		enyo.forEach(clients, function(client){
+			new enyo.sample.SignalsSample.app({renderTarget: client});
+		});
+	</script>
+</body>
+</html>

--- a/samples/SignalsSample.js
+++ b/samples/SignalsSample.js
@@ -1,0 +1,32 @@
+enyo.kind({
+	name: "enyo.sample.SignalsSample.app",
+	kind: "enyo.Application",
+	view: "enyo.sample.SignalsSample.view"
+});
+
+enyo.kind({
+	name: "enyo.sample.SignalsSample.view",
+	classes: "signals-sample",
+	components: [
+		{kind: "enyo.Button", ontap: "sendGlobalSignal", content: "send global signal"},
+		{kind: "enyo.Button", ontap: "sendLocalSignal", content: "send local signal"},
+		{name: "display", content: "Signal received", showing: false},
+		{kind: "enyo.Signals", onreceive: "handleSignal"}
+	],
+	handleSignal: function(){
+		this.showDisplay();
+		this.startJob("hideDisplay", "hideDisplay", 600);
+	},
+	showDisplay: function(){
+		this.$.display.show();
+	},
+	hideDisplay: function(){
+		this.$.display.hide();
+	},
+	sendGlobalSignal: function(){
+		enyo.Signals.send("onreceive", {});
+	},
+	sendLocalSignal: function(){
+		enyo.Signals.send("onreceive", {_targetApp: this.app});
+	}
+});

--- a/source/kernel/Signals.js
+++ b/source/kernel/Signals.js
@@ -31,7 +31,9 @@ enyo.kind({
 		};
 	}),
 	notify: function(inMsg, inPayload) {
-		this.dispatchEvent(inMsg, inPayload);
+		if(!inPayload._targetApp || this.app.id === inPayload._targetApp.id){
+			this.dispatchEvent(inMsg, inPayload);
+		}
 	},
 	protectedStatics: {
 		listeners: [],


### PR DESCRIPTION
Enyo signals are always global and affect all instances of all apps (on the same page). This PR allows signals to be localized to one specific app. This is useful when multiple independent apps or instances are present in the same document. In an additional PR I'll try to implement a global switch to make all signals local by default, but I haven't figured out how, yet.

Enyo-DCO-1.1-Signed-off-by: Johann Jacobsohn j.jacobsohn@satzmedia.de
