### PR TITLE
Fixes ENYO-364

### DIFF
--- a/source/ui/FloatingLayer.js
+++ b/source/ui/FloatingLayer.js
@@ -47,6 +47,10 @@
 			return function() {
 				sup.apply(this, arguments);
 				this.setParent(null);
+
+				if (enyo.platform.ie < 11) {
+					this.removeClass('enyo-fit');
+				}
 			};
 		}),
 


### PR DESCRIPTION
## Issue

< IE 11 doesn't support pointer-events so the mouse wheel events are being captured by the floating layer instead of passing through to the underlying controls
## Fix

For the affected browsers, remove the enyo-fit class from enyo.FloatingLayer so it has no height and therefore won't be the target of any events.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)
