### PR TITLE
ANG-12114: fix index of pages update rountine in VerticalDelegate.js

### DIFF
--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -73,6 +73,7 @@ enyo.DataList.delegates.vertical = {
 			secondIndex = list.$.page2.index;
 		if (firstIndex > pageCount) {
 			firstIndex = pageCount;
+			secondIndex = (firstIndex > 0) ? firstIndex - 1 : firstIndex + 1;
 		}
 		if (secondIndex > pageCount) {
 			if ((firstIndex + 1) > pageCount && (firstIndex - 1) >= 0) {


### PR DESCRIPTION
## Issue

Index of pages in DataList have a same value in certain case.
## Cause

refresh() function has a index setting routine according to pageCount value.
But they can not handle a condition like blew.
- refresh() function
  (firstIndex > pageCount && secondIndex > pageCount)  ==> OK
  (firstIndex > pageCount && secondIndex < pageCount)  ==> OK
  (firstIndex < pageCount && secondIndex > pageCount)  ==> Not Good(result : firstIndex == secondIndex)
  (firstIndex < pageCount && secondIndex < pageCount)  ==> OK
- modelsAdded() function
  (firstIndex === 1 && secondIndex === 0)  ==> Not Good(result : firstIndex = 1, secondIndex =1)
## Fix

Add one line which can handle those condition.

Enyo-DCO-1.1-Signed-off-by: Sungbae Cho sb.cho@lge.com
