### PR TITLE
Update DataRepeater sample to use index property

### DIFF
--- a/samples/DataRepeaterSample.css
+++ b/samples/DataRepeaterSample.css
@@ -1,6 +1,7 @@
 .data-repeater-sample, .data-repeater-sample .repeater-item, .data-repeater-sample .name-wrapper, .data-repeater-sample .repeater-item span {box-sizing: border-box; -webkit-box-sizing: border-box; -moz-box-sizing: border-box; -ms-box-sizing: border-box; -o-box-sizing: border-box;}
 .data-repeater-sample .repeater-item {width: 100%; width: 320px; height: 100px; color: #FFFFFF; margin-bottom: 10px; position: relative;}
 .data-repeater-sample .name-wrapper {position: absolute; height: 35px; top: 50%; left: 0px; margin-top: -17.5px; width: 100%;}
+.data-repeater-sample .repeater-item .index {padding: 4px; font-size: 12px; font-weight: bold; line-height: 12px;}
 .data-repeater-sample .repeater-item .name {padding: 4px; font-size: 35px; font-weight: bold; line-height: 35px;}
 .data-repeater-sample .repeater-item .name.last {font-weight: normal; font-size: 20px; font-style: italic;}
 .data-repeater-sample .repeater-item .name.last-letter {display: block; position: absolute; top: 50%; right: 0; margin-top: -25px; text-align: right; font-weight: normal; font-size: 30px; background-color: #FFFFFF; line-height: 42px; height: 50px;

--- a/samples/DataRepeaterSample.js
+++ b/samples/DataRepeaterSample.js
@@ -1,15 +1,17 @@
 enyo.kind({
 	name: "enyo.sample.DataRepeaterSample",
-	classes: "data-repeater-sample enyo-fit",
+	classes: "data-repeater-sample enyo-fit enyo-border-box",
 	components: [
 		{name: "repeater", kind: "enyo.DataRepeater", components: [
 			{components: [
 				{classes: "name-wrapper", components: [
+					{name: "index", classes: "index", tag: "span"},
 					{name: "firstName", classes: "name", tag: "span"},
 					{name: "lastName", classes: "name last", tag: "span"},
 					{name: "lastNameLetter", classes: "name last-letter", tag: "span"}
 				]}
 			], bindings: [
+				{from: ".index", to: ".$.index.content"},
 				{from: ".model.firstName", to: ".$.firstName.content"},
 				{from: ".model.lastName", to: ".$.lastName.content"},
 				{from: ".model.lastName", to: ".$.lastNameLetter.content", transform: function (v) { return v.charAt(0); }},


### PR DESCRIPTION
We didn't have samples that showed the use of the index property to
get the item number, so I've updated DataRepeaterSampler to have
an index at the start of each line.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
