### PR TITLE
Fix for: ENYO-148

### DIFF
--- a/source/touch/ScrollMath.js
+++ b/source/touch/ScrollMath.js
@@ -546,6 +546,7 @@
 		* @private
 		*/
 		scrollTo: function (x, y) {
+			if (x == this.x && y == this.y) return;
 			if (y !== null) {
 				this.endY = -y;
 				this.y = this.y0 - (y + this.y0) * (1 - this.kFrictionDamping);
@@ -554,7 +555,6 @@
 				this.endX = -x;
 				this.x = this.x0 - (x + this.x0) * (1 - this.kFrictionDamping);
 			}
-			if (x == this.x && y == this.y) return;
 			this.start();
 		},
 


### PR DESCRIPTION
Problem: Change in ScrollMath causes initial scroll to jolt back to 0,0 on first move.

Fix: Ensure it will not improperly set the endX,endY values when exiting early because the values match.

Enyo-DCO-1.1-Signed-Off-By: Cole Davis (cole.davis@lge.com)
