### PR TITLE
ENYO-451: Add "webkitvisibilitychange" event to enyo.dispatcher.events

### DIFF
--- a/source/dom/dispatcher.js
+++ b/source/dom/dispatcher.js
@@ -35,7 +35,8 @@
 		events: ["mousedown", "mouseup", "mouseover", "mouseout", "mousemove", "mousewheel",
 			"click", "dblclick", "change", "keydown", "keyup", "keypress", "input",
 			"paste", "copy", "cut", "webkitTransitionEnd", "transitionend", "webkitAnimationEnd", "animationend",
-			"webkitAnimationStart", "animationstart", "webkitAnimationIteration", "animationiteration", "webkitvisibilitychange"],
+			"webkitAnimationStart", "animationstart", "webkitAnimationIteration", "animationiteration",
+			"visibilitychange", "webkitvisibilitychange"],
 
 		/**
 		* These events come from window


### PR DESCRIPTION
To support below W2 Garnet UX, added "webkitvisibilitychange" event to enyo.dispatcher.events.

Enyo-DCO-1.1-Signed-off-by: Mikyung Kim mikyung27.kim@lge.com
