### PR TITLE
BHV-11657: Make addBodyClass to see the length of enyo.roots to know whe...

### DIFF
--- a/source/dom/dom.js
+++ b/source/dom/dom.js
@@ -468,7 +468,7 @@
 		* @public
 		*/
 		addBodyClass: function(s) {
-			if (!enyo.exists(enyo.roots)) {
+			if (!enyo.exists(enyo.roots) || enyo.roots.length === 0) {
 				if (enyo.dom._bodyClasses) {
 					enyo.dom._bodyClasses.push(s);
 				} else {


### PR DESCRIPTION
...ther it is rendered.
### Issue

enyo-locale-right-to-left is not set on the body of apps.
### Fix

Latest commit is initializing roots as array which resulting return true on enyo.exists which is not intended result.
https://github.com/enyojs/enyo/commit/76e44bc3f1caf45fb060e7da16a62f1d500ede88
So, adding array length check on addBodyClass to address this problem.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
