### PR TITLE
ENYO-424: Prevent tap event when user presses to stop scrolling

### DIFF
--- a/source/dom/gesture.js
+++ b/source/dom/gesture.js
@@ -93,6 +93,11 @@
 			// expose method for configuring holdpulse options
 			e.configureHoldPulse = this.configureHoldPulse;
 
+			// enable prevention of tap event
+			e.preventTap = function() {
+				e._tapPrevented = true;
+			};
+
 			enyo.dispatch(e);
 			this.downEvent = e;
 
@@ -128,12 +133,14 @@
 		*/
 		up: function(evt) {
 			var e = this.makeEvent('up', evt);
-			var tapPrevented = false;
+
+			e._tapPrevented = this.downEvent._tapPrevented;
 			e.preventTap = function() {
-				tapPrevented = true;
+				e._tapPrevented = true;
 			};
+
 			enyo.dispatch(e);
-			if (!tapPrevented && this.downEvent && this.downEvent.which == 1) {
+			if (!e._tapPrevented && this.downEvent && this.downEvent.which == 1) {
 				var target = this.findCommonAncestor(this.downEvent.target, evt.target);
 
 				// the common ancestor of the down/up events is the target of the tap

--- a/source/touch/ScrollStrategy.js
+++ b/source/touch/ScrollStrategy.js
@@ -91,12 +91,21 @@
 		/**
 		* @private
 		*/
+		events: {
+			onScrollStart: '',
+			onScrollStop: ''
+		},
+
+		/**
+		* @private
+		*/
 		handlers: {
 			ondragstart: 'dragstart',
 			ondragfinish: 'dragfinish',
 			ondown: 'down',
 			onmove: 'move',
-			onmousewheel: 'mousewheel'
+			onmousewheel: 'mousewheel',
+			onscroll: 'domScroll'
 		},
 
 		/**
@@ -360,7 +369,10 @@
 		* 
 		* @private
 		*/
-		down: function () {
+		down: function (sender, e) {
+			if (this.isScrolling()) {
+				e.preventTap();
+			}
 			this.calcStartInfo();
 		},
 
@@ -384,6 +396,27 @@
 			if (!this.useMouseWheel) {
 				e.preventDefault();
 			}
+		},
+
+		/**
+		* @private
+		*/
+		domScroll: function(sender, e) {
+			if (!this._scrolling) {
+				this.doScrollStart();
+			}
+			this._scrolling = true;
+			this.startJob('stopScrolling', function() {
+				this._scrolling = false;
+				this.doScrollStop();
+			}, 100);
+		},
+
+		/**
+		* @public
+		*/
+		isScrolling: function() {
+			return this._scrolling;
 		}
 	});
 

--- a/source/touch/TouchScrollStrategy.js
+++ b/source/touch/TouchScrollStrategy.js
@@ -155,14 +155,9 @@
 		* @private
 		*/
 		handlers: {
-			onscroll: 'domScroll',
 			onflick: 'flick',
-			onhold: 'hold',
-			ondragstart: 'dragstart',
 			onShouldDrag: 'shouldDrag',
-			ondrag: 'drag',
-			ondragfinish: 'dragfinish',
-			onmousewheel: 'mousewheel'
+			ondrag: 'drag'
 		},
 
 		/**
@@ -548,17 +543,6 @@
 			if (onAxis && this.dragging) {
 				this.$.scrollMath.flick(e);
 				return this.preventDragPropagation;
-			}
-		},
-
-		/**
-		* @private
-		*/
-		hold: function (sender, e) {
-			if (this.isScrolling() && !this.isOverscrolling()) {
-				var m = this.$.scrollMath || this;
-				m.stop(e);
-				return true;
 			}
 		},
 

--- a/source/touch/TranslateScrollStrategy.js
+++ b/source/touch/TranslateScrollStrategy.js
@@ -275,8 +275,7 @@
 				this.scrollNode.scrollTop = 1;
 				this.scrollNode.scrollTop = 0;
 			}
-		},
-		down: enyo.nop
+		}
 	});
 
 })(enyo, this);


### PR DESCRIPTION
When we stop scrolling in response to a 'down' event, we should
prevent a tap event from firing, on the assumption that the user's
intent was simply to stop the scroller.

To do so, I made the following changes:
- In gesture.js, extended the preventTap() API so that it can be
  used on not only up events, but down events as well
- Changed our scroll strategies to stop scrolling on 'down'
  (utilizing the above-mentioned preventTap() API), rather than on
  'hold'. Implemented this functionality in ScrollStrategy,allowing
  it to be inherited by subkinds.
- To support the above, also added support in ScrollStrategy for
  onScrollStart, onScrollStop and isScrolling(). As a side benefit,
  this makes for better API consistency across our scroll strategies.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
