### PR TITLE
Fix for: BHV-11232

### DIFF
--- a/source/dom/Control.js
+++ b/source/dom/Control.js
@@ -669,7 +669,7 @@
 			
 			// if we are supposed to be hiding the control then we need to cache our current
 			// display state
-			else if (!this.showing) {
+			else if (was && !this.showing) {
 				// we can't truly cache this because it _could_ potentially be set to multiple
 				// values throughout its lifecycle although that seems highly unlikely...
 				this._display = this.hasNode() ? this.node.style.display : '';


### PR DESCRIPTION
We need to coerce the showing property value to always be boolean and better sanity checking in the _showingChanged()_ handler.
