### PR TITLE
BHV-753: Create separate function for waterfallShowingChanged.

### DIFF
--- a/source/dom/Control.js
+++ b/source/dom/Control.js
@@ -931,9 +931,12 @@ enyo.kind({
 	},
 	showingChanged: function(was) {
 		this.syncDisplayToShowing();
-		this.waterfallShowingChanged(was);
+		this.sendShowingChangedEvent(was);
 	},
-	waterfallShowingChanged: function(was) {
+	/**
+		Waterfalls the "onShowingChanged" event of the current control
+	*/
+	sendShowingChangedEvent: function(was) {
 		var waterfall = (was === true || was === false)
 			, parent = this.parent;
 		// make sure that we don't trigger the waterfall when this method


### PR DESCRIPTION
## Issue

For certain controls, such as `moon.Panels`, which override `showingChanged` to perform animations whenever `showing` changes, the `syncDisplayToShowing` should not be called but the waterfalling of `onShowingChanged` is still needed.
## Fix

The waterfalling of `onShowingChanged` has been separated out into a `sendShowingChangedEvent` function. The alternative would be to add another parameter to `showingChanged`, such as `preventSyncDisplay`, but would require some fiddling with the arguments object when calling `this.inherited` and having this separate function seemed like it could potentially be useful for other use cases. Please advise if there is a better way to handle this change.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
