### PR TITLE
ENYO-42: [Garnet] drag event occurs when multi touch

### DIFF
--- a/source/touch/touch.js
+++ b/source/touch/touch.js
@@ -44,6 +44,7 @@
 				this._touchCount += e.changedTouches.length;
 				this.excludedTarget = null;
 				var event = this.makeEvent(e);
+				//store the finger which generated the touchstart event
 				this.currentIdentifier = event.identifier;
 				gesture.down(event);
 				// generate a new event object since over is a different event
@@ -62,7 +63,11 @@
 				var de = gesture.drag.dragEvent;
 				this.excludedTarget = de && de.dragInfo && de.dragInfo.node;
 				var event = this.makeEvent(e);
-				if (this.currentIdentifier != event.identifier) return;
+				// do not generate the move event if this touch came from a different
+				// finger than the starting touch
+				if (this.currentIdentifier !== event.identifier) {
+					return;
+				}
 				gesture.move(event);
 				// prevent default document scrolling if enyo.bodyIsFitting == true
 				// avoid window scrolling by preventing default on this event


### PR DESCRIPTION
### Issue:

Gesture (drag) occurs when two fingers touch simultaneously.
Drag left to right is a gesture for finishing the app on all W2 apps, so it causes an unintentional App exit.
### Fix:

"identifier" is the property in the touch event which identifies the finger. Store the identifier value which generated the starting touch, and compare it to the event identifier in the touchmove event. Do not generate an enyo move event if the identifier values  do not match, i.e. if they came from different fingers.

Enyo-DCO-1.1-Signed-off-by: Krishna Rangarajan krishna.rangarajan@lge.com
