### PR TITLE
Fix for: BHV-8667

### DIFF
--- a/source/dom/delegates/HTMLStringDelegate.js
+++ b/source/dom/delegates/HTMLStringDelegate.js
@@ -179,10 +179,12 @@
 		generateChildHtml: function (control) {
 			var child,
 				html = '',
-				i = 0;
+				i = 0,
+				delegate;
 			
 			for (; (child = control.children[i]); ++i) {
-				html += this.generateHtml(child);
+				delegate = child.renderDelegate || this;
+				html += delegate.generateHtml(child);
 			}
 			
 			return html;


### PR DESCRIPTION
allow child controls to specify their own render delegates to be used

Enyo-DCO-1.1-Signed-Off-By: Cole Davis (cole.davis@lge.com)
