### PR TITLE
Fix for: BHV-7257

### DIFF
--- a/source/ui/data/DataList.js
+++ b/source/ui/data/DataList.js
@@ -131,6 +131,9 @@ enyo.kind({
 	}),
 	create: enyo.inherit(function (sup) {
 		return function () {
+			// synchronize the showing and absoluteShowing properties as absoluteShowing is
+			// an internal property that should not be true if showing is false
+			this.absoluteShowing = this.showing;
 			// if we can, we use transitions
 			this.allowTransitionsChanged();
 			// map the selected strategy to the correct delegate for operations


### PR DESCRIPTION
The `showing` and `absoluteShowing` internal property were not properly synchronized during initialization such that setting `showing` `false` would work but internally when the DataList would request `get('absoluteShowing')` it would return `true`.
