### PR TITLE
Fix for: BHV-10097

### DIFF
--- a/source/dom/Control.js
+++ b/source/dom/Control.js
@@ -569,9 +569,12 @@
 				return false;
 			}
 			
-			if (parent && parent.getAbsoluteShowing && (
-				this.parentNode !== enyo.floatingLayer.hasNode())) {
-				return parent.getAbsoluteShowing(ignoreBounds);
+			if (parent && parent.getAbsoluteShowing) {
+				
+				// we actually don't care what the parent says if it is the floating layer
+				if (!this.parentNode || (this.parentNode !== enyo.floatingLayer.hasNode())) {
+					return parent.getAbsoluteShowing(ignoreBounds);
+				}
 			}
 			
 			return true;


### PR DESCRIPTION
_Spotlight_ was unable to accurately determine a _Control_ to be unspottable because of a fail-case in `getAbsoluteShowing()` of _Control_.

Enyo-DCO-1.1-Signed-Off-By: Cole Davis (cole.davis@lge.com)
