### PR TITLE
ENYO-288 Filesystem errors are now fatal

### DIFF
--- a/tools/deploy.js
+++ b/tools/deploy.js
@@ -77,6 +77,8 @@ var nopt = require("nopt"),
 
 var stat, script;
 
+shell.config.fatal = true;	// Abort on all shelljs errors (e.g. cp/mkdir)
+
 // Send message to parent node process, if any
 process.on('uncaughtException', function (err) {
 	var errMsg = err.toString() + err.stack;


### PR DESCRIPTION
## Issue

Build scripts were not failing on deploy errors
## Cause

Scripts were not set up to stop on errors
## Fix

Add error detection
