### PR TITLE
ENYO-3901: fix placeholder stretching and display

### DIFF
--- a/samples/ImageSample.css
+++ b/samples/ImageSample.css
@@ -21,4 +21,5 @@
 }
 .image-sample .placeholder {
 	width: 200px;
+	height: 200px;
 }

--- a/source/ui/Image.js
+++ b/source/ui/Image.js
@@ -10,7 +10,7 @@ enyo.kind({
 	published: {
 		//* maps to the "alt" attribute of an img tag
 		alt: "",
-		/** 
+		/**
 			By default, the image is rendered using an `<img>` tag.  When this property
 			is set to `"cover"` or `"constrain"`, the image is rendered using a `<div>`,
 			utilizing `background-image` and `background-size`.
@@ -21,7 +21,7 @@ enyo.kind({
 			sized.
 		*/
 		sizing: "",
-		/** 
+		/**
 			When `sizing` is used, this property sets the positioning of the image within the
 			bounds, corresponding to the `background-position` CSS property.
 		*/
@@ -90,10 +90,12 @@ enyo.kind({
 			until final graphics are provided. As a SVG image, it will
 			expand to fill the desired width and height set in the style.
 		*/
-		placeholder: 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" ' +
-			'xmlns:xlink="http://www.w3.org/1999/xlink"><rect width="100%" height="100%" ' +
-			'style="stroke: #444; stroke-width: 1; fill: #aaa;" /><line x1="0" y1="0" ' +
-			'x2="100%" y2="100%" style="stroke: #444; stroke-width: 1;" /><line x1="100%" ' +
-			'y1="0" x2="0" y2="100%" style="stroke: #444; stroke-width: 1;" /></svg>'
+		placeholder:
+			"data:image/svg+xml;charset=utf-8;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC" +
+			"9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48cmVjdCB3aWR0aD0iMTAw" +
+			"JSIgaGVpZ2h0PSIxMDAlIiBzdHlsZT0ic3Ryb2tlOiAjNDQ0OyBzdHJva2Utd2lkdGg6IDE7IGZpbGw6ICNhYW" +
+			"E7IiAvPjxsaW5lIHgxPSIwIiB5MT0iMCIgeDI9IjEwMCUiIHkyPSIxMDAlIiBzdHlsZT0ic3Ryb2tlOiAjNDQ0" +
+			"OyBzdHJva2Utd2lkdGg6IDE7IiAvPjxsaW5lIHgxPSIxMDAlIiB5MT0iMCIgeDI9IjAiIHkyPSIxMDAlIiBzdH" +
+			"lsZT0ic3Ryb2tlOiAjNDQ0OyBzdHJva2Utd2lkdGg6IDE7IiAvPjwvc3ZnPg=="
 	}
 });


### PR DESCRIPTION
Placeholders for images are specified by an inline SVG
imgae. However, the height/width isn't specified by the SVG,
and the placeholder test only specified one of those, resulting
in a stretched appearance.

Also, some browsers had issue with the inline SVG XML
in the data URL, so replace it with the same code, but encoded as
base64.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
