### PR TITLE
added a clone back, and updated var names to match standards

### DIFF
--- a/source/ui/data/DataRepeater.js
+++ b/source/ui/data/DataRepeater.js
@@ -153,7 +153,7 @@
 				props.mixins = props.mixins? props.mixins.concat(this.childMixins): this.childMixins;
 			}
 
-			this.defaultProps = enyo.clone(props, true);
+			this.defaultProps = props;
 		},
 
 		/**


### PR DESCRIPTION
Cleaned up the `initComponents` function, added true to clone to use Object.create, passed back updated props to .defaultProps after they are modified.

Enyo-DCO-1.1-Signed-off-by: Derek Anderson derek.anderson@lge.com
