### PR TITLE
BHV-11567 Fix missing semicolon

### DIFF
--- a/source/ui/data/VerticalGridDelegate.js
+++ b/source/ui/data/VerticalGridDelegate.js
@@ -178,7 +178,7 @@
 						"top: "    + Math.round(s  + (r  * (h+s))) + "px; " +
 						(list.rtl ? "right: " : "left: ") + Math.round(s  + (co * (w+s))) + "px; " +
 						"width: "  + Math.round(w) +                 "px; " +
-						"height: " + Math.round(h) +                 "px"
+						"height: " + Math.round(h) +                 "px;"
 					);
 					// check if we need to increment the row
 					if ((i+1) % cc === 0) { ++r; }


### PR DESCRIPTION
## Issue

When dataGridList is reset, generatePage() assigns appended string to this.style which is composed with css properties. 
Usually It is parsed well but in specific case it return unexpected value due to missing semicolon
## Cause

layout() in VerticalGridDeleage.js missed semicolon when it compose string.
{code}
c.addStyles(
   ...  
   "height: " + Math.round(h) +  "px"
);
{code}
## Fix

Add semicolon resolve it.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
