### PR TITLE
BHV-12273: fix index of pages update rountine in VerticalDelegate.js

### DIFF
--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -104,6 +104,7 @@
 				secondIndex = list.$.page2.index;
 			if (firstIndex > pageCount) {
 				firstIndex = pageCount;
+				secondIndex = (firstIndex > 0) ? firstIndex - 1 : firstIndex + 1;
 			}
 			if (secondIndex > pageCount) {
 				if ((firstIndex + 1) > pageCount && (firstIndex - 1) >= 0) {


### PR DESCRIPTION
## Issue

Index of pages in DataList have a same value in certain case.
## Cause

refresh() function has a index setting routine according to pageCount value.
But they can not handle a condition like blew.
- refresh() function

(firstIndex > pageCount && secondIndex > pageCount)  ==> OK
(firstIndex > pageCount && secondIndex < pageCount)  ==> OK
(firstIndex < pageCount && secondIndex > pageCount)  ==> Not Good(result : firstIndex == secondIndex)
(firstIndex < pageCount && secondIndex < pageCount)  ==> OK
## Fix

Add one line which can handle those condition.
(\* This fix is similar fix with https://github.com/enyojs/enyo/pull/818 - but his is for 2.5.1)

Enyo-DCO-1.1-Signed-off-by: Sungbae Cho sb.cho@lge.com
