### PR TITLE
Revert "ENYO-345: Convert CSS property names with dash to JavaScript-sty...

### DIFF
--- a/source/dom/Control.js
+++ b/source/dom/Control.js
@@ -587,19 +587,6 @@
 				style = this.style,
 				delegate = this.renderDelegate || Control.renderDelegate;
 
-			// FIXME: This is put in place for a Firefox bug where setting a style value of a node 
-			// via its CSSStyleDeclaration object (by accessing its node.style property) does
-			// not work when using a CSS property name that contains one or more dash, and requires 
-			// setting the property via the JavaScript-style property name. This fix should be 
-			// removed once this issue has been resolved in the Firefox mainline and its variants
-			// (it is currently resolved in the 36.0a1 nightly):
-			// https://bugzilla.mozilla.org/show_bug.cgi?id=1083457
-			if (node && (enyo.platform.firefox < 35 || enyo.platform.firefoxOS || enyo.platform.androidFirefox)) {
-				prop = prop.replace(/-([a-z])/gi, function(match, submatch) {
-					return submatch.toUpperCase();
-				});
-			}
-
 			if (value !== null && value !== '' && value !== undefined) {
 				// update our current cached value
 				if (node) {


### PR DESCRIPTION
Will be applying this change onto a new 2.5.1 release branch based on 2.5.1-pre.9

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)
