### PR TITLE
BHV-12306: VideoPlayer does not unload video

### DIFF
--- a/source/ui/Video.js
+++ b/source/ui/Video.js
@@ -341,6 +341,18 @@
 		* @private
 		*/
 		updateSource: function (old, value, source) {
+			// We use a job here to avoid update source multiple
+			// times in succession on unload.
+			this.startJob('updateSource', function() {
+				this.updateSourceJob(old, value, source)
+			}, 10);
+		},
+
+		/**
+		* @method
+		* @private
+		*/
+		updateSourceJob: function(old, value, source) {
 			// if called due to a property change, clear the other property
 			if(source === 'src') {
 				this.sourceComponents = null;
@@ -367,6 +379,7 @@
 				node.load();
 			}
 		},
+
 		/**
 		* Adds `<source>` tags for each source specified in `this.sources`.
 		* 


### PR DESCRIPTION
### Issue:

When sourceComponents is set, can not unload video.
### Fix:

Set sourceComponents back to null when unload.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
