### PR TITLE
ENYO-368: Remove all instances of a property when removing styles before node is attached.

### DIFF
--- a/source/dom/Control.js
+++ b/source/dom/Control.js
@@ -622,7 +622,8 @@
 						// This looks a lot worse than it is. The complexity stems from needing to
 						// match a url container that can have other characters including semi-
 						// colon and also that the last property may/may-not end with one
-						'\\s*' + prop + '\\s*:\\s*[a-zA-Z0-9\\ ()_\\-\'"%,]*(?:url\\(.*\\)\\s*[a-zA-Z0-9\\ ()_\\-\'"%,]*)?\\s*(?:;|;?$)'
+						'\\s*' + prop + '\\s*:\\s*[a-zA-Z0-9\\ ()_\\-\'"%,]*(?:url\\(.*\\)\\s*[a-zA-Z0-9\\ ()_\\-\'"%,]*)?\\s*(?:;|;?$)',
+						'gi'
 					),'');
 					this.set('style', style);
 				}


### PR DESCRIPTION
### Issue

When a control's style property is removed before its node has been attached to DOM, only the first instance of the property is removed. This can cause issues in such cases as when a `FlyweightRepeater` is stamping out items, and we are modifying the style of a repeated element.
### Fix

We add the `gi` flag to perform global, case insensitive matching for our regular expression when removing a style property, pre-attachment.
### Notes

In terms of performance implications, this is a few percent slower: http://jsperf.com/regex-global-vs-no-global/2. If this is a concern, I have an alternate fix that patches the specific sample where this issue was originally raised: https://github.com/enyojs/layout/compare/ENYO-368-aarontam.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
