### PR TITLE
BHV-3615: Make sup call can be called only when scroller is generated on DataList

### DIFF
--- a/source/ui/data/DataList.js
+++ b/source/ui/data/DataList.js
@@ -254,14 +254,14 @@ enyo.kind({
 			if (c === this.collection && this.$.scroller.canGenerate) {
 				if (this.get("absoluteShowing")) {
 					this.delegate.modelsRemoved(this, props);
+					sup.apply(this, arguments);
 				} else {
 					this._addToShowingQueue("refresh", function () {
+						sup.apply(this, arguments);
 						this.refresh();
 					});
 				}
 			}
-
-			sup.apply(this, arguments);
 		};
 	}),
 	destroy: enyo.inherit(function (sup) {


### PR DESCRIPTION
Current enyo.DataList can call sup (which is calling _select and getChildForIndex function in DataRepeater) when this.$.scroller.canGenerate is false.
In this case the list.boundsCache is undefined and this makes error in height function.
Moving sup call inside the canGenerate check make this issue not happens.

Fixing http://jira2.lgsvl.com/browse/BHV-3615

Closing PR for master : https://github.com/enyojs/enyo/pull/695

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
