### PR TITLE
Bhv 11232 Enforce condition statement for setShowing()

### DIFF
--- a/source/dom/Control.js
+++ b/source/dom/Control.js
@@ -528,7 +528,7 @@
 			
 			// if we are supposed to be hiding the control then we need to cache our current
 			// display state
-			else if (!this.showing) {
+			else if (was && !this.showing) {
 				// we can't truly cache this because it _could_ potentially be set to multiple
 				// values throughout its lifecycle although that seems highly unlikely...
 				this._display = this.hasNode() ? this.node.style.display : '';


### PR DESCRIPTION
## Issue

If developer gives null or undefined as an argument for setShowing(), it makes a control to be invisible. It is natural behavior.
However if developer call setShowing(false) at this status, it shows a control.
Here is a logical bug which we did not expected.
## Cause

In Enyo 2.3.0, showingChanged() will waterfall 'onShowingChanged' event when 'was' - previous showing value- was 'true' or 'false'
However in Enyo 2.5.0 we use like follows

if (!was) this.applyStyle('display', this._display || ' ');

So 'false' after 'null' removed display: none and a control becomes visible.
## Fix

Enforce condition statement with double check - was and is -

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
