### PR TITLE
Bhv 5137 Add renderOnShow option

### DIFF
--- a/source/dom/Control.js
+++ b/source/dom/Control.js
@@ -548,7 +548,7 @@
 				// develper intended to make this control un-rendered 
 				// until there is a request to show
 				if (this.renderOnShow && !this.generated) {
-					this.setCanGenerate = true;
+					this.setCanGenerate(true);
 					this.render();
 				}
 			}			


### PR DESCRIPTION
Requested from HQ developers.
## Issue

Due to performance matter, app developers would like to adjust rendering timing between render on creating and render on actual showing.
## Cause

enyo.Control does not have an option to delay rendering
## Fix

Add renderOnShow option. If developer sets it true, 
automatically this control has showing:false and canGenerate: false
When we call setShowing(true) first time, it will start render.
