### PR TITLE
ENYO-3815: Reset lastIndex of RegExp between tests on different strings.

### DIFF
--- a/source/kernel/Router.js
+++ b/source/kernel/Router.js
@@ -345,6 +345,7 @@
 				this.defaultRoute = route;
 			}
 			else if (token.test(route.path)) {
+				token.lastIndex = 0;
 				regex = new RegExp(route.path.replace(token, "([a-zA-Z0-9-]*)"));
 				route.regex = regex;
 				dynamic.push(route);


### PR DESCRIPTION
## Issue

A dynamic router path will be incorrectly classified as static if the previously added path was a dynamic path.
## Fix

There is a difference in how Chrome (resets to 0 after match), Firefox (does not reset), and IE (does not reset, but has different value than Firefox) handle updating of the `lastIndex` property of a global RegExp. We reset this `lastIndex` property to 0 in-between tests on different paths.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
