### PR TITLE
BHV-12661: update delegated fucntion handle routine

### DIFF
--- a/source/kernel/Component.js
+++ b/source/kernel/Component.js
@@ -690,7 +690,7 @@
 				// for non-delgated events, try the handlers block if possible
 				if (!delegate) {
 					var bHandler = this.handlers && this.handlers[nom];
-					var bDelegatedFunction = enyo.isString(this[nom]);
+					var bDelegatedFunction = this[nom] && enyo.isString(this[nom]);
 					var cachePoint = this.cachePoint || bHandler || bDelegatedFunction || this.id === "master" ;
 
 					if (event.bubbling) {


### PR DESCRIPTION
## Issue

Improper delegated function is handled in dispatchEvent fuction
## Cause

In many cases, this[nom] can be "" in dispatchEvent function.
Now current rouine finally makes bubbleUp event in this condition
## Fix

Add one more conditional statement that can catch a condition which is ' this[nom] == "" ' so that don't makes bubbleUp event.
