### PR TITLE
Fix for: ENYO-272

### DIFF
--- a/source/kernel/Router.js
+++ b/source/kernel/Router.js
@@ -501,14 +501,20 @@
 		*/
 		_execHandler: function (context, handler, args, route) {
 			var $fn = handler;
-			var $ctx = 'string' === typeof context? enyo.getPath.call(this, context): context || this;
-			// if the handler is defined as a string, we need to determine if
-			// it is relative to the router, relative to the context, or a named
-			// function in the global scope
+			var $ctx = 'string' === typeof context? enyo.getPath.call(this, context): context;
+			// if the handler is defined as a string, we need to determine if it is relative to the
+			// router, relative to the owner, relative to the context, or a named function in the
+			// global scope
 			if ('string' === typeof handler) {
-				// first check to see if the handler is a named property
-				// on the router; otherwise, try the context itself
-				$fn = this[handler] || $ctx[handler];
+				if (typeof this[handler] === 'function') {
+					$fn = this[handler];
+					$ctx = $ctx || this;
+				} else if (typeof this.owner[handler] === 'function') {
+					$fn = this.owner[handler];
+					$ctx = $ctx || this.owner;
+				} else if (typeof $ctx[handler] === 'function') {
+					$fn = $ctx[handler];
+				}
 				if ('function' === typeof $fn) {
 					// in case we actually found it, let's not go hunting
 					// next time


### PR DESCRIPTION
# Issue

When a router is declared in a components block it does not check the owner for handler methods from declared routes. This behavior differs from normal component behavior and forces the developer to subclass the router unnecessarily to add routes.
# Fix

Ensure that it checks all available contexts including the instance owner of the router.
