### PR TITLE
BHV-5319: parameter ordering should be swapped when calling opts.fail at enyo.XHRSource

### DIFF
--- a/source/data/sources/xhr.js
+++ b/source/data/sources/xhr.js
@@ -60,7 +60,11 @@
 					opts.success(res, xhr);
 				}
 			});
-			xhr.error(opts.fail);
+			xhr.error(function (xhr, res) {
+				if (opts && opts.fail) {
+					opts.fail(res, xhr);
+				}
+			});
 			xhr.go(opts.params);
 		},
 		/**


### PR DESCRIPTION
If the ordering is not swapped, enyo.Store.didFail will lose the error message. Because error message is passed as 5th argument

Enyo-DCO-1.1-Signed-off-by: SoonGil Choi soongil.choi@lge.com
