### PR TITLE
find and findIndex where enumerable

### DIFF
--- a/source/kernel/lang.js
+++ b/source/kernel/lang.js
@@ -1007,22 +1007,21 @@
 	* A [polyfill]{@glossary polyfill} for platforms that don't support
 	* [Array.findIndex()]{@glossary Array.findIndex}.
 	*/
-	Array.prototype.findIndex = Array.prototype.findIndex || function (fn, ctx) {
-		for (var i=0, len=this.length >>> 0; i<len; ++i) {
-			if (fn.call(ctx, this[i], i, this)) return i;
-		}
-		return -1;
-	};
+	if (!Array.prototype.findIndex)
+          Object.defineProperty(Array.prototype, 'findIndex',{enumerable:false, value : function (fn, ctx) {
+            for (var i=0, len=this.length >>> 0; i<len; ++i) if (fn.call(ctx, this[i], i, this)) return i;
+            return -1;
+          } });
+	
 	
 	/**
 	* A [polyfill]{@glossary polyfill} for platforms that don't support
 	* [Array.find()]{@glossary Array.find}.
 	*/
-	Array.prototype.find = Array.prototype.find || function (fn, ctx) {
-		for (var i=0, len=this.length >>> 0; i<len; ++i) {
-			if (fn.call(ctx, this[i], i, this)) return this[i];
-		}
-	};
+        if(!Array.prototype.find)
+          Object.defineProperty(Array.prototype, 'find', {enumerable:false, value: function (fn, ctx) {
+            for (var i=0, len=this.length >>> 0; i<len; ++i) if (fn.call(ctx, this[i], i, this)) return this[i];
+          } });
 	
 	/**
 	* A [polyfill]{@glossary polyfill} for platforms that don't support


### PR DESCRIPTION
setting the functions as enumerable false on the prototype
this way "for(var i in bla)" works again.
Otherwise it would also enumerate over these functions.
I didn't only break my code but also included frameworks code.
