### PR TITLE
ENYO-336 Stay original position when model is removed

### DIFF
--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -412,8 +412,7 @@
 			
 			// props.models is removed modelList and the lowest index among removed models	
 			if (props.models.low <= lastIdx) {
-				this.refresh(list);
-				this.scrollToIndex(list, Math.min(pg1.start, pg2.start));
+				this.refresh(list);				
 			}
 		},
 		


### PR DESCRIPTION
ISSUE

---

Currently removing model which has lower index than last index of pages makes list to be scrolled to the first index of pages.
But this behavior is not natural. Staying its original position is more acceptable.

CAUSE

---

We intentionally scroll list to top position.

FIx

---

Remove scrollToIndex() call.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
