### PR TITLE
Fix for ANG-7896: DataGridList: List item is invisible when adding data to collection

### DIFF
--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -296,6 +296,9 @@ enyo.DataList.delegates.vertical = {
 		if (rf || rs) { this.adjustPagePositions(list); }
 		// either way we need to adjust the buffer size
 		this.adjustBuffer(list);
+		// regardless of the status of updating the pages we need to ensure that we update
+		// the scroll thresholds as space for new pages may now exist that didn't before
+		this.setScrollThreshold(list);
 	},
 	/**
 		Attempts to find the control for the requested index.


### PR DESCRIPTION
The delegate needs to ensure that it updates the scroll threshold even when the active pages aren't modified.
