### PR TITLE
BHV-16137: Only set rtl property when there is content.

### DIFF
--- a/source/dom/Control.js
+++ b/source/dom/Control.js
@@ -1275,8 +1275,8 @@
 			// Values that are null or undefined, or are numbers, arrays, and some objects are safe
 			// to be tested.
 			var str = (arguments.length) ? stringInstead : this.content;
-			this.rtl = enyo.isRtl(str);
 			if (str || str === 0) {
+				this.rtl = enyo.isRtl(str);
 				this.applyStyle('direction', this.rtl ? 'rtl' : 'ltr');
 			} else {
 				this.applyStyle('direction', null);


### PR DESCRIPTION
### Issue

The `rtl` property of a control is being incorrectly set when there is no content. We had made a previous fix for this with respect to the `direction` style property, but had missed including the `rtl` property in the conditional.
### Fix

We only set the `rtl` property if we have content from which to determine directionality.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
