### PR TITLE
ENYO-3852: fix loader handling of //-prefixed URLs

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -240,6 +240,10 @@
 			// Note: manifest file name must end in "package.js"
 			//
 			var folder = '', manifest = 'package.js';
+			// handle urls that start with '//' that use current document's protocol
+			if (/^\/\//.test(inPath)) {
+				inPath = document.location.protocol + inPath;
+			}
 			// convert back slashes to forward slashes, remove double slashes, split on slash
 			var parts = inPath.replace(/\\/g, "/").replace(/\/\//g, "/").replace(/:\//, "://").split("/");
 			if (parts.length) {


### PR DESCRIPTION
Moonstone and spotlight aren't loading for jsFiddle because its
loading their scripts via URLs that start with '//' instead of
'http://' in an attempt to future-proof for HTTPS or HTTP
deployment. Our loader mangled these in determining paths,
so we'll work around that be detecting this before parsing and
adding the protocol ourselves based on the current document.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
