### PR TITLE
ENYO-99: Implement double-tap support

### DIFF
--- a/samples/GestureSample.js
+++ b/samples/GestureSample.js
@@ -5,8 +5,9 @@ enyo.kind({
 	components: [
 		{
 			classes:"gesture-sample-pad",
+			name: "gestureSamplePad",
 			fit:true,
-			doubleTapEnabled: true,
+			doubleTapEnabled: false,
 			ondown: "handleEvent",
 			onup: "handleEvent",
 			ontap: "handleEvent",
@@ -25,8 +26,8 @@ enyo.kind({
 			ongestureend: "handleEvent",
 			ondoubletap: "handleEvent",
 			components: [
-				{content: "Perform gestures here"},
-				{classes: "gesture-sample-note", content:"(tap below for options)"}
+				{content: "Perform gestures here", style: "pointer-events: none;"},
+				{classes: "gesture-sample-note", content:"(tap below for options)", style: "pointer-events: none;"}
 			]
 		},
 		{kind: "onyx.Groupbox", ontap:"toggleSettings", components: [
@@ -41,6 +42,10 @@ enyo.kind({
 				{classes:"gesture-sample-setting", components: [
 					{content:"Truncate detail on small screen: "},
 					{name:"truncateDetail", onchange:"truncateChanged", ontap:"preventDefault", kind:"onyx.Checkbox", checked:true}
+				]},
+				{classes:"gesture-sample-setting", components: [
+					{content:"Enable Double Tap: "},
+					{name:"enableDoubleTap", onchange:"doubleTapChanged", ontap:"preventDefault", kind:"onyx.Checkbox", checked:false}
 				]},
 				{classes:"gesture-sample-setting", style:"min-height:40px;", components: [
 					{content:"Monitor event: "},
@@ -58,7 +63,7 @@ enyo.kind({
 		this.eventCount = 0;
 		enyo.forEach(
 			["All events","down","up","tap","move","enter","leave","dragstart","drag","dragover","hold","release",
-				"holdpulse","flick","gesturestart","gesturechange","gestureend"],
+				"holdpulse","flick","gesturestart","gesturechange","gestureend","doubletap"],
 			this.bindSafely(function(event) {
 				this.$.eventPicker.createComponent({content:event, style:"text-align:left"});
 			}));
@@ -92,6 +97,9 @@ enyo.kind({
 		}
 		this.reflow();
 		return false;
+	},
+	doubleTapChanged: function() {
+		this.$.gestureSamplePad.doubleTapEnabled = this.$.enableDoubleTap.checked;
 	},
 	removeEvent: function(inSender, inEvent) {
 		this.eventCount--;

--- a/source/dom/Control.js
+++ b/source/dom/Control.js
@@ -142,7 +142,7 @@
 		* @default false
 		* @public
 		*/
-		doubleTapEnabled: 'false',
+		doubleTapEnabled: false,
 
 		/**
 		* @todo Find out how to document "handlers".


### PR DESCRIPTION
### Issue:

We don't have double tap support in Enyo (and generally don't think double-tap is a good UX pattern), but Garnet UX requires it for W2.
Needs to be implemented purely at JavaScript level (no WebKit support).
### Fix:

Before sending a tap event, check for doubleTapEnabled. If yes, set a Timeout. If another tap comes before timeout expires, send a double tap event. If timeout fires, send a tap event

Enyo-DCO-1.1-Signed-off-by: Krishna Rangarajan krishna.rangarajan@lge.com
