### PR TITLE
Bhv 11591 Prevent unnecessary refresh() to increase performance

### DIFF
--- a/source/data/Collection.js
+++ b/source/data/Collection.js
@@ -555,7 +555,7 @@
 				len != this.length && this.notify('length', len, this.length);
 				// notify listeners of the addition of records
 				if (added) {
-					this.emit('add', {models: added, collection: this});
+					this.emit('add', {models: added, collection: this, index: idx});
 				}
 			}
 			

--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -336,10 +336,8 @@
 			// if the list has not already reset, reset
 			if (!list.hasReset) return this.reset(list);
 			
-			var collection = list.collection,
-				
-				// we need the controls per page for simple arithmetic
-				cpp = this.controlsPerPage(list),
+			// we need the controls per page for simple arithmetic
+			var cpp = this.controlsPerPage(list),
 				pos = this.pagesByPosition(list),
 				first = pos.firstPage.start != null ? pos.firstPage.start : 0,
 				end = (cpp * 2) + (first - 1),
@@ -347,7 +345,7 @@
 				idx;
 			
 			// retrieve the first index for the first added model in the collection
-			idx = collection.indexOf(props.models[0]);
+			idx = props.index;
 			
 			// the only time we don't refresh is if the first index of the contiguous set of added
 			// models is beyond our final rendered page (possible) indices


### PR DESCRIPTION
## Issue

Whenever user removes models from collection, `refresh()` is executed.
## Cause

If removing models are placed in current pages, `refresh()` should be called.
To decide it, we use `indexOf()` to get the first position of models.
However when we call `indexOf()` in VerticalDelegates,js, models are already removed from collection
So conditional statement for deciding `refresh()` makes wrong judgement.
## Fix

Get target index before model is removed from collection.
And deliver index info with `remove` event

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
