### PR TITLE
ENYO-388: Added explicit dimensions for button with image in sample.

### DIFF
--- a/samples/ButtonSample.css
+++ b/samples/ButtonSample.css
@@ -21,3 +21,7 @@
 	color: #FFF;
 	background-color: #555;
 }
+.button-sample .image-button {
+	width: 200px;
+	height: 100px;
+}

--- a/samples/ButtonSample.js
+++ b/samples/ButtonSample.js
@@ -18,7 +18,7 @@ enyo.kind({
 			{kind: "enyo.Button", content: "Grouped Button 3"}
 		]},
 		{content: "Image Button", classes: "section"},
-		{kind: "enyo.Button", content: "Image Button", ontap: "buttonTapped", components: [
+		{kind: "enyo.Button", content: "Image Button", classes: "image-button", ontap: "buttonTapped", components: [
 			{kind: "enyo.Image", src: "http://enyojs.com/img/enyo-logo.png", alt: "Enyo Logo"}
 		]},
 		{name: "results", classes: "results"}


### PR DESCRIPTION
### Issue

The button with image in the Enyo `ButtonSample` was not appearing with the full height on iOS devices. This appears to be an implementation detail in iOS Safari (and UIWebView i.e. iOS Chrome) when placing an image inside a button tag.
### Fix

Short of rewriting this sample, we set explicit dimensions for this control.
### Notes

This also needs to be cherry-picked into the `2.5.1-release` branch.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
