### PR TITLE
Added proper webOS identification for the webOS-ports release of Open we...

### DIFF
--- a/source/dom/platform.js
+++ b/source/dom/platform.js
@@ -69,9 +69,9 @@
 		// webOS 1 - 3
 		{platform: 'webos', regex: /(?:web|hpw)OS\/(\d+)/},
 		// webOS 4 / OpenWebOS
-		{platform: "webos", regex: /WebAppManager|Isis|webOS\./, forceVersion: 4},
+		{platform: 'webos', regex: /WebAppManager|Isis|webOS\./, forceVersion: 4},
 		// Open webOS release LuneOS
-		{platform: "webos", regex: /LuneOS/, forceVersion: 4, extra: {luneos: 1}},
+		{platform: 'webos', regex: /LuneOS/, forceVersion: 4, extra: {luneos: 1}},
 		// desktop Safari
 		{platform: 'safari', regex: /Version\/(\d+)[.\d]+\s+Safari/},
 		// desktop Chrome


### PR DESCRIPTION
...bOS known as LuneOS

Enyo-DCO-1.1-Signed-off-by: Jason Robitaille jason.robitaille@lge.com
