### PR TITLE
Bhv 9729 Fix logical fault in modelsAdded()

### DIFF
--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -289,32 +289,24 @@ enyo.DataList.delegates.vertical = {
 			lastPageEnd = (cpp * 2) + (firstPageStart - 1),
 			len = props.models.length,
 			gen,
-			check,
-			idx;
+			idx;			
 			
-		check = function (i) {
-			return (i >= firstPageStart && i <= lastPageEnd);
-		};
-		
 		// retrieve the first index for the first added model in the collection
 		idx = collection.indexOf(props.models[0]);
 		
-		gen = check(idx);
-		
-		if (!gen) {
-			
-			// we can use the fact that we know that all indices of the models that were added are
-			// sequential and contiguous to know where the last index is
-			idx = idx + len - 1;
-			
-			gen = check(idx);
+		// we can use the fact that we know that all indices of the models that were added are
+		// sequential and contiguous to know where the last index is
+		if (idx >= firstPageStart) {
+			gen = (idx <= lastPageEnd);			
+		} else {
+			gen = ((idx + len - 1) <= lastPageEnd);
 		}
 		
 		// if we need to refresh, do it now and ensure that we're properly setup to scroll
 		// if we were adding to a partially filled page
-		if (gen) this.refresh(list);
-		else {
-			
+		if (gen) {
+			this.refresh(list);
+		} else {
 			// we still need to ensure that the metrics are updated so it knows it can scroll
 			// past the boundaries of the current pages (potentially)
 			this.adjustBuffer(list);


### PR DESCRIPTION
Currently there is logical trap in modelsAdded() from VerticalDelegate.js
If given list are overlapped whole of active pages, current logic could not detect it.
For example, if given list's start index is less than firstPageStart and list index is bigger than lastPageEnd
then list should be refreshed but it couldn't do that.

Like following case, current logic could not know it.
Current collection 1 ......................................................100
Active pages                      36............................71
Added items             7............................................................110

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
