### PR TITLE
ENYO-3938: Gracefully handle/prevent circular reference errors when stringifying objects.

### DIFF
--- a/source/kernel/log.js
+++ b/source/kernel/log.js
@@ -44,7 +44,10 @@ enyo.logging = {
         }
 		//var a$ = enyo.logging.formatArgs(inMethod, inArgs);
 		var a$ = enyo.isArray(inArgs) ? inArgs : enyo.cloneArray(inArgs);
-		enyo.logging.validateArgs(a$);
+		if (enyo.platform.androidFirefox) {
+			// Firefox for Android's console does not handle objects with circular references
+			enyo.logging.validateArgs(a$);
+		}
 		if (enyo.dumbConsole) {
 			// at least in early versions of webos, console.* only accept a single argument
 			a$ = [a$.join(" ")];


### PR DESCRIPTION
## Issue

Firefox for Android runs into a loop whenever `enyo.log` is called with a complex object that has a circular reference as a parameter.
## Fix

The first two strategies to invoke `console.log` via the `apply` method cause the issue. The fallback method of calling `console.log`and converting the parameter(s) to a string works with Firefox for Android, so we attempt to stringify arguments first and handle the circular reference errors as necessary.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
