### PR TITLE
modify inherited execution, so view is not recreated due to resetView

### DIFF
--- a/source/kernel/ViewController.js
+++ b/source/kernel/ViewController.js
@@ -3,12 +3,12 @@
 	* {@link enyo.ViewController} is designed to manage the lifecycle of a particular view
 	* ({@link enyo.Control}) that it owns. It is capable of controlling when a view is inserted into
 	* the DOM and where, managing [events]{@glossary event} bubbled from the view, and isolating (or
-	* encapsulating) the entire view hierarchy below it. Alternatively, it may be implemented as a 
+	* encapsulating) the entire view hierarchy below it. Alternatively, it may be implemented as a
 	* [component]{@link enyo.Component} in a larger hierarchy, in which case it will inject its view
-	* into its parent rather than directly into the DOM. And, of course, a ViewController may be 
-	* used as the `controller` property of another view, although this usage will (by default) 
+	* into its parent rather than directly into the DOM. And, of course, a ViewController may be
+	* used as the `controller` property of another view, although this usage will (by default)
 	* result in the removal of its own view from the {@link enyo.Component} bubbling hierarchy.
-	* 
+	*
 	* Note that `enyo.ViewController` may have components defined in its
 	* `components` [array]{@glossary Array}, but these components should
 	* not be `enyo.Controls`.
@@ -120,7 +120,7 @@
 		},
 
 		/**
-		* Renders the view into the specified `target` and sets the 
+		* Renders the view into the specified `target` and sets the
 		* [renderTarget]{@link enyo.ViewController#renderTarget} property to
 		* `target`.
 		*
@@ -201,7 +201,7 @@
 			}
 			this.view = v;
 		},
-		
+
 		/**
 		* @method
 		* @private
@@ -219,9 +219,9 @@
 		*/
 		destroy: enyo.inherit(function (sup) {
 			return function () {
-				sup.apply(this, arguments);
 				this.view = null;
 				this.viewKind = null;
+				sup.apply(this, arguments);
 			};
 		}),
 		/**


### PR DESCRIPTION
Issue.

When setting `resetView` property to true on a ViewController, the view will be created again after the controller is destroyed due to the order in which the calls are being made.

Fix.

Move inherited call for destroy after the values of `view` and `viewKind` are nullified. 

Enyo-DCO-1.1-Signed-off-by: Derek Anderson derek.anderson@lge.com
