### PR TITLE
Except ios platform, adding enyo-clip on body.

### DIFF
--- a/source/dom/dom.js
+++ b/source/dom/dom.js
@@ -160,6 +160,11 @@
 				this.addClass(h, 'enyo-document-fit');
 			}
 			enyo.dom.addBodyClass('enyo-body-fit');
+			if (!enyo.platform.ios) {
+				// Defeat native scroller by clip on body.
+				// In ios, leave overflow as auto beacuse it helps defeat ios page scrolling.
+				enyo.dom.addBodyClass("enyo-clip");
+			}
 			enyo.bodyIsFitting = true;
 		},
 


### PR DESCRIPTION
Referencing https://github.com/enyojs/enyo/commit/63033dc0bd32169d4fcb5db2e181a0ecc2c17047

Problem:
When popup is showing with animation, popup is created in offscreen area and fly into the screen.
The scroll bar is often remains after finishing animation and this makes screen scrollable by mouse wheel.
In this case, whole screen content can be scroll up.

Solution:
Applying overflow: hidden on body can suppress this behavior.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
