### PR TITLE
ENYO-365: Prevent text from overflowing bounds.

### DIFF
--- a/source/ui/ui.css
+++ b/source/ui/ui.css
@@ -69,3 +69,8 @@
 	pointer-events: auto;
 	background: transparent;
 }
+
+.enyo-richtext {
+	overflow: hidden;
+	word-wrap: break-word;
+}


### PR DESCRIPTION
### Issue

When explicit dimensions are set for an `enyo.RichText` control, text can overflow the bounds of the control.
### Fix

We set `overflow:hidden` for this control and apply `word-wrap:break-word` to have consistent line-breaking behavior among browsers.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
