### PR TITLE
Fix for: BHV-8308

### DIFF
--- a/source/ajax/xhr.js
+++ b/source/ajax/xhr.js
@@ -63,7 +63,7 @@ enyo.xhr = {
 		}
 		//
 		xhr.send(inParams.body || null);
-		if (async && inParams.callback) {
+		if (!async && inParams.callback) {
 			xhr.onreadystatechange(xhr);
 		}
 		return xhr;


### PR DESCRIPTION
Poor handling of xhr responses of binary content was causing exceptions to be thrown. Now we guard these scenarios consistent with other operations.
