### PR TITLE
Fix for: BHV-5137

### DIFF
--- a/source/dom/Control.js
+++ b/source/dom/Control.js
@@ -219,7 +219,7 @@
 		* be set to `false` again to preserve the original behavior. If the desire is only to delay
 		* render the initial time set `renderOnShow` to `false` post-render.
 		*
-		* @type Boolean
+		* @type {Boolean}
 		* @default false
 		* @public
 		*/

--- a/source/dom/Control.js
+++ b/source/dom/Control.js
@@ -214,10 +214,8 @@
 		* to be `false`. Arbitrarily modifying the values of these properties prior to its initial
 		* render may have unexpected results.
 		*
-		* Also note that if `renderOnShow` is `true` and the control has its
-		* [teardownRender]{@link enyo.Control#teardownRender} method called, these properties will
-		* be set to `false` again to preserve the original behavior. If the desire is only to delay
-		* render the initial time set `renderOnShow` to `false` post-render.
+		* Once a control has been shown/rendered with `renderOnShow` `true` the behavior will not
+		* be used again.
 		*
 		* @type {Boolean}
 		* @default false
@@ -833,6 +831,11 @@
 		* @private
 		*/
 		showingChangedHandler: function (sender, event) {
+			
+			if (!this.showing && event.showing && this.renderOnShow && !this.generated) {
+				this.set('showing', true);
+			}
+			
 			return sender === this ? false : !this.showing;
 		},
 
@@ -1070,13 +1073,6 @@
 			}
 
 			delegate.teardownRender(this);
-			
-			// if the original state was set with renderOnShow true then we need to reset these
-			// values as well to coordinate the original intent
-			if (this.renderOnShow) {
-				this.set('showing', false);
-				this.set('canGenerate', false);
-			}
 		},
 
 		/**

--- a/tools/mocha-tests/tests/Control.js
+++ b/tools/mocha-tests/tests/Control.js
@@ -2,6 +2,55 @@ describe('enyo.Control', function () {
 	
 	var Control = enyo.Control;
 	
+	describe('usage', function () {
+		
+		describe('renderOnShow', function () {
+			
+			var testControl;
+			
+			before(function () {
+				enyo.kind({
+					name: 'TestControl',
+					kind: 'enyo.Control',
+					id: 'TESTCONTROL1',
+					components: [
+						{name: 'child', id: 'TESTCONTROL2', renderOnShow: true}
+					]
+				});
+				
+				testControl = new TestControl({parentNode: document.body});
+			});
+			
+			after(function () {
+				testControl.destroy();
+				TestControl = null;
+			});
+			
+			it ('should not render a control with renderOnShow true until it has its showing ' +
+				'value set to true', function () {
+				
+				var pn, node;
+				
+				testControl.render();
+				pn = document.querySelector('#TESTCONTROL1');
+				
+				expect(pn).to.exist;
+				
+				node = pn.querySelector('#TESTCONTROL2');
+				
+				expect(node).to.not.exist;
+				
+				testControl.$.child.set('showing', true);
+				
+				node = pn.querySelector('#TESTCONTROL2');
+				
+				expect(node).to.exist;
+			});
+			
+		});
+		
+	});
+	
 	describe('statics', function () {
 		
 		describe('concat', function () {


### PR DESCRIPTION
# Task

Add a `renderOnShow` option to enyo.Control as a base API that allows individual controls (and their children) to be created but not rendered until explicitly set via the `showing` property.

Enyo-DCO-1.1-Signed-Off-By: Cole Davis (cole.davis@lge.com)