### PR TITLE
fix updateProgress in ie8

### DIFF
--- a/source/ajax/Ajax.js
+++ b/source/ajax/Ajax.js
@@ -251,7 +251,7 @@ enyo.kind({
 				ev[k] = event[k];
 			}
 		}
-		this.sendProgress(event.loaded, 0, event.total, ev);
+		this.sendProgress(ev.loaded, 0, ev.total, ev);
 	},
 	statics: {
 		objectToQuery: function(/*Object*/ map) {


### PR DESCRIPTION
"event" is probably meant to be "ev"; IE8 throws an exception otherwise.

Enyo-DCO-1.1-Signed-off-by: Johann Jacobsohn j.jacobsohn@satzmedia.de