### PR TITLE
removed transparent on highlight, bad UX, not really unselectable

### DIFF
--- a/source/dom/dom.css
+++ b/source/dom/dom.css
@@ -52,10 +52,6 @@ button::-moz-focus-inner {
 	user-select: none;
 }
 
-.enyo-unselectable::selection, .enyo-unselectable ::selection {
-	color: transparent;
-}
-
 .enyo-selectable {
 	cursor: auto;
 	-ms-user-select: element;


### PR DESCRIPTION
Resubmission of https://github.com/enyojs/enyo/pull/885 against 2.5.1-release

Issue.

Cascades have changed in Chrome, causing this rule to be applied when text is highlighted, and making it appear transparent to the user.

Fix.

Remove the rule all together, it is not truly making text un-selectable, just appearing so. Discussion here: https://enyojs.atlassian.net/browse/ENYO-4056

Enyo-DCO-1.1-Signed-off-by: Derek Anderson derek.anderson@lge.com
