### PR TITLE
GF-60073: Focus lost after remove all items while focus is on one of the...

### DIFF
--- a/source/dom/Control.js
+++ b/source/dom/Control.js
@@ -956,11 +956,11 @@ enyo.kind({
 			b = this.getBounds();
 		}
 
-		if(this.generated === false || (this.destroyed && this.destroyed === true) || this.getShowing() === false || (b && b.height === 0 && b.width === 0)) {
+		if (!this.generated || this.destroyed || !this.getShowing() || (b && b.height === 0 && b.width === 0)) {
 			return false;
 		}
 
-		if(this.parent && this.parent.getAbsoluteShowing) {
+		if (this.parent && this.parent.getAbsoluteShowing) {
 			return this.parent.getAbsoluteShowing(ignoreBounds);
 		} else {
 			return true;


### PR DESCRIPTION
... items from moon.DataGridList and moon.DataList

The spotlight disappear routine is for item hide, disable and destroy.

But in data control, when items which having focus is removed from list.
Then the focus is not jump to other control because spotlight disappear
routine doesn't consider this case.

This behavior can make dual focus problem.

I propose a simple solution to detect item removal from data control by
add observer on generated property.

This fix is dependent on https://github.com/enyojs/spotlight/pull/101

Fixing: http://jira2.lgsvl.com/browse/GF-60073

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
