### PR TITLE
Enyo-56: change DataRepeater to be able to catch event from it's items

### DIFF
--- a/source/kernel/Component.js
+++ b/source/kernel/Component.js
@@ -678,7 +678,7 @@
 				}
 
 				// first, handle any delegated events intended for this object
-				if (delegate && delegate.owner === this) {
+				if (delegate) {
 					// the most likely case is that we have a method to handle this
 					if (this[nom] && 'function' === typeof this[nom]) {
 						return this.dispatch(nom, event, sender);


### PR DESCRIPTION
## Issue

DataRepeater loses ontap events(even all of events)
## Cause

Usally, owner of DataRepeater items aren't DataRepeater, owner of DataRepeater items are same with DataRepeater's owner. And owner of components in the item is just the item.  
As a fix for an issue(http://jira2.lgsvl.com/browse/GF-35208), comparison code is inserted in dispatchEvent function. That code are checking whether event originator's owner is same with this or not.  
After that fix, events from the components in the item can not handled properly
## Fix

Unlike the 2.3.0-rc, getBubbleTarget function in 2.5.0 are checking event.delegate and returing owner directly(it can solve previous issue - http://jira2.lgsvl.com/browse/GF-35208)
So, I removed owner of comparison line to be able to handle event which is from the item

Enyo-DCO-1.1-Signed-off-by: Sungbae Cho sb.cho@lge.com
