### PR TITLE
ENYO-3902: Fix issue with grouping in Firefox, general clean up.

### DIFF
--- a/samples/GroupSample.css
+++ b/samples/GroupSample.css
@@ -10,6 +10,9 @@
 	font-weight: bold;
 	margin-bottom: 8px;
 }
+.group-sample .grouping > * {
+	display: block;
+}
 .group-sample .results {
 	margin: 20px 0;
 	padding: 20px;
@@ -17,4 +20,7 @@
 	border-radius: 10px;
 	color: #FFF;
 	background-color: #555;
+}
+.group-sample .results > *:not(:last-child) {
+	margin-bottom: 10px;
 }

--- a/samples/GroupSample.js
+++ b/samples/GroupSample.js
@@ -13,82 +13,93 @@ enyo.kind({
 	classes: "group-sample",
 	components: [
 		{content: "Grouped Buttons", classes: "section"},
-		{kind: "enyo.Group", ontap: "groupButtonsTapped", components: [
-			{kind: "enyo.Button", content: "Grouped Button 1"},
-			{kind: "enyo.Button", content: "Grouped Button 2"},
-			{kind: "enyo.Button", content: "Grouped Button 3"}
+		{kind: "enyo.Group", ontap: "groupTapped", classes: "grouping", components: [
+			{kind: "enyo.Button", content: "Button 1"},
+			{kind: "enyo.Button", content: "Button 2"},
+			{kind: "enyo.Button", content: "Button 3"}
 		]},
 		{content: "Grouped Checkboxes", classes: "section"},
-		{kind: "enyo.Group", onActivate: "groupCheckboxesActivated", components: [
-			{kind: "enyo.Checkbox", content: "Checkbox 1"},
-			{kind: "enyo.Checkbox", content: "Checkbox 2"},
-			{kind: "enyo.Checkbox", content: "Checkbox 3"}
+		{kind: "enyo.Group", onActivate: "groupTapped", classes: "grouping", components: [
+			{tag: "label", components: [
+				{kind: "enyo.Checkbox", content: "Checkbox 1"}
+			]},
+			{tag: "label", components: [
+				{kind: "enyo.Checkbox", content: "Checkbox 2"}
+			]},
+			{tag: "label", components: [
+				{kind: "enyo.Checkbox", content: "Checkbox 3"}
+			]}
 		]},
 		{content: "Named Grouped Buttons", classes: "section"},
-		{kind: "enyo.Group", ontap: "namedGroupButtonsTapped", groupName: "buttonGroup", components: [
-			{kind: "enyo.Button", content: "Named Grouped Button 1", groupName: "buttonGroup"},
-			{kind: "enyo.Button", content: "Named Grouped Button 2 (excluded)"},
-			{kind: "enyo.Button", content: "Named Grouped Button 3", groupName: "buttonGroup"}
+		{kind: "enyo.Group", ontap: "groupTapped", classes: "grouping", groupName: "buttonGroup", components: [
+			{kind: "enyo.Button", content: "Named Button 1", groupName: "buttonGroup"},
+			{kind: "enyo.Button", content: "Named Button 2 (excluded)"},
+			{kind: "enyo.Button", content: "Named Button 3", groupName: "buttonGroup"}
 		]},
 		{content: "Multiple Active Grouped Checkboxes", classes: "section"},
-		{kind: "enyo.Group", onActivate: "groupMultiCheckboxesActivated", highlander: false, components: [
-			{kind: "enyo.Checkbox", content: "Multi Checkbox 1"},
-			{kind: "enyo.Checkbox", content: "Multi Checkbox 2"},
-			{kind: "enyo.Checkbox", content: "Multi Checkbox 3"}
+		{kind: "enyo.Group", onActivate: "multiCheckboxGroupTapped", classes: "grouping", highlander: false, components: [
+			{tag: "label", components: [
+				{kind: "enyo.Checkbox", content: "Multi Checkbox 1"}
+			]},
+			{tag: "label", components: [
+				{kind: "enyo.Checkbox", content: "Multi Checkbox 2"}
+			]},
+			{tag: "label", components: [
+				{kind: "enyo.Checkbox", content: "Multi Checkbox 3"}
+			]}
 		]},
 		{content: "Multiple Active Grouped Buttons", classes: "section"},
-		{kind: "enyo.Group", ontap: "groupMultiButtonsTapped", highlander: false, components: [
-			{kind: "enyo.Button", content: "Multi Grouped Button 1"},
-			{kind: "enyo.Button", content: "Multi Grouped Button 2"},
-			{kind: "enyo.Button", content: "Multi Grouped Button 3"}
+		{kind: "enyo.Group", ontap: "multiButtonGroupTapped", classes: "grouping", highlander: false, components: [
+			{kind: "enyo.Button", content: "Multi Button 1"},
+			{kind: "enyo.Button", content: "Multi Button 2"},
+			{kind: "enyo.Button", content: "Multi Button 3"}
 		]},
 		{name: "results", classes: "results"}
 	],
-	groupCheckboxesActivated: function(inSender, inEvent) {
-		if (inEvent.originator.getActive()) {
-			this.updateResult({content: "The \"" + inEvent.originator.getContent() + "\" checkbox is selected."});
+	groupTapped: function(inSender, inEvent) {
+		if (inEvent.originator !== inSender) {
+			this.updateResults([
+				{content: "The \"" + inEvent.originator.getContent() + "\" control is selected."},
+				{content: "The \"" + inSender.getActive().getContent() + "\" control is active."}
+			]);
 		}
+		return true;
 	},
-	groupButtonsTapped: function(inSender, inEvent) {
-		if (inEvent.originator.getParent().getActive && inEvent.originator.getParent().getActive()) {
-			this.updateResult({content: "The \"" + inEvent.originator.getParent().getActive().getContent() + "\" button is selected."});
-		}
-	},
-	namedGroupButtonsTapped: function(inSender, inEvent) {
-		if (inEvent.originator.getParent().getActive && inEvent.originator.getParent().getActive()) {
-			this.updateResult({content: "The \"" + inEvent.originator.getParent().getActive().getContent() + "\" button is selected."});
-		}
-	},
-	groupMultiCheckboxesActivated: function(inSender, inEvent) {
-		var activeCheckboxes = [],
-			checkboxes = inEvent.originator.getParent().getControls();
-		enyo.log(inEvent.originator.getParent());
-		for (var i=0; i<checkboxes.length; i++) {
-			if (checkboxes[i].getChecked()) {
-				activeCheckboxes.push({content: "The \"" + checkboxes[i].getContent() + "\" checkbox is selected."});
-			}
-		}
-		this.updateResult(activeCheckboxes);
-	},
-	groupMultiButtonsTapped: function(inSender, inEvent) {
-		if (inEvent.originator.kindName === "enyo.Button") {
-			var activeButtons = [],
-				buttons = inEvent.originator.getParent().getControls();
-			for (var i=0; i<buttons.length; i++) {
-				if (buttons[i].getActive && buttons[i].getActive()) {
-					activeButtons.push({content: "The \"" + buttons[i].getContent() + "\" button is selected."});
+	multiCheckboxGroupTapped: function(inSender, inEvent) {
+		if (inEvent.originator !== inSender) {
+			var results = [{content: "The \"" + inEvent.originator.getContent() + "\" control is selected."}],
+				controls = inSender.getControls(),
+				control,
+				i;
+			for (i = 0; i < controls.length; i++) {
+				control = controls[i].getControls()[0];
+				if (control.getActive()) {
+					results.push({content: "The \"" + control.getContent() + "\" control is active."});
 				}
 			}
-			this.updateResult(activeButtons);
+			this.updateResults(results);
 		}
+		return true;
 	},
-	updateResult: function(inComponents) {
-		this.$.results.destroyClientControls();
-		if( Object.prototype.toString.call(inComponents) === '[object Array]' ) {
-			this.$.results.createComponents(inComponents);
-		} else {
-			this.$.results.createComponent(inComponents);	
+	multiButtonGroupTapped: function(inSender, inEvent) {
+		if (inEvent.originator !== inSender) {
+			var results = [{content: "The \"" + inEvent.originator.getContent() + "\" control is selected."}],
+				controls = inSender.getControls(),
+				control,
+				i;
+			for (i = 0; i < controls.length; i++) {
+				control = controls[i];
+				if (control.getActive()) {
+					results.push({content: "The \"" + control.getContent() + "\" control is active."});
+				}
+			}
+			this.updateResults(results);
 		}
+		return true;
+	},
+	updateResults: function(inComponents) {
+		this.$.results.destroyClientControls();
+		this.$.results.createComponents(inComponents);
 		this.$.results.render();
 	}
 });


### PR DESCRIPTION
## Issue

Multiple grouped checkboxes are unselectable in Firefox mobile.
## Fix

There is general difficulty in tapping checkboxes; they are now wrapped in labels. Also, some logging cruft was left behind, which caused an infinite loop in Firefox Mobile. Lastly, there is some general cleanup for both the event handling and the layout of the controls.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
