### PR TITLE
Fix for: ENYO-276 (external ENYO-4076)

### DIFF
--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -565,7 +565,7 @@
 			if (lastIdx >= count) {
 				threshold[lowerProp] = undefined;
 			} else {
-				threshold[lowerProp] = (metrics[lastIdx][lowerProp] - fn(list) - this.childSize(list));
+				threshold[lowerProp] = (metrics[lastIdx][lowerProp] - fn.call(this, list) - this.childSize(list));
 			}
 			if (list.usingScrollListener) {
 				list.$.scroller.setScrollThreshold(threshold);


### PR DESCRIPTION
ENYO-4076: VerticalDelegate controlsPerPage executes sizeProp function in wrong scope

`enyo.DataList.delegates.vertical.controlsPerPage` contains the following line of code:

``` javascript
perPage = list.controlsPerPage = Math.ceil(((fn(list) * multi) / childSize) + 1);
```

Note the `fn` variable, it references the width or height methods on the delegate, but it gets executed globally. However, the methods it references seem designed to be executed within the delegate's scope.

The same thing happens further down the file in `enyo.DataList.delegates.vertical.setScrollThreshold`.
