### PR TITLE
ENYO-3969: Remove enyo-fit class from DataRepeaterSample.

### DIFF
--- a/samples/DataRepeaterSample.js
+++ b/samples/DataRepeaterSample.js
@@ -1,6 +1,6 @@
 enyo.kind({
 	name: "enyo.sample.DataRepeaterSample",
-	classes: "data-repeater-sample enyo-fit enyo-border-box",
+	classes: "data-repeater-sample enyo-border-box",
 	components: [
 		{name: "repeater", kind: "enyo.DataRepeater", components: [
 			{components: [


### PR DESCRIPTION
## Issue

On touch devices, when you initially scroll the `DataRepeater` in the `DataRepeaterSample`, you can't scroll past the first screen (it does the overscroll bounce).
## Fix

The `enyo-fit` class set on the `DataRepeaterSample` kind was causing a `scrollHeight` equal to the size of the viewport to be returned for the scroller, so this class has been removed.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
