### PR TITLE
ENYO-345: Convert CSS property names with dash to JavaScript-style name.

### DIFF
--- a/source/dom/Control.js
+++ b/source/dom/Control.js
@@ -594,7 +594,7 @@
 			// removed once this issue has been resolved in the Firefox mainline and its variants
 			// (it is currently resolved in the 36.0a1 nightly):
 			// https://bugzilla.mozilla.org/show_bug.cgi?id=1083457
-			if (node && (enyo.platform.firefox || enyo.platform.firefoxOS || enyo.platform.androidFirefox)) {
+			if (node && (enyo.platform.firefox < 35 || enyo.platform.firefoxOS || enyo.platform.androidFirefox)) {
 				prop = prop.replace(/-([a-z])/gi, function(match, submatch) {
 					return submatch.toUpperCase();
 				});


### PR DESCRIPTION
### Issue

There is an issue in Firefox (https://bugzilla.mozilla.org/show_bug.cgi?id=1083457) where utilizing the CSS property name for does not have any effect when attempting to change the style property value of a node. This was something non-standard supported in WebKit that has since been added to the CSS object model spec and will be supported in Firefox 35. The net effect is that any `enyo.Popup` and its derivatives would not have the proper z-index value applied, leading to the control unexpectedly appearing beneath the scrim. The scrim does not suffer from this problem, as the z-index value is applied prior to its generation, which goes through a different style application path. This used to work in 2.4 because our implementation of style application was different and we were not utilizing the style object accessor technique that was implemented for 2.5.
### Fix

We make an exception for the case of Firefox and its variants and convert any dashed property names to their JavaScript-style equivalents.
### Note

We will want to remove this fix once the bug has been resolved in Firefox and its variants (estimate is January 2015). Using the `setProperty` and `removeProperty` methods of the style object would appear to resolve this as well, but the performance drop-off would not be insignificant: http://jsperf.com/style-setproperty-versus-direct/2

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
