### PR TITLE
BHV-10954: Account for over scroll when setting target X/Y positions.

### DIFF
--- a/source/touch/ScrollMath.js
+++ b/source/touch/ScrollMath.js
@@ -305,11 +305,11 @@ enyo.kind({
 	*/
 	scrollTo: function(inX, inY) {
 		if (inY !== null) {
-			this.endY = -inY;
+			this.endY = this.clampY(-inY);
 			this.y = this.y0 - (inY + this.y0) * (1 - this.kFrictionDamping);
 		}
 		if (inX !== null) {
-			this.endX = -inX;
+			this.endX = this.clampX(-inX);
 			this.x = this.x0 - (inX + this.x0) * (1 - this.kFrictionDamping);
 		}
 		this.start();
@@ -329,5 +329,11 @@ enyo.kind({
 	isInOverScroll: function() {
 		return this.job && (this.x > this.leftBoundary || this.x < this.rightBoundary ||
 			this.y > this.topBoundary || this.y < this.bottomBoundary);
+	},
+	clampX: function(inX) {
+		return Math.min(this.leftBoundary, Math.max(inX, this.rightBoundary));
+	},
+	clampY: function(inY) {
+		return Math.min(this.topBoundary, Math.max(inY, this.bottomBoundary));
 	}
 });


### PR DESCRIPTION
## Issue

We were not accounting for overscroll when setting the target X/Y position to set as the final scroller position.
## Fix

We clamp the X and Y target positions based upon the scroller boundaries.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
