### PR TITLE
Fixes BHV-17375

### DIFF
--- a/source/ui/data/DataList.js
+++ b/source/ui/data/DataList.js
@@ -154,7 +154,7 @@
 		*
 		* @private
 		*/
-		_absoluteShowingPriority:['reset', 'refresh', 'scrollToIndex', 'finish rendering', 'didResize' , 'select'],
+		_absoluteShowingPriority:['reset', 'refresh', 'finish rendering', 'scrollToIndex', 'didResize' , 'select'],
 
 		/**
 		* Completely resets the current [list]{@link enyo.DataList} such that it scrolls to the top


### PR DESCRIPTION
## Issue

`enyo.DataList.scrollToIndex` relies on the bounds of the list to calculate the where to scroll. The bounds are initially set up in the delegate's `rendered` method. When the list is showing initially, this method is called early thereby allowing `scrollToIndex` to function correctly. When the list is hidden, the method is queued up _by priority_ to be executed when the list is shown. The current priority has the `rendered` method at a lower priority and therefore called after `scrollToIndex` causing the exception
## Fix

Move the priority of `rendered` before `scrollToIndex`.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)
