### PR TITLE
Exception occurred in Group control

### DIFF
--- a/source/ui/Group.js
+++ b/source/ui/Group.js
@@ -141,7 +141,7 @@
 		* @private
 		*/
 		activeChanged: function (was) {
-			if (was) {
+			if (was && !was.destroyed) {
 				was.setActive(false);
 				was.removeClass('active');
 			}


### PR DESCRIPTION
Issue:
When components are destroyed dynamically in side a group control,
exception observed inside the activeChanged function.

Fix:
checking whether the component is destroyed or not.

Enyo-DCO-1.1-Signed-off-by: Srinivas V srinivas.v@lge.com
