### PR TITLE
fix for BHV-16168 select method delay

### DIFF
--- a/source/ui/data/DataList.js
+++ b/source/ui/data/DataList.js
@@ -320,13 +320,12 @@
 			if (this.get('absoluteShowing') && this._showingQueueMethods) {
 				var methods = this._showingQueueMethods;
 				var fn;
+				this._showingQueueMethods = null;
 
 				for (var i = 0; i < this._absoluteShowingPriority.length; i++) {
 					fn = methods[this._absoluteShowingPriority[i]];
 					if(fn) fn.call(this);
 				}
-
-				this._showingQueueMethods = null;
 			}
 		},
 


### PR DESCRIPTION
Issue.

The root problem is that all of the methods for the `DataList` are deferred, but the `_select` method was inherited from the `DataRepeater`, and is not deferred. This causes the `_select` method from the repeater to ask for controls from the vertical delegate, which is out of sync.

Solution.

Extend the _select method for the `DataList`, and standardize the way it is called, by utilizing the deferred construct of other methods. Without needing to edit the absoluteShowingChanged method, I used `enyo.asyncMethod` to ensure that inherited `_select` method would be executed at the end of the stack.

Enyo-DCO-1.1-Signed-off-by: Derek Anderson derek.anderson@lge.com
