### PR TITLE
ENYO-307: DataList generation issue when list hidden...

### DIFF
--- a/source/ui/data/DataList.js
+++ b/source/ui/data/DataList.js
@@ -273,12 +273,12 @@
 		*/
 		rendered: function () {
 			// Initialize / sync the internal absoluteShowing property when we're rendered
-			var as = this.absoluteShowing = this.getAbsoluteShowing(true);
-			if (as) {
-				// actually rendering a datalist can be taxing for some systems so
-				// we arbitrarily delay showing for a fixed amount of time unless delay is
-				// null in which case it will be executed immediately
-				var startup = function () {
+			this.absoluteShowing = this.getAbsoluteShowing(true);
+			// actually rendering a datalist can be taxing for some systems so
+			// we arbitrarily delay showing for a fixed amount of time unless delay is
+			// null in which case it will be executed immediately
+			var finishRendering = function () {
+				if (this.get('absoluteShowing')) {
 					// now that the base list is rendered, we can safely generate our scroller
 					this.$.scroller.canGenerate = true;
 					this.$.scroller.render();
@@ -291,16 +291,16 @@
 					if (this.didRender) {
 						this.didRender();
 					}
-				};
-				if (this.renderDelay === null) {
-					startup.call(this);
 				} else {
-					this.startJob('rendering', startup, this.renderDelay);
-					// this delay will allow slower systems to keep going and get everything else
-					// on screen before worrying about setting up the list
+					this._addToShowingQueue('finish rendering', finishRendering);
 				}
+			};
+			if (this.renderDelay === null) {
+				finishRendering.call(this);
 			} else {
-				this._addToShowingQueue('rendered', this.rendered);
+				this.startJob('finish rendering', finishRendering, this.renderDelay);
+				// this delay will allow slower systems to keep going and get everything else
+				// on screen before worrying about setting up the list
 			}
 		},
 		


### PR DESCRIPTION
...immediately after rendering.

By default, DataList doesn't render list contents immediately; it
renders them after a brief delay, to speed up the initial render
of the view containing the list.

It also waits to generate contents until the list is actually
showing, because it needs to measure the dimensions of the list
to generate the list pages correctly.

We had an issue in the edge case where a list was rendered and
then immediately hidden, because the initial check for
'absoluteShowing' would return true, but then the list would be
hidden by the time the async generation routine ran, and the bogus
measurements would cause the generation to go wrong.

To fix, we refactor things a bit to ensure that the check for
'absoluteShowing' always happens immediately before the generation
routine runs.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
