### PR TITLE
GF-60944: Return false when parentNode is Floating layer on getAbsoluteS...

### DIFF
--- a/source/dom/Control.js
+++ b/source/dom/Control.js
@@ -951,7 +951,7 @@ enyo.kind({
 			return false;
 		}
 
-		if (this.parent && this.parent.getAbsoluteShowing) {
+		if (this.parent && this.parent.getAbsoluteShowing && (this.parentNode !== enyo.floatingLayer.hasNode())) {
 			return this.parent.getAbsoluteShowing(ignoreBounds);
 		} else {
 			return true;


### PR DESCRIPTION
...howing

Fixing http://jira2.lgsvl.com/browse/GF-60944

Reproduce:
- Tap on "Open Dialog" on attached Sample.

Problem:
- The getAbsoluteShowing returns false on popup which is resulting in
  isSpottable returns false.
- Focus is not getting into Dialog.

Solution:
- Returns false when parent node is Floating layer on getAbsoluteShowing

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
