### PR TITLE
changes to getTouchStrategy

### DIFF
--- a/source/touch/Scroller.js
+++ b/source/touch/Scroller.js
@@ -142,9 +142,9 @@ enyo.kind({
 			return true;
 		},
 		getTouchStrategy: function() {
-			return (enyo.platform.android >= 3) || (enyo.platform.windowsPhone === 8) || (enyo.platform.webos >= 4)
+			return (enyo.platform.android >= 3) (enyo.platform.androidChrome >= 18) || (enyo.platform.windowsPhone === 8) || (enyo.platform.webos >= 4)
 				? "TranslateScrollStrategy"
-				: "TouchScrollStrategy";
+				: (enyo.platform.ios >= 5) ? "TransitionScrollStrategy" : "TouchScrollStrategy";
 		}
 	},
 	controlParentName: "strategy",


### PR DESCRIPTION
Enable TranslateScrollStrategy on Android Kitkat and later, and TransitionScrollStrategy on iOS5 and later.