### PR TITLE
BHV-6832: Fire onEnd when rAF animation has actually finished.

### DIFF
--- a/source/ui/Animator.js
+++ b/source/ui/Animator.js
@@ -137,7 +137,9 @@ enyo.kind({
 			this.fraction = 1;
 			this.fire("onStep");
 			this.cancel();
-			this.fire("onEnd");
+			enyo.asyncMethod(this.bindSafely(function() {
+				this.fire("onEnd");
+			}));
 		} else {
 			this.fire("onStep");
 			this.requestNext();


### PR DESCRIPTION
## Issue

The `onEnd` event is fired before the animation has actually finished, which can have a negative impact on animation performance if there are complex operations that are run in the `onEnd` handler.
## Fix

We make sure `onEnd` is sent after the final animation step, via `enyo.asyncMethod`.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
