### PR TITLE
BHV-743: Compute index bounds for rows whenever metrics are changed.

### DIFF
--- a/source/ui/data/VerticalGridDelegate.js
+++ b/source/ui/data/VerticalGridDelegate.js
@@ -94,8 +94,10 @@
 			// be used for each page
 			this.controlsPerPage(list);
 			// Compute first and last row index bounds
-			list.indexBoundFirstRow = list.columns;
-			list.indexBoundLastRow = (Math.ceil(list.collection.length / list.columns) - 1) * list.columns - 1;
+			if (list.collection) {
+				list.indexBoundFirstRow = list.columns;
+				list.indexBoundLastRow = (Math.ceil(list.collection.length / list.columns) - 1) * list.columns - 1;
+			}
 		},
 		/**
 			The number of controls necessary to fill a page will change depending on some


### PR DESCRIPTION
## Issue

Making a DataGridList specific fix (as opposed to DataList) involving calculation of index bounds for the first and last rows, dependent on the column count.
## Fix

This has been moved to `updateMetrics` as the column count can change here and we want to keep these index bounds in sync with the columns.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
