### PR TITLE
Fix for: ENYO-56

### DIFF
--- a/source/ui/data/RepeaterChildSupport.js
+++ b/source/ui/data/RepeaterChildSupport.js
@@ -109,7 +109,7 @@
 				// if the event is coming from a child of the repeater-child (this...) and has a
 				// delegate assigned to it there is a distinct possibility it is supposed to be
 				// targeting the instanceOwner of repeater-child not the repeater-child itself
-				// so we have to check this case and treat is as expected - if there is a handler
+				// so we have to check this case and treat it as expected - if there is a handler
 				// and it returns true then we must skip the normal flow
 				if (event.originator !== this && event.delegate && event.delegate.owner === this) {
 					if (typeof this[name] != 'function') {
@@ -117,8 +117,8 @@
 						owner = this.getInstanceOwner();
 						if (owner && owner !== this) {
 							if (typeof owner[name] == 'function') {
-								// alright it appears that we're supposed to forward this the next
-								// owner instead
+								// alright it appears that we're supposed to forward this to the
+								// next owner instead
 								return owner.dispatch(name, event, sender);
 							}
 						}


### PR DESCRIPTION
# Issue

When using the delegate support for forward events from declarative child-components to an owner handler, directly, it is being lost from repeater children. This happens because children of repeater children are scoped to be owned by the repeater child for scoping related issues for a repeated child. This does, however, keep the expected behavior of delegated events from working.
# Fix

We can clearly identify when those cases exist and we can attempt to forward them to the owner of the repeater child (expected behavior) when possible.
