### PR TITLE
BHV-8206: Call the super of the constructor.

### DIFF
--- a/source/data/ModelController.js
+++ b/source/data/ModelController.js
@@ -161,13 +161,17 @@
 			@private
 			@method
 		*/
-		constructor: function (props) {
-			// ensure we have our own model property
-			this.model = null;
-			
-			// adhere to normal approach to constructor properties hash
-			props && enyo.mixin(this, props);
-		},
+		constructor: enyo.inherit(function (sup) {
+			return function (props) {
+				sup.apply(this, arguments);
+
+				// ensure we have our own model property
+				this.model = null;
+				
+				// adhere to normal approach to constructor properties hash
+				props && enyo.mixin(this, props);
+			};
+		}),
 		
 		/**
 			@public


### PR DESCRIPTION
## Issue

If there are child components of `enyo.ModelController`, an exception is thrown at create time: http://jsfiddle.net/aarontam/pg6Dr/
## Fix

Call the super of `constructor` at create time.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
