### PR TITLE
ENYO-271: Fix DataList refresh after models removed while hidden

### DIFF
--- a/source/ui/data/DataList.js
+++ b/source/ui/data/DataList.js
@@ -358,9 +358,7 @@
 				if (this.get('absoluteShowing')) {
 					this.delegate.modelsAdded(this, props);
 				} else {
-					this._addToShowingQueue('refresh', function () {
-						this.refresh();
-					});
+					this._addToShowingQueue('refresh', this.refresh);
 				}
 			}
 		},
@@ -369,20 +367,16 @@
 		*
 		* @private
 		*/
-		modelsRemoved: enyo.inherit(function (sup) {
-			return function modelsRemoved(c, e, props) {
-				if (c === this.collection && this.$.scroller.canGenerate) {
-					if (this.get('absoluteShowing')) {
-						this.delegate.modelsRemoved(this, props);
-						this.deselectRemovedModels(props.models);
-					} else {
-						this._addToShowingQueue('refresh', function () {
-							sup.apply(this, arguments);
-						});
-					}
+		modelsRemoved: function (c, e, props) {
+			if (c === this.collection && this.$.scroller.canGenerate) {
+				this.deselectRemovedModels(props.models);
+				if (this.get('absoluteShowing')) {
+					this.delegate.modelsRemoved(this, props);
+				} else {
+					this._addToShowingQueue('refresh', this.refresh);
 				}
-			};
-		}),
+			}
+		},
 
 		/**
 		* @method


### PR DESCRIPTION
# Issue

DataList doesn't refresh immediately if models are removed from its
collection when it's hidden; instead, it waits until it's shown
to refresh. However, due to a recent regression, this refresh was
not working properly (because arguments weren't being passed as
expected to an inherited method, due to a scope issue).

In addition, there was a separate issue. After models are removed
from a list's collection, we have to update the list's selection
state in case any of the removed models happen to have been
selected at the time of their removal. Previously, this selection-
state update  was being deferred along with the list's DOM refresh,
but this didn't work properly in the case where models were removed
in multiple "batches" during the time the list was hidden, because
only the last set of removed models was checked.
# Fix

To fix both of these issues, we now perform the selection-state
update immediately and defer only the DOM refresh. Because we're
doing this, we no longer need to call the inherited method at
all (so didn't need to directly address the scope issue mentioned
above).

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
