### PR TITLE
Fix for: ENYO-22

### DIFF
--- a/source/data/Model.js
+++ b/source/data/Model.js
@@ -649,6 +649,9 @@
 					if (!silent) this.emit('change', changed, this);
 				
 					if (commit && !fetched) this.commit(opts);
+					
+					// reset value so subsequent changes won't be added to this change-set
+					this.changed = null;
 				}
 			}
 			


### PR DESCRIPTION
Changesets in _enyo.Model_ were being munged together inadvertently. Needed to reset the `changed` hash to keep this from happening.
