### PR TITLE
BHV-14565: add payload checking code in cached bubbling routine

### DIFF
--- a/source/kernel/Component.js
+++ b/source/kernel/Component.js
@@ -694,7 +694,7 @@
 					var cachePoint = this.cachePoint || bHandler || bDelegatedFunction || this.id === "master" ;
 
 					if (event.bubbling) {
-						if (event.lastHandledComponent && cachePoint) {
+						if (event.lastHandledComponent && cachePoint && !event.payload) {
 							event.lastHandledComponent.cachedBubbleTarget[nom] = this;
 							event.lastHandledComponent = null;
 						}
@@ -1143,6 +1143,8 @@
 				var e = payload;
 				if (!e) {
 					e = {};
+				} else {
+					e.payload = true;
 				}
 				var d = e.delegate;
 				// delete payload.delegate;
@@ -1153,6 +1155,9 @@
 				this.bubble(nom, e);
 				if (d) {
 					e.delegate = d;
+				}
+				if (e.payload) {
+					e.payload = null;
 				}
 			};
 			// NOTE: Mark this function as a generated event handler to allow us to


### PR DESCRIPTION
## Issue

Newly genearated event during the event bubbing often makes maxium call stack error.
## Cause
1. Newly generated event during the event bubbling makes another bubbling
2. If the generated event bubble with the event which is bubbling(as a parameter), generated event name(nom) is changed but actual event is not changed.
3. During the generated event bubbling, event caching routine save unnecessary lastHandledComponent information and cachedBubbleTarget. 
4. After finishing the generated event bubbling, original event bubble up again but improper cachedBubbleTarget information makes abnormal cyclic bubbling.
## Fix

Add payload flag when new event is generated and makes event cache routine to check that flag.

Enyo-DCO-1.1-Signed-Off-By: Sungbae Cho (sb.cho@lge.com)
