### PR TITLE
GF-58769: Secure scroll threshold for 5-way key moving

### DIFF
--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -457,7 +457,7 @@ enyo.DataList.delegates.vertical = {
 		if (firstIdx === 0) {
 			threshold[upperProp] = undefined;
 		} else {
-			threshold[upperProp] = (metrics[firstIdx][upperProp] + this.childSize(list));
+			threshold[upperProp] = (metrics[firstIdx][upperProp] + Math.max(fn(list), this.childSize(list)));
 		}
 		if (lastIdx >= count) {
 			threshold[lowerProp] = undefined;


### PR DESCRIPTION
When we use 5-way key to move next control in DataList,
It scrolls as much as childSize.
So, if we just have space like childSize for threshold[upperProp], page
adjusting does not occur properly.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
