### PR TITLE
Fixes CMB-3602

### DIFF
--- a/source/ui/data/DataList.js
+++ b/source/ui/data/DataList.js
@@ -438,7 +438,7 @@
 		* @private
 		*/
 		didScroll: function (sender, e) {
-			if (this.hasRendered && this.collection) {
+			if (this.hasRendered && this.collection && this.collection.length > 0) {
 				if (this.heightNeedsUpdate || this.widthNeedsUpdate) {
 					// assign this here so that if for any reason it needs to
 					// it can reset it


### PR DESCRIPTION
## Issue

If the collection for a DataList has no models, no pages are generated and code that relies on generated content fails. In this case, when the scroller is scrolled (or when it's shown and stabilized), the delegate tries to use the scroll threshold which hasn't been set up yet. DataList guards against the absence of a collection in its onScroll handler but doesn't guard against an empty collection.
## Fix

Add a guard for an empty collection in didScroll

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)
