### PR TITLE
BHV-12191: Fix bodyArgsFromParams to work with a null params

### DIFF
--- a/source/ajax/Jsonp.js
+++ b/source/ajax/Jsonp.js
@@ -205,7 +205,7 @@
 			if (enyo.isString(params)) {
 				return params.replace('=?', '=' + fn);
 			} else {
-				params = enyo.clone((params == null) ? {} : params, true);
+				params = params ? enyo.clone(params, true) : {};
 				if (this.callbackName) {
 					params[this.callbackName] = fn;
 				}


### PR DESCRIPTION
The params on bodyArgsFromParams can be a null.

In 2.5.0, mixin is used to clone the params. When params is null, it returns empty object.
In 2.5.1, clone is used but it is bypassing null.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
