### PR TITLE
Gf 58769 Fix page positioning related logic.

### DIFF
--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -457,7 +457,7 @@ enyo.DataList.delegates.vertical = {
 		if (firstIdx === 0) {
 			threshold[upperProp] = undefined;
 		} else {
-			threshold[upperProp] = (metrics[firstIdx][upperProp] + Math.max(fn(list), this.childSize(list)));
+			threshold[upperProp] = (metrics[firstIdx][upperProp] + this.childSize(list));
 		}
 		if (lastIdx >= count) {
 			threshold[lowerProp] = undefined;


### PR DESCRIPTION
1. Threshold[upperProp] had too small space.
2. scrollBounds was not updated after actual scrolling is occurred.

I fixed those 2 matter in these commits.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
