### PR TITLE
ENYO-363: Add info properties to onratechange event.

### DIFF
--- a/source/ui/Media.js
+++ b/source/ui/Media.js
@@ -880,6 +880,7 @@
 			}
 
 			info = this.createEventData();
+			enyo.mixin(e, enyo.clone(info, true));
 			info.originalEvent = enyo.clone(e, true);
 
 			pbNumber = this.calcNumberValueOfPlaybackRate(info.playbackRate);

--- a/source/ui/Video.js
+++ b/source/ui/Video.js
@@ -905,6 +905,7 @@
 			}
 
 			info = this.createEventData();
+			enyo.mixin(e, enyo.clone(info, true));
 			info.originalEvent = enyo.clone(e, true);
 
 			pbNumber = this.calcNumberValueOfPlaybackRate(info.playbackRate);


### PR DESCRIPTION
### Issue

We were previously decorating the `onratechange` event with several playback related properties. These were removed when addressing an issue with shared event object references.
### Fix

We mixin the playback related properties with the bubbled `onratechange` event in both `enyo.Media` and `enyo.Video`, for consistency.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
