### PR TITLE
BHV-4135: Apply kFrictionEpsilon as 1e-1 on webos platform for fast scrollStop

### DIFF
--- a/source/touch/ScrollMath.js
+++ b/source/touch/ScrollMath.js
@@ -41,7 +41,7 @@ enyo.kind({
 	kMaxFlick: enyo.platform.android > 2 ? 2 : 1e9,
 	//* The value used in friction() to determine if the delta (e.g., y - y0) is
 	//* close enough to zero to consider as zero
-	kFrictionEpsilon: enyo.platform.webos > 3 ? 1e-1 : 1e-2,
+	kFrictionEpsilon: enyo.platform.webos >= 4 ? 1e-1 : 1e-2,
 	//* Top snap boundary, generally 0
 	topBoundary: 0,
 	//* Right snap boundary, generally (viewport width - content width)


### PR DESCRIPTION
Currently we can tell this scroll is over when scroll bouncing is under 1e-2.
However considering for TV device, we will reduce it to 1e-1.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
