### PR TITLE
Fix for: ENYO-193

### DIFF
--- a/source/ui/data/DataList.js
+++ b/source/ui/data/DataList.js
@@ -476,7 +476,9 @@
 		* @private
 		*/
 		childForIndex: function (i) {
-			return this.delegate.childForIndex(this, i);
+			if (this.generated) {
+				return this.delegate.childForIndex(this, i);
+			}
 		},
 		
 		/**


### PR DESCRIPTION
Properly guard calls to this method that occur prior to having been generated. If this is not guarded, it will throw an exception.

Enyo-DCO-1.1-Signed-Off-By: Cole Davis (cole.davis@lge.com)
