### PR TITLE
BHV-11927: Re-add fix for BHV-10727

### DIFF
--- a/source/touch/ScrollMath.js
+++ b/source/touch/ScrollMath.js
@@ -367,10 +367,10 @@
 					this.scroll();
 				} else if (!this.dragging) {
 					// set final values
-					if (enyo.exists(this.endX)) {
+					if (this.endX != null) {
 						this.x = this.x0 = this.endX;
 					}
-					if (enyo.exists(this.endY)) {
+					if (this.endY != null) {
 						this.y = this.y0 = this.endY;
 					}
 
@@ -378,8 +378,8 @@
 					this.scroll();
 					this.doScrollStop();
 
-					this.endX = undefined;
-					this.endY = undefined;
+					this.endX = null;
+					this.endY = null;
 				}
 				y0 = this.y;
 				x0 = this.x;


### PR DESCRIPTION
## Issue

Adjacent `moon.IntegerPicker` controls display misaligned values on the TV due to an incomplete animation state. This was originally fixed by https://github.com/enyojs/enyo/pull/772 and https://github.com/enyojs/enyo/pull/773 but the changes were lost.
## Fix

Re-adding the original fixes.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
