### PR TITLE
ENYO-4067: Center floating popup relative to full viewport.

### DIFF
--- a/source/ui/Popup.js
+++ b/source/ui/Popup.js
@@ -411,7 +411,7 @@
 				// 'initial' values are necessary to override positioning rules in the CSS
 				this.addStyles('left: ' + (p.left !== null ? p.left + 'px' : 'initial') + '; right: ' + (p.right !== null ? p.right + 'px' : 'initial') + '; top: ' + (p.top !== null ? p.top + 'px' : 'initial') + '; bottom: ' + (p.bottom !== null ? p.bottom + 'px' : 'initial') + ';');
 			} else if (this.centered) {
-				var o = this.getInstanceOwner().getBounds();
+				var o = this.floating ? d : this.getInstanceOwner().getBounds();
 				this.addStyles( 'top: ' + Math.max( ( ( o.height - b.height ) / 2 ), 0 ) + 'px; left: ' + Math.max( ( ( o.width - b.width ) / 2 ), 0 ) + 'px;' );
 			}
 		},


### PR DESCRIPTION
## Issue

Floating popups that have `centered:true` set are centered relative to their instance owner instead of the full viewport.
## Fix

Position centered, floating popups relative to the full viewport, otherwise position relative to instance owner.
## Note

This is a bit of a simplification as the purpose of floating a popup is to ensure that it appears above other content, rather than necessarily being tied to the whole viewport, but it seems to be complementary and is in lieu of adding another property. We could alternatively add another property to specify the element which to relatively center against.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
