### PR TITLE
ENYO-379: Bubble caching interferes with repeater event decoration

### DIFF
--- a/source/ui/data/RepeaterChildSupport.js
+++ b/source/ui/data/RepeaterChildSupport.js
@@ -25,6 +25,17 @@
 		* @public
 		*/
 		selected: false,
+
+		/**
+		* Setting cachePoint: true ensures that events from the repeater child's subtree will
+		* always bubble up through the child, allowing the events to be decorated with repeater-
+		* related metadata and references.
+		*
+		* @type {Boolean}
+		* @default true
+		* @private
+		*/
+		cachePoint: true,
 		
 		/*
 		* @method


### PR DESCRIPTION
Children of DataRepeater (and its subkinds) decorate events as they
bubble up, so that handlers can act on repeater-related metadata
(e.g. index) and references (e.g. model).

However, the event bubble caching mechanism recently added to Enyo
can prevent this event decoration from happening properly, since
events are no longer guaranteed to bubble up through the repeater
child.

To fix this, we set cachePoint: true in the RepeaterChildSupport
mixin, ensuring that events will always bubble up through repeater
children, allowing event decoration to occur as intended.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
