### PR TITLE
BHV-6058: Use absolute positioning to implement .enyo-scrollee-fit when ...

### DIFF
--- a/source/touch/Scroller.css
+++ b/source/touch/Scroller.css
@@ -17,3 +17,11 @@
 .enyo-scrollee-fit {
 	height: 100%;
 }
+
+.enyo-flex-item.flex .enyo-scrollee-fit {
+	position: absolute;
+	top: 0;
+	left: 0;
+	bottom: 0;
+	right: 0;
+}


### PR DESCRIPTION
...scroller is used as a child of flexbox, since percentage-based sizing is not supported by flexbox.  According to notes in TouchScrollStrategy, the percentage sizing was only needed for IE to avoid a bug with non-zero scrollTop and abs pos siblings; since older versions of IE won't opt-in to the flexbox implementation, we can get away with reverting back to an enyo-fit implementation when using flexbox.

DCO-1.1-Signed-Off-By: Kevin Schaaf kevin.schaaf@lge.com
