### PR TITLE
BHV-10740: Add netcast platform to enyo platform detection

### DIFF
--- a/source/dom/platform.js
+++ b/source/dom/platform.js
@@ -69,7 +69,7 @@
 		// webOS 1 - 3
 		{platform: 'webos', regex: /(?:web|hpw)OS\/(\d+)/},
 		// webOS 4 / OpenWebOS
-		{platform: 'webos', regex: /WebAppManager|Isis/, forceVersion: 4},
+		{platform: "webos", regex: /WebAppManager|Isis|webOS\./, forceVersion: 4},
 		// desktop Safari
 		{platform: 'safari', regex: /Version\/(\d+)[.\d]+\s+Safari/},
 		// desktop Chrome


### PR DESCRIPTION
### Issue:

The user agent string of Netcast apps were not being detected as webos platform apps, even though they run within WAM on the webOS tv. The user agent string is:
"Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.41 (KHTML, like Gecko) Large Screen Safari/537.41 LG Browser/7.00.00(LGE; WEBOS1; 01.00.95; 1); webOS.TV-2014; LG NetCast.TV-2013 Compatible (LGE, WEBOS1, wired)"
### Fix:

The older webOS devices have UA strings of form webOS/(\d+) or hpwOS/(\d+) . Matching "webOS." seems like the most generic phrase to match, without matching the older webOS devices.

Enyo-DCO-1.1-Signed-off-by: Krishna Rangarajan krishna.rangarajan@lge.com
