### PR TITLE
ENYO-275: Properly initialize DataList.absoluteShowing

### DIFF
--- a/source/ui/data/DataList.js
+++ b/source/ui/data/DataList.js
@@ -273,8 +273,8 @@
 		*/
 		rendered: function () {
 			// Initialize / sync the internal absoluteShowing property when we're rendered
-			this.absoluteShowing = this.getAbsoluteShowing({ignoreBounds: true});
-			if (this.get('absoluteShowing')) {
+			var as = this.absoluteShowing = this.getAbsoluteShowing(true);
+			if (as) {
 				// actually rendering a datalist can be taxing for some systems so
 				// we arbitrarily delay showing for a fixed amount of time unless delay is
 				// null in which case it will be executed immediately


### PR DESCRIPTION
DataList maintains an internal absoluteShowing property and
observes changes to it, for the purpose of deferring certain
operations when the list is hidden.

Previously, DataList initialized absoluteShowing when the list was
created, setting it to value of the list's own "showing" property.
This meant it wasn't accurate if any of the list's ancestors
happened to be hidden at the time the list was created...and this,
in turn, meant that certain operations (e.g. initial generation of
pages and layout of child controls) that should have been deferred
happened immediately instead.

We now initialize on render instead, getting the value from a call
to getAbsoluteShowing().

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
