### PR TITLE
ENYO-36: Add the ability to specify controlsPerPage in a DataList.

### DIFF
--- a/source/ui/data/DataList.js
+++ b/source/ui/data/DataList.js
@@ -23,6 +23,16 @@
 	*/
 
 	/**
+	* When this property is specified, we force the static usage of this value instead of 
+	* dynamically calculating the number of controls per page based upon the viewport size.
+	* 
+	* @name enyo.DataList#controlsPerPage
+	* @type {Number}
+	* @default undefined
+	* @public
+	*/
+
+	/**
 	* {@link enyo.DataList} is an {@link enyo.DataRepeater} that employs a paginated
 	* scrolling scheme to enhance performance with larger datasets. The data is provided to
 	* the DataList by an {@link enyo.Collection} set as the value of its
@@ -30,7 +40,7 @@
 	* 
 	* Note that care should be taken when deciding how to lay out the list's children. When
 	* there are a large number of child [elements]{@link enyo.Control}, the layout process
-	* can be taxing and non-performant for the browser. Avoid	dynamically-updated
+	* can be taxing and non-performant for the browser. Avoid dynamically-updated
 	* [layouts]{@glossary layout} that require lots of calculations each time the data in a
 	* view is updated. Try to use CSS whenever possible.
 	* 
@@ -206,10 +216,6 @@
 				this.metrics.pages = {};
 				if (this.pageSizeMultiplier !== null && !isNaN(this.pageSizeMultiplier)) {
 					this.pageSizeMultiplier = Math.max(1.2, this.pageSizeMultiplier);
-				}
-				// determine if the _controlsPerPage_ property has been set
-				if (this.controlsPerPage !== null && !isNaN(this.controlsPerPage)) {
-					this._staticControlsPerPage = true;
 				}
 			};
 		}),

--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -38,6 +38,10 @@
 			// this is a datalist...it has to be scroll or auto for vertical
 			so.vertical    = so.vertical == 'scroll'? 'scroll': 'auto';
 			so.horizontal  = so.horizontal || 'hidden';
+			// determine if the _controlsPerPage_ property has been set on the list
+			if (list.controlsPerPage !== null && !isNaN(list.controlsPerPage)) {
+				this._staticControlsPerPage = true;
+			}
 		},
 		
 		/**
@@ -230,7 +234,7 @@
 		* @private
 		*/
 		controlsPerPage: function (list) {
-			if (list._staticControlsPerPage) {
+			if (this._staticControlsPerPage) {
 				return list.controlsPerPage;
 			} else {
 				var updatedControls = list._updatedControlsPerPage,


### PR DESCRIPTION
## Issue

There does not exist a way to override the dynamically calculated `controlsPerPage` property for `enyo.DataList`.
## Fix

If a value for `controlsPerPage` is provided upon initialization, this value will be used and dynamic calculation will be bypassed.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
