### PR TITLE
[Hotfix] 2.5.1-pre.1 hot fix on Async.js

### DIFF
--- a/source/ajax/Async.js
+++ b/source/ajax/Async.js
@@ -103,12 +103,12 @@
 			// we go ahead and bind the method to its context to preserve the original
 			// implementation
 			if (ctx) {
-                if (typeof ctx == "string") {
-                    enyo.bind(fn, ctx);
-                } else {
-                    fn = fn.bind(ctx);
-                }
-            }
+				if (typeof ctx == "string") {
+					enyo.bind(fn, ctx);
+				} else {
+					fn = fn.bind(ctx);
+				}
+			}
 			
 			// now store it for use later
 			array.push(fn);


### PR DESCRIPTION
### Issue

Accumulate is assuming first argument as a function and second argument as a context.
But, Luna send is calling response by sending first argument as an object and second argument as a string.
### Fix

Adding a check for second argument to cover the Luna send case.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
