### PR TITLE
ENYO-3928: Expose API for triggering event handler on a control.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Added support for `mozAnon` and `mozSystem` properties to enyo.xhr. The mozSyste
  and the mozAnon boolean enables anonymous xhr by not sending cookies or authentication headers. Both these
 settings are currently only working on Firefox OS.
 
+Added triggerHandler method to Component that invokes the handler for a given event type.
+
 ## 2.4.0-pre.2
 
 _controller_ is no longer a special property. This affects _DataRepeater_,

--- a/source/dom/dispatcher.js
+++ b/source/dom/dispatcher.js
@@ -108,11 +108,6 @@
 			var type = e.type;
 			type = e.customEvent ? type : "on" + type;
 			return c.bubble(type, e, c);
-		},
-		triggerHandler: function() {
-			var args = enyo.cloneArray(arguments),
-				control = args.shift();
-			return control.dispatchEvent(args);
 		}
 	};
 
@@ -128,18 +123,6 @@
 
 	enyo.dispatch = function(inEvent) {
 		return enyo.dispatcher.dispatch(inEvent);
-	};
-
-	/**
-		Triggers the handler for a given event type on the specified control.
-		The _inControl_ parameter is the control object, and the _inEventType_ parameter is the event type string.
-		The _inEvent_ and _inSender_ parameters are optional and represent event and sender objects, respectively,
-		to pass to the handler. For example:
-
-		enyo.triggerHandler(myControl, "ontap");
-	*/
-	enyo.triggerHandler = function(/* inControl, inEventType, [inEvent], [inSender] */) {
-		return enyo.dispatcher.triggerHandler.apply(this, arguments);
 	};
 
 	enyo.bubble = function(inEvent) {

--- a/source/kernel/Component.js
+++ b/source/kernel/Component.js
@@ -461,6 +461,17 @@ enyo.kind({
 		}
 	},
 	/**
+		Triggers the handler for a given event type.
+		The _inEventType_ parameter is the event type string.
+		The _inEvent_ and _inSender_ parameters are optional and represent event and sender objects, respectively,
+		to pass to the handler. 
+
+		Example usage: myControl.triggerHandler("ontap");
+	*/
+	triggerHandler: function(/* inEventType, [inEvent], [inSender] */) {
+		return this.dispatchEvent.apply(this, arguments);
+	},
+	/**
 		Sends a message to myself and all of my components.
 		You can stop a waterfall into components owned by a
 		receiving object by returning a truthy value from


### PR DESCRIPTION
## Issue

We need a way to directly trigger a handler for a specific event on a given control.
## Fix

We expose an API method `triggerHandler` that utilizes the `dispatch` method of `Component.`

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
