### PR TITLE
BHV-11259/BHV-11469 Ternary operator fixes, EventEmitter Tests

### DIFF
--- a/source/data/Store.js
+++ b/source/data/Store.js
@@ -107,20 +107,22 @@
 		* @private
 		*/
 		add: function (models, opts) {
-			var ctor = models && models instanceof Array ? models[0].ctor : models.ctor,
+			var ctor = models && (models instanceof Array ? models[0].ctor : models.ctor),
 				kindName = ctor && ctor.prototype.kindName,
-				list = this.models[kindName],
+				list = kindName && this.models[kindName],
 				added,
 				i;
 				
 			// if we were able to find the list then we go ahead and attempt to add the models
-			if (list) added = list.add(models);
-			// if we successfully added models and this was a default operation (not being
-			// batched by a collection or other feature) we emit the event needed primarily
-			// by relational models but could be useful other places
-			if (added.length && (!opts || !opts.silent)) {
-				for (i = 0; i < added.length; ++i) {
-					this.emit(ctor, 'add', {model: added[i]});
+			if (list) {
+				added = list.add(models);
+				// if we successfully added models and this was a default operation (not being
+				// batched by a collection or other feature) we emit the event needed primarily
+				// by relational models but could be useful other places
+				if (added.length && (!opts || !opts.silent)) {
+					for (i = 0; i < added.length; ++i) {
+						this.emit(ctor, 'add', {model: added[i]});
+					}
 				}
 			}
 			
@@ -131,20 +133,22 @@
 		* @private
 		*/
 		remove: function (models, opts) {
-			var ctor = models && models instanceof Array ? models[0].ctor : models.ctor,
+			var ctor = models && (models instanceof Array ? models[0].ctor : models.ctor),
 				kindName = ctor && ctor.prototype.kindName,
-				list = this.models[kindName],
+				list = kindName && this.models[kindName],
 				removed,
 				i;
 			
 			// if we were able to find the list then we go ahead and attempt to remove the models
-			if (list) removed = list.remove(models);
-			// if we successfully removed models and this was a default opreation (not being
-			// batched by a collection or other feature) we emit the event needed primarily
-			// by relational models but could be useful other places
-			if (removed.length && (!opts || !opts.silent)) {
-				for (i = 0; i < removed.length; ++i) {
-					this.emit(ctor, 'remove', {model: removed[i]});
+			if (list) {
+				removed = list.remove(models);
+				// if we successfully removed models and this was a default operation (not being
+				// batched by a collection or other feature) we emit the event. Needed primarily
+				// by relational models but could be useful other places
+				if (removed.length && (!opts || !opts.silent)) {
+					for (i = 0; i < removed.length; ++i) {
+						this.emit(ctor, 'remove', {model: removed[i]});
+					}
 				}
 			}
 			

--- a/source/kernel/mixins/EventEmitter.js
+++ b/source/kernel/mixins/EventEmitter.js
@@ -30,7 +30,7 @@
 			
 		if (listeners.length) {
 			idx = listeners.findIndex(function (ln) {
-				return ln.event == e && ln.method === fn && ctx? ln.ctx === ctx: true;
+				return ln.event == e && ln.method === fn && (ctx? ln.ctx === ctx: true);
 			});
 			idx >= 0 && listeners.splice(idx, 1);
 		}

--- a/tools/mocha-tests/index.html
+++ b/tools/mocha-tests/index.html
@@ -38,6 +38,7 @@
 		<script src="tests/RelationalModel.js"></script>
 		<script src="tests/ModelController.js"></script>
 		<script src="tests/BucketFilter.js"></script>
+		<script src="tests/EventEmitter.js"></script>
 		<script>
 			if (window.mochaPhantomJS) {
 				mochaPhantomJS.run();

--- a/tools/mocha-tests/tests/.jshintrc
+++ b/tools/mocha-tests/tests/.jshintrc
@@ -1,0 +1,32 @@
+{
+    "globals": {
+        "enyo": false,
+        "$L": false,
+        "describe"   : false,
+        "xdescribe"  : false,
+        "it"         : false,
+        "xit"        : false,
+        "before"     : false,
+        "beforeEach" : false,
+        "after"      : false,
+        "afterEach"  : false,
+        "expect"     : false,
+        "sinon"      : false
+    },
+    "es3": true,
+    "evil": false,
+    "regexdash": true,
+    "browser": true,
+    "wsh": false,
+    "trailing": false,
+    "sub": true,
+    "eqnull": true,
+    "laxbreak": true,
+    "laxcomma": true,
+    "curly": false,
+    "indent": 4,
+    "newcap": true,
+    "undef": true,
+    "expr": true,
+    "unused": "vars"
+}

--- a/tools/mocha-tests/tests/EventEmitter.js
+++ b/tools/mocha-tests/tests/EventEmitter.js
@@ -1,0 +1,195 @@
+// TODO: Someday add tests that test with default context and emit with a specified object to emit to
+describe('enyo.EventEmitter', function () {
+	var EventEmitter = enyo.EventEmitter;
+
+	describe('methods', function () {
+		
+		var emitter;
+
+		beforeEach(function() {
+			emitter = new enyo.Object({mixins: [EventEmitter]});
+		});
+		
+		describe('silence', function () {
+			it ('should start unsilenced', function () {
+				expect(emitter.isSilenced()).to.equal(false);
+			});
+
+			it ('should set silenced flag', function () {
+				emitter.silence();
+				expect(emitter.isSilenced()).to.equal(true);
+			});
+
+			it ('should return this', function () {
+				expect(emitter.silence()).to.equal(emitter);
+			});
+
+			it ('should stack', function () {
+				emitter.silence();
+				emitter.silence();
+				emitter.unsilence();
+				expect(emitter.isSilenced()).to.equal(true);
+				emitter.unsilence();
+				expect(emitter.isSilenced()).to.equal(false);
+			});
+		});
+
+		describe('unsilence', function () {
+			it ('should return this', function () {
+				expect(emitter.unsilence()).to.equal(emitter);
+			});
+
+			it ('should clear all with truthy parameter', function () {
+				emitter.silence();
+				emitter.silence();
+				emitter.unsilence(true);
+				expect(emitter.isSilenced()).to.equal(false);
+			});
+
+			it ('should work with multiple unsilence calls', function () {
+				emitter.unsilence();
+				emitter.unsilence();
+				emitter.unsilence();
+				expect(emitter.isSilenced()).to.equal(false);
+				emitter.silence();
+				expect(emitter.isSilenced()).to.equal(true);
+				emitter.unsilence();
+				expect(emitter.isSilenced()).to.equal(false);
+			});
+		});
+
+		describe('addListener/on', function () {
+			var mock, listener = { method1: function () {}, method2: function () {} };
+
+			beforeEach(function () {
+				mock = sinon.mock(listener);
+			});
+
+			it ('should return this', function () {
+				expect(emitter.on('*', mock.method1, mock)).to.equal(emitter);
+			});
+
+			it ('should add listeners', function () {
+				emitter.on('*', mock.method1, mock);
+				expect(emitter.listeners().length).to.equal(1);
+				emitter.on('*', mock.method2, mock);
+				expect(emitter.listeners().length).to.equal(2);
+			});
+		});
+
+		describe('removeListener/off', function () {
+			var mock, listener = { method1: function () {}, method2: function () {} };
+
+			beforeEach(function () {
+				mock = sinon.mock(listener);
+			});
+
+			it ('should return this', function () {
+				expect(emitter.off('*', mock.method1, mock)).to.equal(emitter);
+			});
+
+			it ('should remove existing listeners', function () {
+				emitter.on('*', mock.method1, mock);
+				emitter.on('*', mock.method2, mock);
+				emitter.off('*', mock.method2, mock);
+				expect(emitter.listeners().length).to.equal(1);
+				expect(emitter.listeners()[0].fn).to.equal(mock['method1']);
+				emitter.off('*', mock.method1, mock);
+				expect(emitter.listeners().length).to.equal(0);
+			});
+
+			it ('shouldn\'t remove non-matching listeners', function () {
+				emitter.on('*', mock.method1, mock);
+				emitter.on('*', mock.method2, mock);
+				emitter.off('frank', mock.method2, mock);
+				expect(emitter.listeners().length).to.equal(2);
+				emitter.off('*', 'method3', mock);
+				expect(emitter.listeners().length).to.equal(2);
+				emitter.off('*', mock.method2, emitter);
+				expect(emitter.listeners().length).to.equal(2);
+			});
+		});
+
+		describe('removeAllListeners', function () {
+			var mock, listener = { method1: function () {}, method2: function () {} };
+
+			beforeEach(function () {
+				mock = sinon.mock(listener);
+			});
+
+			it ('should return this', function () {
+				expect(emitter.removeAllListeners()).to.equal(emitter);
+			});
+
+			it ('should remove all existing listeners with no params', function () {
+				emitter.on('*', mock.method1, mock);
+				emitter.on('*', mock.method2, mock);
+				emitter.removeAllListeners();
+				expect(emitter.listeners().length).to.equal(0);
+			});
+
+			it ('shouldn\'t remove non-matching listeners', function () {
+				emitter.on('a', mock.method1, mock);
+				emitter.on('b', mock.method2, mock);
+				emitter.removeAllListeners('*');
+				expect(emitter.listeners().length).to.equal(2);
+				emitter.removeAllListeners('a');
+				expect(emitter.listeners().length).to.equal(1);
+				emitter.removeAllListeners('b');
+				expect(emitter.listeners().length).to.equal(0);
+			});
+		});
+
+		describe('emit/triggerEvent', function () {
+			var mock, listener = { method1: function () {}, method2: function () {} };
+
+			beforeEach(function () {
+				mock = sinon.mock(listener);
+			});
+
+			afterEach(function () {
+				mock.restore();
+			});
+
+			it ('should return false with no listeners', function () {
+				expect(emitter.emit()).to.equal(false);
+			});
+
+			it ('should send all events to *', function () {
+				mock.expects('method1').twice();
+				mock.expects('method2').once();
+				emitter.on('*', listener.method1, listener);
+				emitter.on('cole', listener.method2, listener);
+				emitter.emit('aaron');
+				emitter.emit('cole');
+				mock.verify();
+			});
+
+			it ('should not send any events when silenced', function () {
+				emitter.silence();
+				mock.expects('method1').never();
+				mock.expects('method2').never();
+				emitter.on('*', listener.method1, listener);
+				emitter.on('cole', listener.method2, listener);
+				emitter.emit('aaron');
+				emitter.emit('cole');
+				mock.verify();
+			});
+
+			it ('should send event name', function () {
+				mock.expects('method1').once().withArgs(emitter, 'data');
+				emitter.on('*', listener.method1, listener);
+				emitter.emit('data');
+				mock.verify();
+			});
+
+			it ('should send passed-in data', function () {
+				mock.expects('method1').once().withArgs(emitter, 'data', {a: 1});
+				emitter.on('*', listener.method1, listener);
+				emitter.emit('data', {a: 1});
+				mock.verify();
+			});
+		});
+	});
+});
+


### PR DESCRIPTION
Includes .jshintrc file for tests that includes mocha/sinon globals
Fixes an issue with EventEmitter deleting the wrong listener, needed to fix BucketFilter tests

Enyo-DCO-1.1-Signed-off-by: Roy Sutton (roy.sutton@lge.com)
