### PR TITLE
BHV-11000: Make both src and sourceComponents in enyo.Video works

### DIFF
--- a/source/ui/Video.js
+++ b/source/ui/Video.js
@@ -135,7 +135,7 @@ enyo.kind({
 			i
 		;
 		
-		if (!sources || sources.length == 0) {
+		if (!sources || sources.length === 0) {
 			return;
 		}
 		


### PR DESCRIPTION
Fixing: http://jira2.lgsvl.com/browse/BHV-11000

Issue:
'sourceComponents' in enyo.Video is used for clarifying multiple video format about same video file such 'mp4', 'webm' and 'ogv'. However, some functions for handling the property was erased.

Fix:
Recover codes related to video sources and makes them bindable from player.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
