### PR TITLE
[enyo] WTWOAPP-2365 fix animationend event issue

### DIFF
--- a/source/dom/dispatcher.js
+++ b/source/dom/dispatcher.js
@@ -7,7 +7,7 @@
 		// these events come from document
 		events: ["mousedown", "mouseup", "mouseover", "mouseout", "mousemove", "mousewheel",
 			"click", "dblclick", "change", "keydown", "keyup", "keypress", "input",
-			"paste", "copy", "cut", "webkitTransitionEnd", "transitionend", "webkitAnimationEnd", "animationEnd"],
+			"paste", "copy", "cut", "webkitTransitionEnd", "transitionend", "webkitAnimationEnd", "animationend"],
 		// these events come from window
 		windowEvents: ["resize", "load", "unload", "message", "hashchange", "popstate"],
 		// feature plugins (aka filters)


### PR DESCRIPTION
http://mlm.lge.com/di/browse/WTWOAPP-2365

animation end event was not triggering in Mozilla etc. due to
animationEnd typo

DCO-1.1-Signed-Off-By: Seungho Park seunghoh.park@lge.com
