### PR TITLE
copy & paste error in Binding.js

### DIFF
--- a/source/kernel/Binding.js
+++ b/source/kernel/Binding.js
@@ -86,7 +86,7 @@
 			// now our sanitation
 			rdy = !! (
 				(source && (typeof source == 'object')) &&
-				(target && (typeof source == 'object')) &&
+				(target && (typeof target == 'object')) &&
 				(from) &&
 				(to)
 			);


### PR DESCRIPTION
checked for typeof source == object two times, changed second test to test for target.

Enyo-DCO-1.1-Signed-off-by: Achim Königs garfonso@tratschtante.de
