### PR TITLE
ENYO-4077: Resetting unrendered DataList attempts to access nonexistent boundsCache

### DIFF
--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -642,7 +642,7 @@
 		*/
 		height: function (list) {
 			if (list._updateBounds) { this.updateBounds(list); }
-			return list.boundsCache.height;
+			return list.boundsCache ? list.boundsCache.height : undefined;
 		},
 
 		/**
@@ -653,7 +653,7 @@
 		*/
 		width: function (list) {
 			if (list._updateBounds) { this.updateBounds(list); }
-			return list.boundsCache.width;
+			return list.boundsCache ? list.boundsCache.width : undefined;
 		},
 
 		/**


### PR DESCRIPTION
When passing an existing collection to a new `DataList` instance, a race condition can occur where the `DataList` tries to refresh itself before it's been rendered.

`enyo.DataList.delegates.vertical.width` and `enyo.DataList.delegates.vertical.height` try to find the (non-existent) list items that correspond with the deleted records by their index. During this search `VerticalDelegate` tries to calculate the amount of items contained within a single page, which triggers the call to `enyo.DataList.delegates.vertical.width` or `enyo.DataList.delegates.vertical.height`, which tries to retrieve the width from the `boundsCache`.

However, because the `DataList` has not been rendered yet, there are no bounds yet. The `enyo.DataList.delegates.vertical.width` and `enyo.DataList.delegates.vertical.height` methods do not anticipate this and throw an exception.

This pull request fixes the problem by returning `undefined`, which seems semantically correct and doesn't appear to cause further problems with the `DataList` either.
