### PR TITLE
Fixes ENYO-394 (2.5.1-release)

### DIFF
--- a/source/touch/Scroller.js
+++ b/source/touch/Scroller.js
@@ -540,7 +540,7 @@
 		* Retrieves the vertical scroll position.
 		*
 		* @returns {Number} The vertical scroll position in pixels.
-		* @private
+		* @public
 		*/
 		getScrollTop: function () {
 			// sync our internal property
@@ -567,6 +567,23 @@
 			this.scrollTop  = bounds.top;
 			this.scrollLeft = bounds.left;
 			return bounds;
+		},
+
+		/** 
+		* Trigger a remeasurement of the scroller's metrics (specifically, the
+		* size of its viewport, the size of its contents and the difference between
+		* the two, which determines the extent to which the scroller may scroll).
+		* 
+		* You should generally not need to call this from application code, as the
+		* scroller usually remeasures automatically whenever needed. This method
+		* exists primarily to support an internal use case for
+		* [enyo.DataList]{@link enyo.DataList}.
+		*
+		* @public
+		*/
+		remeasure: function() {
+			var s = this.$.strategy;
+			if (s.remeasure) s.remeasure();
 		},
 
 		/**

--- a/source/touch/TouchScrollStrategy.js
+++ b/source/touch/TouchScrollStrategy.js
@@ -784,6 +784,24 @@
 		}),
 
 		/** 
+		* This method exists primarily to support an internal use case for
+		* [enyo.DataList]{@link enyo.DataList}. It is intended to be called by the
+		* [scroller]{@link enyo.Scroller} that owns this strategy.
+		*
+		* Triggers a remeasurement of the scroller's metrics (specifically, the
+		* size of its viewport, the size of its contents and the difference between
+		* the two, which determines the extent to which the scroller may scroll).
+		*
+		* @public
+		*/
+		remeasure: function () {
+			this.calcBoundaries();
+			if (this.thumb) {
+				this.syncThumbs();
+			}
+		},
+
+		/** 
 		* Displays the scroll indicators and sets the auto-hide timeout.
 		*
 		* @public

--- a/source/touch/TranslateScrollStrategy.js
+++ b/source/touch/TranslateScrollStrategy.js
@@ -114,7 +114,7 @@
 		*/
 		syncScrollMath: enyo.inherit(function (sup) {
 			return function() {
-				if (!this.translateOptimized) {
+				if (!this._translated) {
 					sup.apply(this, arguments);
 				}
 			};
@@ -169,7 +169,7 @@
 		*/
 		getScrollLeft: enyo.inherit(function (sup) {
 			return function() {
-				return this.translateOptimized ? this.scrollLeft: sup.apply(this, arguments);
+				return this._translated ? this.scrollLeft: sup.apply(this, arguments);
 			};
 		}),
 		
@@ -182,7 +182,7 @@
 		*/
 		getScrollTop: enyo.inherit(function (sup) {
 			return function() {
-				return this.translateOptimized ? this.scrollTop : sup.apply(this, arguments);
+				return this._translated ? this.scrollTop : sup.apply(this, arguments);
 			};
 		}),
 		
@@ -194,9 +194,7 @@
 			return function(inSender) {
 				sup.apply(this, arguments);
 				this.scrollStarting = true;
-				this.startX = 0;
-				this.startY = 0;
-				if (!this.translateOptimized && this.scrollNode) {
+				if (!this._translated) {
 					this.startX = this.getScrollLeft();
 					this.startY = this.getScrollTop();
 				}
@@ -232,6 +230,7 @@
 		effectScroll: function (x, y) {
 			var o = x + 'px, ' + y + 'px' + (this.accel ? ',0' : '');
 			enyo.dom.transformValue(this.$.client, this.translation, o);
+			this._translated = true;
 		},
 
 		/**
@@ -262,6 +261,7 @@
 				if (needsBoundsFix) {
 					enyo.dom.transformValue(this.$.client, this.translation, t);
 				}
+				this._translated = false;
 			}
 		},
 

--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -438,6 +438,7 @@
 				list.bufferSize = bs;
 				n.style[sp] = bs + 'px';
 				n.style[ss] = this[ss](list) + 'px';
+				list.$.scroller.remeasure();
 			}
 		},
 		


### PR DESCRIPTION
Cherry-picking this into `2.5.1-release` as it is the same issue/fix. Just to clarify, this commit already exists on `master`.
### ENYO-349: Fixes issues with TranslateScrollStrategy

TranslateScrollStrategy was not working properly when the
'translateOptimized' option was disabled. In this case, the
strategy uses CSS translation during scrolling, but removes the
translation and sets 'scrollTop' when the scroller stops. There
are several methods in the strategy that need to behave differently
depending on whether translation is currently applied, but before
this fix these methods were sometimes taking the wrong code path
because we weren't explicitly keeping track of whether a
translation was currently applied and the logic we used instead
was wrong in certain cases -- in particular when starting a new
drag or flick before the previous one completed.

In testing this fix, I also came across an issue when using
enyo.TouchScrollStrategy or any of its subkinds with enyo.DataList.
In certain cases, when you scrolled continuously from the top of a
list to the bottom, the scroll boundaries and thumb would become
inaccurate by the time you reached the bottom of the list (because
DataList progressively refines its calculation of the list's size
as it pages). To fix this, I added 'remeasure' methods to Scroller
and TouchScrollStrategy to manually trigger remeasurement, and then
used this feature in VerticalDelegate to force the Scroller to
remeasure whenever DataList refines its list size calculation.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
