### PR TITLE
ENYO-455: Set explicit version of chai.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "nopt": "2.1.2"
   },
   "devDependencies": {
+    "chai": "~1.9.2",
     "sinon": "~1.8.1",
     "sinon-chai": "~2.5.0",
     "mocha": "~1.20.0",


### PR DESCRIPTION
### Issue

When `chai` was automatically updated to version `1.10.0` from `1.9.2` in Travis, a number of assertions began throwing a TypeError

```
TypeError: '0' is not a function (evaluating 'expect(foo).to.exist.and.to.have.length(bar)')
```
### Fix

Changing the assertion from the form

```
expect(foo).to.exist.and.to.have.length(bar)
```

to the form

```
expect(foo).to.exist().and.to.have.length(bar)
```

seems to fix the errors as`1.10.0` introducing noop functional calls for assertion properties to allow chaining that caused some issues as we are accessing the noop function's `length` property rather than the chai length assertion; the second form returns the assertion rather than the noop function (see https://github.com/chaijs/chai/issues/302). While this is still being investigated, we explicitly set the version of `chai` to a working version, which is `1.9.x`.
### Notes

This should also be cherry-picked into the `release-2.5.2-pre.7` branch.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
