### PR TITLE
ENYO-113: Making "gathering" feature more robust

### DIFF
--- a/tools/minifier/minify.js
+++ b/tools/minifier/minify.js
@@ -48,6 +48,9 @@
 		w("");
 		var blob = "";
 		var addToBlob = function(sheet, code) {
+			// for the "gathering" feature, we need to determine whether this sheet lives
+			// inside a lib directory; normalizing the path makes it easier to check, below
+			sheet = path.normalize(sheet);
 			// fix url paths
 			code = code.replace(/url\([^)]*\)/g, function(inMatch) {
 				// find the url path, ignore quotes in url string


### PR DESCRIPTION
The first pass at this feature didn't work for libraries that
were included in package.js via relative paths (e.g. ../lib)
rather than using the $lib shorthand. We now normalize the
path to each CSS sheet during minification so that the path
looks the same regardless of whether $lib is used or not.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
