### PR TITLE
ENYO-398: Eliminate "jump" after dragging during animated scroll

### DIFF
--- a/source/touch/ScrollMath.js
+++ b/source/touch/ScrollMath.js
@@ -351,6 +351,7 @@
 				if (this.dragging) {
 					this.y0 = this.y = this.uy;
 					this.x0 = this.x = this.ux;
+					this.endX = this.endY = null;
 				}
 				// frame-time accumulator
 				// min acceptable time is 16ms (60fps)


### PR DESCRIPTION
If you are using enyo.Scroller with enyo.TouchScrollStrategy (or a
subkind like enyo.TranslateScrollStrategy), and you drag to scroll
while an animated scroll is already in progress, then the scroller
will jump to the wrong position when you stop dragging.

This is because enyo.ScrollMath keeps track of the final position
it's scrolling to and doesn't properly reset it when dragging.

To fix, we reset this.endX and this.endY in animate() when we're
dragging. We do this in animate() because resetting this.endX and
this.endY in startDrag() isn't sufficient in the case where an app
attempts to start a _new_ animated scroll while the drag is in
progress.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
