### PR TITLE
Removing redundant onScrollStop event in the cases of stopping previous ...

### DIFF
--- a/source/touch/TouchScrollStrategy.js
+++ b/source/touch/TouchScrollStrategy.js
@@ -204,9 +204,9 @@ enyo.kind({
 			this.$.scrollMath.frame = this.frame;
 		}
 	},
-	stop: function() {
+	stop: function(inFireEvent) {
 		if (this.isScrolling()) {
-			this.$.scrollMath.stop(true);
+			this.$.scrollMath.stop(inFireEvent);
 		}
 	},
 	stabilize: function() {


### PR DESCRIPTION
...scroll behavior.

Adding inFireEvent parameter on stop function of TouchScrollStrategy.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
