### PR TITLE
ENYO-3833: Update Repeater documentation

### DIFF
--- a/source/ui/Repeater.js
+++ b/source/ui/Repeater.js
@@ -62,8 +62,10 @@ enyo.kind({
 	//* @public
 	/** Renders the collection of items. This will delete any existing items and
 		recreate the repeater if called after the repeater has been rendered.
-		This is called automatically if _set_ is called for the "count" property
-		and we set the "force" parameter to true i.e. set("count", value, true)
+		This is called automatically when the count property changes. To set the 
+		count and force a re-render, such as when a data model changes, use 
+		set("count", newCount, true) where the last parameter forces the change 
+		handler to be called, even if the count remains the same.
 	*/
 	build: function() {
 		this.destroyClientControls();


### PR DESCRIPTION
## Issue

The `enyo.Repeater` documentation had become updated, incorrectly stating that the `build` method is always called when `setCount` is called, even if the count remains the same.
## Fix

Update the documentation to demonstrate the setter pattern and include the use of the `force` parameter.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
