### PR TITLE
Fixes BHV-15323

### DIFF
--- a/source/kernel/Oop.js
+++ b/source/kernel/Oop.js
@@ -87,6 +87,13 @@
 	};
 
 	/**
+	* Array of all finalized kind constructors
+	*
+	* @type {Function[]}
+	*/
+	enyo._finishedKinds = [];
+
+	/**
 	* @private
 	*/
 	enyo.kind.finish = function (props) {
@@ -149,6 +156,10 @@
 			enyo.error('enyo.kind: ' + name + ' is already in use by another ' +
 				'kind, all kind definitions must have unique names.');
 		}
+
+		// add the constructor to the list of finalized
+		enyo._finishedKinds.push(ctor);
+
 		return ctor;
 	};
 


### PR DESCRIPTION
## Issue

Non-deferred constructors can not be initialized as spotlight containers because spotlight hooks enyo.Control.prototype.create but that hook isn't effective if the prototype chain has already been set up for a kind.
## Fix

Maintain an array of finalized constructors and extend those as well

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)
