### PR TITLE
ENYO-255: Re-implement legacy setCount method.

### DIFF
--- a/source/ui/Repeater.js
+++ b/source/ui/Repeater.js
@@ -158,6 +158,18 @@
 		renderRow: function (idx) {
 			var c = this.itemAtIndex(idx);
 			this.doSetupItem({index: idx, item: c});
+		},
+
+		/**
+		* A legacy method that sets the number of items to be repeated and effectively forces a 
+		* rebuild of the [repeater]{@link enyo.Repeater}, regardless of whether or not the count has
+		* changed.
+		*
+		* @param {Number} count - The number of items to be repeated.
+		* @public
+		*/
+		setCount: function (count) {
+			this.set('count', count, {force: true});
 		}
 	});
 


### PR DESCRIPTION
### Issue

The `setCount` method was removed during a code cleanup, but is still used by apps prior to 2.4.0.
### Fix

We re-implement the `setCount` method to provide legacy support.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
