### PR TITLE
Fixes ENYO-147

### DIFF
--- a/source/ui/Popup.js
+++ b/source/ui/Popup.js
@@ -281,6 +281,23 @@
 				sup.apply(this, arguments);
 			};
 		}),
+		
+		/**
+		* @method
+		* @private
+		*/
+		teardownRender: enyo.inherit(function (sup) {
+			return function () {
+				// if this is a rendered floating popup, remove the node from the
+				// floating layer because it won't be removed otherwise
+				var node = this.hasNode();
+				if(this.floating && node) {
+					this.node.remove();
+				}
+
+				sup.apply(this, arguments);	
+			};
+		}),
 
 		/**
 		* @method


### PR DESCRIPTION
## Issue

Re-rendering a component that owns a floating Popup will cause another DOM node to be created in the floating layer.
## Fix

Remove the floating Popup's node from the floating layer on teardown.

Enyo-DCO-Signed-off-by: Ryan Duffy ryan.duffy@lge.com
