### PR TITLE
ENYO-262: Bubble the correct payload in do<Event>() methods

### DIFF
--- a/source/kernel/Component.js
+++ b/source/kernel/Component.js
@@ -1138,9 +1138,8 @@
 		}
 		proto[nom] = v;
 		if (!proto[fn]) {
-			proto[fn] = function(payload) {
+			proto[fn] = function(sender, e) {
 				// bubble this event
-				var e = payload;
 				if (!e) {
 					e = {};
 				}


### PR DESCRIPTION
The automatically generated do<Event>() methods have been bubbling
the wrong payload – the the component itself instead of the event
object.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
