### PR TITLE
Fix for: ENYO-262

### DIFF
--- a/source/kernel/Component.js
+++ b/source/kernel/Component.js
@@ -1138,9 +1138,14 @@
 		}
 		proto[nom] = v;
 		if (!proto[fn]) {
-			proto[fn] = function(payload) {
+			proto[fn] = function(payload, other) {
 				// bubble this event
-				var e = payload;
+				
+				// if the second parameter exists then we use that - this is for a single case
+				// where a named event delegates happent to point to an auto generated event
+				// bubbler like this one - in that case the first parameter is actually the
+				// sender
+				var e = other || payload;
 				if (!e) {
 					e = {};
 				}
@@ -1155,9 +1160,6 @@
 					e.delegate = d;
 				}
 			};
-			// NOTE: Mark this function as a generated event handler to allow us to
-			// do event chaining. Is this too complicated?
-			//proto[fn]._dispatcher = true;
 		}
 	};
 


### PR DESCRIPTION
# Issue

When components add a named delegate method for an event and that happens to be an auto-generated event sender from the owner's `events` block, it does not pass the correct parameters. Most method dispatchers pass the _sender_ as the first parameter but the auto generated methods only accept an _event_ (object) parameter.
# Fix

Simply check to see if the dispatch function is of that form in the quickest, least-intrusive way possible. We do not want to decorate the methods since it is not necessary in this case.
