### PR TITLE
Fix for: BHV-9729

### DIFF
--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -353,12 +353,11 @@ enyo.DataList.delegates.vertical = {
 			pos = this.pagesByPosition(list),
 			first = pos.firstPage.start != null ? pos.firstPage.start : 0,
 			end = (cpp * 2) + (first - 1),
-			len = props.models.length,
 			gen,
 			idx;
 		
-		// retrieve the index for the last added model in the collection
-		idx = collection.indexOf(props.models[0]) + len - 1;
+		// retrieve the index for the first added model in the collection
+		idx = collection.indexOf(props.models[0]);
 		
 		// if the index is above the end of our currently rendered indices we need to refresh
 		gen = idx <= end;


### PR DESCRIPTION
Originally found by @DavidUM with a proposed fix https://github.com/enyojs/enyo/pull/751, this is the same fix with minimal changes to the existing code and a similar normalization in the `modelsRemoved()` method.

Enyo-DCO-1.1-Signed-Off-By: Cole Davis (cole.davis@lge.com)
