### PR TITLE
ENYO-113: Support non-standard locations for enyo, libs

### DIFF
--- a/tools/deploy.js
+++ b/tools/deploy.js
@@ -105,12 +105,13 @@ var node = process.argv[0],
 	less = true, // LESS compilation, turned on by default
 	verbose = false,
 	beautify = false,
-	noexec = false;
+	noexec = false,
+	gather = true;
 
 function printUsage() {
 	// format generated using node-optimist...
 	console.log('\n' +
-		'Usage: ' + node + ' ' + deploy + ' [-c][-e enyo_dir][-l lib_dir][-b build_dir][-o out_dir][-p package_js][-s source_dir][-f map_from -t map_to ...]\n' +
+		'Usage: ' + node + ' ' + deploy + ' [-c][-g][-v][-B][-e enyo_dir][-l lib_dir][-b build_dir][-o out_dir][-p package_js][-s source_dir][-f map_from -t map_to ...]\n' +
 		'\n' +
 		'Options:\n' +
 		'  -v  verbose operation                     [boolean]  [default: ' + verbose + ']\n' +
@@ -121,7 +122,8 @@ function printUsage() {
 		'  -o  alternate output directory            [default: "PWD/deploy/APPNAME"]\n' +
 		'  -p  main package.js file (relative)       [default: "./package.js"]\n' +
 		'  -s  source code root directory            [default: "PWD"]\n' +
-		'  -B  pretty-print (beautify) JS output     [default: "' + beautify + '"]\n' +
+		'  -B  pretty-print (beautify) JS output     [boolean]  [default: ' + beautify + ']\n' +
+		'  -g  gather libs to default location       [boolean]  [default: ' + gather + ']\n' +
 		'  -f  remote source mapping: from local path\n' +
 		'  -t  remote source mapping: to remote path\n' +
 		'  -E|--noexec disallow execution of application-provided scripts [default: false]\n' +
@@ -143,7 +145,8 @@ var opt = nopt(/*knownOpts*/ {
 	"noexec": Boolean,
 	"test": Boolean,
 	"mapfrom": [String, Array],
-	"mapto": [String, Array]
+	"mapto": [String, Array],
+	"gather": Boolean
 }, /*shortHands*/ {
 	"b": "--build",
 	"c": "--no-less",
@@ -159,7 +162,8 @@ var opt = nopt(/*knownOpts*/ {
 	"t": "--mapto",
 	"E": "--noexec",
 	"T": "--test",
-	"?": "--help"
+	"?": "--help",
+	"g": "--gather"
 }, process.argv /*args*/, 2 /*slice*/);
 
 var log = function() {};
@@ -199,7 +203,7 @@ if (fs.existsSync("deploy.json")) {
 } else {
 	manifest = {
 		_default: true
-	};	
+	};
 }
 
 opt.packagejs = opt.packagejs || manifest.packagejs || "package.js";
@@ -213,6 +217,7 @@ opt.enyo = opt.enyo || manifest.enyo || "enyo"; // from top-level folder
 log("opt:", opt);
 
 less = (opt.less !== false) && less;
+gather = (opt.gather !== false) && gather;
 beautify = opt.beautify;
 noexec = opt.noexec;
 verbose = opt.verbose;
@@ -234,6 +239,7 @@ log("Using: opt.test=" + opt.test);
 log("Using: less=" + less);
 log("Using: beautify=" + beautify);
 log("Using: noexec=" + noexec);
+log("Using: gather=" + gather);
 
 // utils
 
@@ -297,6 +303,9 @@ if (opt.lib) {
 	// LIBPATH, from the top-level package.js
 	args.push("-lib", path.join(rootFolder, opt.lib));
 }
+if (gather) {
+	args.push("-gathering");
+}
 run(args);
 
 // Deploy / Copy
@@ -333,15 +342,16 @@ if (opt.test) {
 	shell.cp('-r', path.join(opt.out, opt.build), ".");
 }
 
-function deployDir(subDir) {
+function deployDir(subDir, dstSubDir) {
 	log("Deploying '" + subDir + "'...");
 	var dj = path.join(subDir, "deploy.json");
 	if (fs.existsSync(dj)) {
 		try {
 			var manifest = JSON.parse(fs.readFileSync(dj));
+			dstSubDir = dstSubDir || subDir;
 			if (Array.isArray(manifest.assets)) {
 				manifest.assets.forEach(function(asset) {
-					var dstAssetDir = path.dirname(path.join(opt.out, subDir, asset));
+					var dstAssetDir = path.dirname(path.join(opt.out, dstSubDir, asset));
 					log("% mkdir -p " + dstAssetDir);
 					shell.mkdir('-p', dstAssetDir);
 					log("% cp -r " + path.join(subDir, asset) + "...");
@@ -350,7 +360,8 @@ function deployDir(subDir) {
 			}
 			if (Array.isArray(manifest.libs)) {
 				manifest.libs.forEach(function(libDir) {
-					deployDir(path.join(subDir, libDir));
+					var libDst = gather ? path.join(subDir, "lib", path.basename(libDir)) : undefined;
+					deployDir(path.join(subDir, libDir), libDst);
 				});
 			}
 		} catch(e) {

--- a/tools/minifier/minify.js
+++ b/tools/minifier/minify.js
@@ -11,6 +11,8 @@
 	var basename = path.basename(__filename),
 		w = console.log,
 		e = console.error,
+		defaultEnyoLoc = "enyo",
+		defaultLibLoc = "lib",
 		opt;
 
 	// Shimming path.relative with 0.8.8's version if it doesn't exist
@@ -32,6 +34,7 @@
 		w("-beautify:", "Output pretty version that's less compressed but has code on separate lines");
 		w("-f", "Remote source mapping: from local path");
 		w("-t", "Remote source mapping: to remote path");
+		w("-gathering:", "Gathering libs to default location, so rewrite urls accordingly");
 		w("-h, -?, -help:", "Show this message");
 	}
 
@@ -60,13 +63,19 @@
 					return "url('" + urlPath + "')";
 				}
 
+				// if we are gathering libs to default location, rewrite urls beneath lib folder
+				var dstSheet = (opt.gathering && sheet.indexOf(opt.lib) == 0) ?
+					defaultLibLoc + sheet.substr(opt.lib.length) :
+					sheet;
+
 				// Make relative asset path from 'top-of-the-tree/build'
-				var relPath = path.join("..", opt.relsrcdir, path.dirname(sheet), urlPath);
+				var relPath = path.join("..", opt.relsrcdir, path.dirname(dstSheet), urlPath);
 				if (process.platform == "win32") {
 					relPath = pathSplit(relPath).join("/");
 				}
 				console.log("opt.relsrcdir:", opt.relsrcdir);
 				console.log("sheet:", sheet);
+				console.log("dstSheet:", dstSheet);
 				console.log("urlPath:", urlPath);
 				console.log("relPath:", relPath);
 				return "url('" + relPath + "')";
@@ -214,7 +223,8 @@
 		"help": Boolean,
 		"beautify": Boolean,
 		"mapfrom": [String, Array],
-		"mapto": [String, Array]
+		"mapto": [String, Array],
+		"gathering": Boolean
 	};
 
 	var shortHands = {
@@ -276,8 +286,13 @@
 		throw new Error("-output must be a relative path prefix");
 	}
 
+	opt.enyo = opt.enyo || defaultEnyoLoc;
+
+	opt.lib = opt.lib || path.join(opt.enyo, "../lib");
+	opt.gathering = opt.gathering && (opt.lib != defaultLibLoc);
+
 	w(opt);
-	walker.init(opt.enyo, opt.lib || opt.enyo + "/../lib", opt.mapfrom, opt.mapto);
+	walker.init(opt.enyo, opt.lib, opt.mapfrom, opt.mapto);
 	walker.walk(path.basename(opt.packagejs), walkerFinished);
 
 })();


### PR DESCRIPTION
Garnet and Sunstone are using a slightly different bootplate
structure, with enyo and the libs one level up from the app
source code.

Adding "gather" support to deploy.js and minify.js to gather
lib assets up into the default location during deployment
(and rewrite url paths in CSS files accordingly).

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
