### PR TITLE
Bhv 5137 Add renderOnShow option

### DIFF
--- a/source/dom/Control.js
+++ b/source/dom/Control.js
@@ -143,7 +143,11 @@
 		*/
 		renderOnShow: false,
 		/**
-		* private
+		* When you make a control which renderOnShow is true visible,
+		* you should know where it placed.
+		* To resolve this matter, we remember the position
+		* when we traverse component hierachy to generate HTML
+		* @private
 		*/
 		renderOnShowQueue: [],
 		/**

--- a/source/dom/Control.js
+++ b/source/dom/Control.js
@@ -685,8 +685,16 @@
 
 			// if we are changing from not showing to showing we attempt to find whatever
 			// our last known value for display was or use the default
-			if (!was) this.applyStyle('display', this._display || '');
-
+			if (!was) {
+				this.applyStyle('display', this._display || '');
+				// If renderOnShow is true and generated is false then
+				// develper intended to make this control un-rendered 
+				// until there is a request to show
+				if (this.renderOnShow && !this.generated) {
+					this.setCanGenerate(true);
+					this.render();
+				}
+			}
 			// if we are supposed to be hiding the control then we need to cache our current
 			// display state
 			else if (!this.showing) {

--- a/source/dom/Control.js
+++ b/source/dom/Control.js
@@ -142,7 +142,10 @@
 		* @public
 		*/
 		renderOnShow: false,
-
+		/**
+		* private
+		*/
+		renderOnShowQueue: [],
 		/**
 		* @todo Find out how to document "handlers".
 		* @public

--- a/source/dom/Control.js
+++ b/source/dom/Control.js
@@ -136,6 +136,11 @@
 		content: '',
 
 		/**
+		* @public
+		*/
+		renderOnShow: false,
+
+		/**
 		* @todo Find out how to document "handlers".
 		* @public
 		*/
@@ -646,6 +651,13 @@
 			var delegate = this.renderDelegate || Control.renderDelegate;
 			delegate.invalidate(this, 'content');
 		},
+		/**
+		* @private
+		*/
+		renderOnShowChanged: function () {
+			if (!this.hasNode() && this.renderOnShow) this.showing = false;
+			this.setCanGenerate(!this.renderOnShow);
+		},
 
 		/**
 		* If the control has been generated, re-flows the control.
@@ -1030,6 +1042,7 @@
 				// setup the id for this control if we have one
 				this.idChanged();
 				this.contentChanged();
+				this.renderOnShowChanged();
 			};
 		}),
 

--- a/source/dom/Control.js
+++ b/source/dom/Control.js
@@ -1277,7 +1277,26 @@
 
 			return this;
 		},
-
+		/**
+			@public
+			@deprecated
+		*/
+		getRenderOnShow: function () {
+			return this.renderOnShow;
+		},
+		
+		/**
+			@public
+			@deprecated
+		*/
+		setRenderOnShow: function (can) {
+			var was = this.renderOnShow;
+			this.renderOnShow = can;
+			
+			if (was !== can) this.notify('renderOnShow', was, can);
+			
+			return this;
+		},
 		/**
 		* @deprecated
 		* @public

--- a/source/dom/Control.js
+++ b/source/dom/Control.js
@@ -136,6 +136,9 @@
 		content: '',
 
 		/**
+		* Due to performace matter, developer could delay rendering of Control
+		* until when it becomes visible.
+		* You may set this property to true to postpone rendering.
 		* @public
 		*/
 		renderOnShow: false,
@@ -652,6 +655,11 @@
 			delegate.invalidate(this, 'content');
 		},
 		/**
+		* If developer would like to delay rendering of control
+		* until it is required to be shown actually,
+		* set renderOnShow to true.
+		* It means that _canGenerate_ becomes false and will be true 
+		* when you set showing to true
 		* @private
 		*/
 		renderOnShowChanged: function () {

--- a/source/dom/delegates/HTMLStringDelegate.js
+++ b/source/dom/delegates/HTMLStringDelegate.js
@@ -128,9 +128,14 @@
 			var content,
 				html,
 				prevControl;
-
+				
+			// If previous control has enabled renderOnShow
+			// then renderOnShowQueue has an entity.
 			if (control.renderOnShowQueue.length) {
 				prevControl = control.renderOnShowQueue.pop();
+				// If prevControl and control are sibling
+				// then place prevControl before control
+				// If they are not sibling, just append prevControl to parent
 				if (prevControl.parent === control.parent) {
 					prevControl.addBefore = control;	
 				}				

--- a/source/dom/delegates/HTMLStringDelegate.js
+++ b/source/dom/delegates/HTMLStringDelegate.js
@@ -126,9 +126,20 @@
 		*/
 		generateHtml: function (control) {
 			var content,
-				html;
-			
-			if (control.canGenerate === false) {
+				html,
+				prevControl;
+
+			if (control.renderOnShowQueue.length) {
+				prevControl = control.renderOnShowQueue.pop();
+				if (prevControl.parent === control.parent) {
+					prevControl.addBefore = control;	
+				}				
+			}
+
+			if (control.canGenerate === false) {				
+				if (control.renderOnShow === true) {
+					control.renderOnShowQueue.push(control);
+				}
 				return '';
 			}
 			// do this first in case content generation affects outer html (styles or attributes)


### PR DESCRIPTION
Requested from HQ developers.

Issue
------
Due to performance matter, app developers would like to adjust rendering timing between render on creating and render on actual showing.

Cause
-------
enyo.Control does not have an option to delay rendering


Fix
----
Add renderOnShow option. If developer sets it true, 
automatically this control has showing:false and canGenerate: false
When we call setShowing(true) first time, it will start render.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com