### PR TITLE
GF-59152: Add flag to control calling preventDefault for a captured event.

### DIFF
--- a/source/ui/Popup.js
+++ b/source/ui/Popup.js
@@ -33,7 +33,9 @@ enyo.kind({
 		centered: false,
 		//* Set to true to be able to show transition on the style modifications otherwise
 		//* the transition is invisible (visibility: hidden)
-		showTransitions: false
+		showTransitions: false,
+		//* Set to true to stop preventDefault from being called on captured events
+		allowDefault: false
 	},
 	//* @protected
 	showing: false,
@@ -216,7 +218,7 @@ enyo.kind({
 		this.downEvent = inEvent;
 
 		// prevent focus from shifting outside the popup when modal.
-		if (this.modal) {
+		if (this.modal && !this.allowDefault) {
 			inEvent.preventDefault();
 		}
 		return this.modal;


### PR DESCRIPTION
## Issue

The capture API is calling `preventDefault` when capturing the `down` event, but this prevents blurring of an input in a popup, which prevents the VKB from hiding.
## Fix

Create a flag that controls whether `preventDefault` is called.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
