### PR TITLE
fix zIndex (had problems in firefox)

### DIFF
--- a/source/ui/Popup.js
+++ b/source/ui/Popup.js
@@ -695,7 +695,7 @@
 				enyo.Popup.highestZ = this._zIndex;
 			}
 			// leave room for scrim
-			this.applyStyle('z-index', this._zIndex);
+			this.applyStyle('zIndex', this._zIndex);
 		},
 
 		/**


### PR DESCRIPTION
Changed 'z-index' to 'zIndex' since applyStyle uses node.stylep[prop] we need to use the js style names.
Didn't look further into it but without the change I had problems in firefox, not chrome,.. strange but now fixed for firefox too.
