### PR TITLE
Update ready.js to not use other Enyo code

### DIFF
--- a/source/boot/ready.js
+++ b/source/boot/ready.js
@@ -28,7 +28,7 @@
 		queue.push([fn, context]);
 		// schedule another queue flush if needed to run new ready calls
 		if (ready && !flushScheduled) {
-			enyo.asyncMethod(window, flush);
+			setTimeout(flush, 0);
 			flushScheduled = true;
 		}
 	};
@@ -42,7 +42,7 @@
 		// if we're interactive, it should be safe to move
 		// forward because the content has been parsed
 		if ((ready = ("interactive" === doc.readyState))) {
-			if (!~enyo.indexOf(event.type, ["DOMContentLoaded", "readystatechange"])) {
+			if ("DOMContentLoaded" !== event.type && "readystatechange" !== event.type) {
 				remove(event.type, init);
 				flush();
 			}

--- a/source/kernel/lang.js
+++ b/source/kernel/lang.js
@@ -928,11 +928,11 @@
 
 	/**
 		Calls method _inMethod_ on _inScope_ asynchronously.
-	
+
 		Uses _window.setTimeout_ with minimum delay, usually around 10ms.
-	
+
 		Additional arguments are passed to _inMethod_ when it is invoked.
-	
+
 		If only a single argument is supplied, will just call that
 		function asyncronously without doing any additional binding.
 	*/


### PR DESCRIPTION
ENYO-3870 reports that due to the use of enyo.indexOf and enyo.asyncMethod in ready.js,
you can no longer load Enyo dynamically after the page starts.  While I've not verified
that use case, this patch at least fixes ready.js to no longer use calls defined later in
the enyo library.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
