### PR TITLE
ENYO-2457: Added support for mozSystem and mozAnon on Firefox OS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.4.0-pre.3
+
+Added support for `mozAnon` and `mozSystem` properties to enyo.xhr. The mozSystem boolean enables cross-origin requests
+ and the mozAnon boolean enables anonymous xhr by not sending cookies or authentication headers. Both these
+settings are currently only working on Firefox OS.
+
 ## 2.4.0-pre.2
 
 _controller_ is no longer a special property. This affects _DataRepeater_,

--- a/source/ajax/xhr.js
+++ b/source/ajax/xhr.js
@@ -16,6 +16,8 @@ enyo.xhr = {
 		- _password_: The optional password to use for authentication purposes.
 		- _xhrFields_: Optional object containing name/value pairs to mix directly into the generated xhr object.
 		- _mimeType_: Optional string to override the MIME-Type.
+        - _mozSystem_: Optional boolean to create cross-domain XHR (Firefox OS only)
+        - _mozAnon_: Optional boolean to create anonymous XHR that doesn't not send cookies or authentication headers (Firefox OS only)
 
 		Note: on iOS 6, we will explicity add a "cache-control: no-cache"
 		header for any non-GET requests to workaround a system bug that caused


### PR DESCRIPTION
ENYO-2457: Added support for mozSystem and mozAnon on Firefox OS

We can create xhr with the mozSystem and mozAnon features by passing booleans in the ajaxProperties such as:

var x = new enyo.Ajax({
    url: "http://query.yahooapis.com/v1/public/yql?format=json",
    mozSystem: true,
    mozAnon: true
});

I decided to use prefixed names for the properties because they are not standard. There is a check in the source code to make sure we're running on Firefox OS before trying to add this type of thing.

mozAnon and mozSystem do not depend on each other. You can use any of them without using the other.

Enyo-DCO-1.1-Signed-off-by: Andre Alves Garzia andre@andregarzia.com
