### PR TITLE
ENYO-373: Add option to bypass adding control to roots.

### DIFF
--- a/source/dom/Control.js
+++ b/source/dom/Control.js
@@ -925,10 +925,12 @@
 		* target `parentNode`.
 		*
 		* @param {Node} parentNode - The new parent of this control.
+		* @param {Boolean} preventRooting - If `true`, this control will not be treated as a root 
+		*	view and will not be added to the set of roots.
 		* @returns {this} The callee for chaining.
 		* @public
 		*/
-		renderInto: function (parentNode) {
+		renderInto: function (parentNode, preventRooting) {
 			var delegate = this.renderDelegate || Control.renderDelegate,
 				noFit = this.fit === false;
 
@@ -953,7 +955,9 @@
 
 			// we inject this as a root view because, well, apparently that is just an assumption
 			// we've been making...
-			enyo.addToRoots(this);
+			if (!preventRooting) {
+				enyo.addToRoots(this);
+			}
 
 			// now let the delegate render it the way it needs to
 			delegate.renderInto(this, parentNode);


### PR DESCRIPTION
### Issue

There are situations where we do not wish to add a control to the view roots.
### Fix

We added a parameter, `preventRooting`, to `enyo.Control`'s `renderInto` method that allows for the prevention of adding a control to the view roots.
### Notes

This also needs to be cherry-picked into the `branch-2.5.2-pre.4` branch.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
