### PR TITLE
Bhv 10114 Break down updateMetric() to increase performance

### DIFF
--- a/source/ui/data/DataGridList.js
+++ b/source/ui/data/DataGridList.js
@@ -62,21 +62,6 @@ enyo.kind({
 		};
 	}),
 	/**
-		We guarantee that index bound is maintained and up to date.
-	*/
-	modelsAdded: enyo.inherit(function (sup) {
-		return function (list, props) {
-			this.updateIndexBound(list);
-			sup.apply(this, arguments);
-		};
-	}),
-	modelsRemoved: enyo.inherit(function (sup) {
-		return function (list, props) {
-			this.updateIndexBound(list);
-			sup.apply(this, arguments);
-		};
-	}),
-	/**
 		We don't want to worry about the normal required handling when showing changes unless
 		we're actually visible and the list has been fully rendered and we actually have
 		some data.

--- a/source/ui/data/VerticalGridDelegate.js
+++ b/source/ui/data/VerticalGridDelegate.js
@@ -113,6 +113,21 @@
 			list.indexBoundLastRow = (Math.ceil(list.collection.length / list.columns) - 1) * list.columns - 1;
 		},
 		/**
+			We guarantee that index bound is maintained and up to date.
+		*/
+		modelsAdded: enyo.inherit(function (sup) {
+			return function (list, props) {
+				this.updateIndexBound(list);
+				sup.apply(this, arguments);
+			};
+		}),
+		modelsRemoved: enyo.inherit(function (sup) {
+			return function (list, props) {
+				this.updateIndexBound(list);
+				sup.apply(this, arguments);
+			};
+		}),
+		/**
 			The number of controls necessary to fill a page will change depending on some
 			factors such as scaling and list-size adjustments. It is a function of the calculated
 			size required (pageSizeMultiplier * the current boundary height) and the adjusted tile height and


### PR DESCRIPTION
After model added or removed, you should update index bound.
Currently updating index bound logic is included in updateMetric(), so if you want to update index bound then you will undergo redundant work load. 
To increase performance, I pull update index bound logic out of updateMetric()

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
