### PR TITLE
ENYO-382: Access the correct source/target properties.

### DIFF
--- a/source/ext/InputBinding.js
+++ b/source/ext/InputBinding.js
@@ -46,8 +46,8 @@
 		*/
 		transform: function (value, direction, binding) {
 			if (value) { return value; }
-			var pd = binding.placeholderDirection,
-				ph = binding['_' + pd].placeholder || '';
+			var pd = '_' + binding.placeholderDirection,
+				ph = binding[pd] && binding[pd].placeholder || '';
 			return ph;
 		}
 	});


### PR DESCRIPTION
### Issue

In `enyo.Binding`, we had previously been re-assigning `source` and `target` if they had originally been falsy, based on the paths in `from` and/or `to`. These properties of `enyo.Binding` were accessed by `enyo.InputBinding` via its transform function. For 2.5, bindings have been updated such that we do not re-assign `source` and `target`, so that the binding can be reset, which requires the original values to be preserved. Because `enyo.InputBinding` is depending on these specific properties, an exception is now being thrown.
### Fix

Since `enyo.InputBinding` is a subkind of `enyo.Binding`, it can access its private properties, and thus we access the source and target properties with the `_` prefix for the property names. 
### Notes

This also needs to be cherry-picked into the `2.5.1-release` branch.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
