### PR TITLE
readd charset to generated script elements for internet explorer

### DIFF
--- a/source/boot/boot.js
+++ b/source/boot/boot.js
@@ -50,6 +50,7 @@ enyo.machine = {
 			/* jshint evil: true */
 			document.write(
 				'<scri' + 'pt src="' + inSrc + '"' +
+				' charset="utf-8" ' +
 				(onLoad ? ' onload="' + onLoad + '"' : '') +
 				(onError ? ' onerror="' + onError + '"' : '') +
 				'></scri' + 'pt>');


### PR DESCRIPTION
This fix apparently got lost in 4e3bef5 (original fix: 6dbc4a9)

Enyo-DCO-1.1-Signed-off-by: Johann Jacobsohn j.jacobsohn@satzmedia.de