### PR TITLE
Fix for: BHV-8906

### DIFF
--- a/source/ui/Image.js
+++ b/source/ui/Image.js
@@ -44,6 +44,7 @@ enyo.kind({
 			sup.apply(this, arguments);
 			this.altChanged();
 			this.sizingChanged();
+			this.srcChanged();
 		};
 	}),
 	getSrc: function () {


### PR DESCRIPTION
ensure that the src property is initialized for subkinds

Enyo-DCO-1.1-Signed-Off-By: Cole Davis (cole.davis@lge.com)
