### PR TITLE
Do preventDefault on focus and keydown event in enyo.input

### DIFF
--- a/source/ui/Input.js
+++ b/source/ui/Input.js
@@ -133,7 +133,7 @@ enyo.kind({
 	dragstart: function() {
 		return this.hasFocus();
 	},
-	focused: function() {
+	focused: function(inSender, inEvent) {
 		this.preventDefaultOnOffscreen(inSender, inEvent);
 		if (this.selectOnFocus) {
 			enyo.asyncMethod(this, "selectContents");


### PR DESCRIPTION
Problem:
If input field is focused or get key event while it is at outside of screen,
browser is re-positioning whole content which is including input into the screen.
This happens even if body has overflow: hidden on it.

Fix:
Do preventDefault on focus and keydown event to prevent browser's behavior
while it is at outside of screen.

Fixing http://jira2.lgsvl.com/browse/BHV-11008

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
