### PR TITLE
ENYO-452: Legacy configureHoldPulse settings not converted properly

### DIFF
--- a/source/dom/drag.js
+++ b/source/dom/drag.js
@@ -453,7 +453,7 @@
 		normalizeHoldPulseConfig: function (oldOpts) {
 			var nOpts = enyo.clone(oldOpts);
 			nOpts.frequency = nOpts.delay;
-			nOpts.events = [{hold: nOpts.delay}];
+			nOpts.events = [{name: 'hold', time: nOpts.delay}];
 			return nOpts;
 		},
 


### PR DESCRIPTION
This regression is a result of the implementation of ENYO-392.

To implement our custom hold feature, we changed the format of the
argument to configureHoldPulse(). To preserve backward
compatibility, we implemented automatic conversion of the old
format to the new format, but this auto-conversion is failing
because the new format itself was changed during the course of
implementation and the conversion method was not updated to target
the "new new" format.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
