### PR TITLE
BHV-6022-fix: Change remapping files/folders to work fine

### DIFF
--- a/tools/minifier/node_modules/walker.js
+++ b/tools/minifier/node_modules/walker.js
@@ -62,7 +62,7 @@ module.exports = {
 			}
 		});
 		loader.loadPackage = function(inScript) {
-			if (!checkMapping(inScript)) {
+			if (!checkMapping(inScript, true)) {
 				script(inScript);
 			}
 		};


### PR DESCRIPTION
Tested on OSX

Problem
- filed in https://github.com/enyojs/enyo/commit/dd96f393b136c39d5ef811b1473978138a67dde3

fixed an invalid checkMapping() function call  
- pass `true` argument to `checkMapping()` so that enyo's deploying step can remap files/folders properly.

Enyo-DCO-1.1-Signed-off-by Junil Kim logyourself@gmail.com
