### PR TITLE
BHV-16550: Use getBoundingClientRect inside of getAbsoluteBounds

### DIFF
--- a/source/dom/dom.js
+++ b/source/dom/dom.js
@@ -503,15 +503,14 @@
 		* @public
 		*/
 		getAbsoluteBounds: function(targetNode) {
-			var node           = targetNode,
-				rect           = node.getBoundingClientRect(),
-				width          = node.offsetWidth,
-				height         = node.offsetHeight;
+			var rect           = targetNode.getBoundingClientRect(),
+				width          = targetNode.offsetWidth,
+				height         = targetNode.offsetHeight;
 			return {
-				top     : targetNode ? rect.top : undefined,
-				left    : targetNode ? rect.left : undefined,
-				bottom  : targetNode ? document.body.offsetHeight - rect.top  - height : undefined,
-				right   : targetNode ? document.body.offsetWidth  - rect.left - width : undefined,
+				top     : rect.top,
+				left    : rect.left,
+				bottom  : document.body.offsetHeight - rect.top  - height,
+				right   : document.body.offsetWidth  - rect.left - width,
 				height  : height,
 				width   : width
 			};


### PR DESCRIPTION
### Issue:

Previous implementation of getAbsoluteBounds is accumulate all offsetTop + scrollTop + translate values of all the parents.
But, we found some edge cases that getAbsoluteBounds doesn't calculate absolute bounds well.
- Previous implementation doesn't add value of border
- Previous implementation doesn't add value of translateX(100%)
### Fix:

The result of getBoundingClientRect() is actually the absolute bounds of element measured from viewport.
We calculate right and bottom values just like previous implementation did because getBoundingClientRect returns the distance from top and left.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
