### PR TITLE
Fix for: BHV-9375

### DIFF
--- a/source/dom/Control.js
+++ b/source/dom/Control.js
@@ -390,7 +390,8 @@
 			// if we have a node we render the value immediately and update our style string
 			// in the process to keep them synchronized
 			var node = this.hasNode(),
-				style = this.style;
+				style = this.style,
+				delegate = this.renderDelegate || Control.renderDelegate;
 				
 			if (value !== null && value !== '' && value !== undefined) {
 				// update our current cached value
@@ -400,10 +401,13 @@
 					// cssText is an internal property used to help know when to sync and not
 					// sync with the node in styleChanged
 					this.style = this.cssText = node.style.cssText;
+					
+					// we need to invalidate the style for the delegate
+					delegate.invalidate(this, 'style');
 				
-					// otherwise we have to try and prepare it for the next time it is rendered we will
-					// need to update it because it will not be synchronized
-				} else this.set('style', style + (prop + ':' + value + ';'));
+					// otherwise we have to try and prepare it for the next time it is rendered we 
+					// will need to update it because it will not be synchronized
+				} else this.set('style', style + (' ' + prop + ':' + value + ';'));
 			} else {
 				
 				// in this case we are trying to clear the style property so if we have the node
@@ -413,6 +417,9 @@
 				if (node) {
 					node.style[prop] = '';
 					this.style = this.cssText = node.style.cssText;
+					
+					// we need to invalidate the style for the delegate
+					delegate.invalidate(this, 'style');
 				} else {
 					
 					// this is a rare case to nullify the style of a control that is not


### PR DESCRIPTION
Changes to the `style` and `classes` properties of _enyo.Control_ were not properly setting their `tagsValid` internal flag. This particular state is handled by the `enyo.HTMLStringDelegate` by default but it wasn't getting the opportunity if the _control_ had a `node` already. Now it can properly handle the changes as it needs and other _render delegates_ will have the opportunity as well.

Enyo-DCO-1.1-Signed-Off-By: Cole Davis (cole.davis@lge.com)
