### PR TITLE
BHV-15359: List item shows incorrect result when it has an checkbox item and bind with model's selected property

### DIFF
--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -183,6 +183,7 @@
 				view.stopNotifications();
 				view.set('model', data.at(i));
 				view.set('index', i);
+				this.checkSelected(list, view);
 				view.set('selected', list.isSelected(view.model));
 				view.startNotifications();
 				view.canGenerate = true;
@@ -202,6 +203,20 @@
 			metrics.width  = this.pageWidth(list, page);
 			// update the childSize value now that we have measurements
 			this.childSize(list);
+		},
+
+		/**
+		* checks whether the control should have selected set based on selectionProperty
+		*
+		* @private
+		*/
+		checkSelected: function (list, view) {
+			var s = list.selectionProperty;
+			if (s && view.model.get(s) && !list.isSelected(view.model)) {
+				list.select(view.index);
+				// don't have to check opposite case (model is false and isSelected is true) 
+				// because that shouldn't happen
+			}
 		},
 
 		/**


### PR DESCRIPTION
### Issue:

Problems when you combine binding a model property to a checkbox, with using the selectionProperty attribute
### Fix:

when a control is assigned a model in generatePage(), add a check to synchronize the model property with the list's selections

Enyo-DCO-1.1-Signed-off-by: Krishna Rangarajan krishna.rangarajan@lge.com
