### PR TITLE
ENYO-112: Apply TranslateScrollStrategy on Android 4.3 or higher

### DIFF
--- a/source/touch/Scroller.js
+++ b/source/touch/Scroller.js
@@ -314,7 +314,7 @@
 				return true;
 			},
 			getTouchStrategy: function() {
-				return (enyo.platform.android >= 3) || (enyo.platform.windowsPhone === 8) || (enyo.platform.webos >= 4)
+				return (enyo.platform.androidChrome >= 27) || (enyo.platform.android >= 3) || (enyo.platform.windowsPhone === 8) || (enyo.platform.webos >= 4)
 					? 'TranslateScrollStrategy'
 					: 'TouchScrollStrategy';
 			}


### PR DESCRIPTION
## Issue

TouchScrollStrategy is applied on Android 4.3 or higher, not TranslateScrollStrategy
## Cause

UserAgnet string is chagned from WebView of Android 4.3
Enyo Platform name is as following
~ Android 4.2 (JellyBean) : enyo.platform.android = 4
Android 4.3 (JellyBean) : enyo.platform.androidChrome = 27
Android 4.4 (Kitkat) : enyo.platform.androidChrome = 30 
## Fix

Add condition (enyo.platform.androidChrome >= 2) to getTouchStargety function

Enyo-DCO-1.1-Signed-off-by: Seungho Park seunghoh.park@lge.com
