### PR TITLE
Improve event bubbling routine to cache bubble target

### DIFF
--- a/source/kernel/UiComponent.js
+++ b/source/kernel/UiComponent.js
@@ -286,8 +286,8 @@ enyo.kind({
 			}
 		}
 	},
-	getBubbleTarget: function() {
-		return this.bubbleTarget || this.parent || this.owner;
+	getBubbleTarget: function(inEventName, inEvent) {
+		return (inEvent.delegate) ? this.owner : this.bubbleTarget || this.cachedBubbleTarget[inEventName] || this.parent || this.owner;
 	}
 });
 


### PR DESCRIPTION
Improve event bubbling routine which can bubble up to proper target(having handler block or inline handler) using cachedBubbleTarget.

Enyo-DCO-1.1-Signed-off-by: Sungbae Cho sb.cho@lge.com
