### PR TITLE
Run triggerOnStart async to allow parent to create

### DIFF
--- a/source/kernel/Router.js
+++ b/source/kernel/Router.js
@@ -454,12 +454,13 @@
 				// ok, register for events
 				listeners.push(this);
 				// ok, if we need to go ahead and route our current
-				// location, lets do it
+				// location, lets do it, but let create finish first
 				if (this.triggerOnStart) {
 					if (this.defaultPathOnStart) {
-						this.trigger({change: true, location: this.get('defaultPath')});
+						enyo.asyncMethod(this, 'trigger', {change: true, location: this.get('defaultPath')});
 					} else {
-						this.trigger();
+						enyo.asyncMethod(this, 'trigger');
+
 					}
 				}
 			};


### PR DESCRIPTION
## Issue

A router created during initialization will trigger its default route before the parent object completes its initialization. This could lead to problems with other components not being ready to be used.
## Cause

`triggerOnStart` triggers immediately on creation of the router
## Fix

Defer `triggerOnStart` with `asyncMethod`

Enyo-DCO-1.1-Signed-off-by: Roy Sutton roy.sutton@lge.com
