### PR TITLE
BHV-10367: AlwaysViewingPanels: Unexpected Path is Created for background source

### DIFF
--- a/source/dom/Control.js
+++ b/source/dom/Control.js
@@ -1204,7 +1204,9 @@
 	*/
 	Control.normalizeCssStyleString = function (style) {
 		return style ? (
-			(";" + style + ";")
+			(";" + style)
+			// add a semi-colon if it's not the last character (also trim possible unnecessary whitespace)
+			.replace(/([^;])\s*$/, "$1;")
 			// ensure we have one space after each colon or semi-colon
 			.replace(/\s*;\s*([\w-]+)\s*:\s*/g, "; $1: ")
 			// remove first semi-colon and space


### PR DESCRIPTION
**Issue**

An extra space was being added after url colons in the style attribute, resulting in wrong paths

**Fix**

modifying a regular expression in Control.normalizeCssStyleString() to not add spaces after colons preceded by http or https

Enyo-DCO-1.1-Signed-off-by: Krishna Rangarajan krishna.rangarajan@lge.com
