### PR TITLE
ENYO-402: Increased the precision by 10x to match the amount being added...

### DIFF
--- a/source/ui/SpriteAnimation.js
+++ b/source/ui/SpriteAnimation.js
@@ -397,7 +397,7 @@
 		* @private
 		*/
 		_generateKeyframe: function (percent, x, y) {
-			return (Math.ceil(percent*10000000, 10) / 100000) +'%	{ -webkit-transform: translate3d('+ x +'px, '+ y +'px, 0);	transform: translate3d('+ x +'px, '+ y +'px, 0); }\n';
+			return (Math.ceil(percent*10000000) / 100000) +'%	{ -webkit-transform: translate3d('+ x +'px, '+ y +'px, 0);	transform: translate3d('+ x +'px, '+ y +'px, 0); }\n';
 		}
 	});
 


### PR DESCRIPTION
... for the even frames.

The values 10000000 and 0.0000001 should always have the same inverted factor of 10, so on close rounding cases, their precision isn't dropped.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
