### PR TITLE
GF-58661: Remove unnecessary animate effect.

### DIFF
--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -43,7 +43,7 @@ enyo.DataList.delegates.vertical = {
 		list.hasReset = true;
 		// reset the scroller so it will also start from the 'top' whatever that may
 		// be (left/top)
-		list.$.scroller.scrollTo(0, 0);
+		list.$.scroller.scrollTo(0, 0, false);
 	},
 	/**
 		Returns a hash of the pages marked by there position as either 'firstPage' or 'lastPage'.


### PR DESCRIPTION
We list reset its list, animate effect is meanless.
Whole pages are totally repainted, so animate is not required at this
moment.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
