### PR TITLE
ENYO-462: Fire onScrollStop when stabilizing.

### DIFF
--- a/source/touch/ScrollMath.js
+++ b/source/touch/ScrollMath.js
@@ -432,7 +432,7 @@
 			this.y = this.y0 = y;
 			this.x = this.x0 = x;
 			this.scroll();
-			this.stop();
+			this.stop(true);
 		},
 
 		/**


### PR DESCRIPTION
### Issue

We are currently triggering an `onScrollStart` event when stabilizing in `ScrollMath`, and recently stopped triggering a corresponding `onScrollStop` event when cleaning up the scroller logic, specifically to prevent excess firing of `onScrollStop` events. In Moonstone, this causes the scroll thumbs to appear indefinitely when the scroller is stabilized (this also causes the scroll thumbs to appear indefinitely for translate-optimized TranslateScrollStrategy).
### Fix

I considered not firing `onScrollStart` when stabilizing, but this prevents a call to `calcBoundaries` that is needed. Instead, we again pass a truthy `fire` parameter to trigger the `onScrollStop` event. It seems relatively consistent to fire this event even during stabilization (though this is open to discussion as to the overall logic we're using here), as TranslateScrollStrategy stabilizes after setting scroll left/top when translate optimized without an explicit call to `stop` (this is the same technique used by MoonScrollStrategy): https://github.com/enyojs/enyo/blob/master/source/touch/TranslateScrollStrategy.js#L154. As far as I can tell, this does not cause any issues with both TranslateScrollStrategy (both translate optimized and not) and TouchScrollStrategy when testing via the DataListScrollTestbed sample, but I'd appreciate some extra eyes on this.

All that being said, I did notice some pre-existing issues in the sample, such as pressing the "Scroll to Bottom" button for TranslateScrollStrategy, which results in a blank page. Additionally, scrolling fast enough can also cause a similar effect (I believe this is an old and known issue). These issues occur with and without this proposed change.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
