### PR TITLE
Ensure innerHTML is set to a valid value

### DIFF
--- a/source/dom/dom.js
+++ b/source/dom/dom.js
@@ -301,6 +301,8 @@ enyo.dom = {
 		//For IE 8 compatibility, need to ensure html is not an empty value.  Empty stings will cause it to explode.
 		if (html.length > 0) {
 			node.innerHTML = html;
+		} else {
+			node.nodeValue = '';
 		}
 	},
 	//* check a DOM node for a specific CSS class


### PR DESCRIPTION
Enyo-DCO-1.1-Signed-off-by: David Posin dposin@smpdevelopment.com

For IE 8 compatibility, need to ensure html is not an empty value.  Empty stings will cause it to explode.
