### PR TITLE
Fixes BHV-15490

### DIFF
--- a/source/dom/dom.js
+++ b/source/dom/dom.js
@@ -510,10 +510,12 @@
 				my             = 0,
 				width          = node.offsetWidth,
 				height         = node.offsetHeight,
-				transformProp  = enyo.dom.getCssTransformProp(),
+				transformProp  = enyo.dom.getStyleTransformProp(),
+				cssTransProp   = enyo.dom.getCssTransformProp(),
 				xRegEx         = /translateX\((-?\d+|-?\d*\.\d+)px\)/i,
 				yRegEx         = /translateY\((-?\d+|-?\d*\.\d+)px\)/i,
 				m3RegEx        = /(?!matrix(3d)?\()(-?\d+|-?\d*\.\d+)(?=[,\)])/g,
+				unitRegEx      = /\d(em|ex|rem|%|ch|vh|vw|vmin|vmax|mm|cm|in|pt|pc)/g,
 				match          = null,
 				style          = null,
 				offsetParent   = null;
@@ -533,7 +535,12 @@
 				}
 				// Add offset from transforms
 				if (transformProp && node.style) {
-					style = enyo.dom.getComputedStyle(node)[transformProp];
+					style = node.style[transformProp];
+					// if the transform is using a non-px value in transform, use the computed
+					// style instead
+					if(unitRegEx.test(style)) {
+						style = enyo.dom.getComputedStyle(node)[cssTransProp];
+					}
 					// translateX
 					match = style.match(xRegEx);
 					if (match && typeof match[1] != 'undefined' && match[1]) {


### PR DESCRIPTION
## Issue

`enyo.dom.getAbsoluteBounds()` was using the style property to retrieve the value of the CSS transform which returns the explicit value set (e.g. the percentage), not the calculated value. Furthermore, it did not account for `matrix` transforms, only `translateX`, `translateY`, and `matrix3d`.
## Fix
- Use enyo.dom.getComputedStyle and account for matrix transforms in getAbsoluteBounds
- Use enyo.dom.transform for panels animation

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)
