### PR TITLE
Call start only when scroll position is actually changing.

### DIFF
--- a/source/touch/ScrollMath.js
+++ b/source/touch/ScrollMath.js
@@ -312,6 +312,7 @@ enyo.kind({
 			this.endX = this.clampX(-inX);
 			this.x = this.x0 - (inX + this.x0) * (1 - this.kFrictionDamping);
 		}
+		if (inX == this.x && inY == this.y) return;
 		this.start();
 	},
 	setScrollX: function(inX) {


### PR DESCRIPTION
There is unnecessary onScrollStart call in DataGridList render time.
DataGridList is reset itself when it is rendered and call scrollTo(0,0).
The scrollTo is calling doScrollStart without checking the position changes.
So, it is fires onScrollStart but there is no onScrollStop because it is not actually scrolling.

Fixing http://jira2.lgsvl.com/browse/BHV-11027 and http://hlm.lge.com/qi/browse/WEBOSLCD13-85658

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
