### PR TITLE
ENYO-473, 476, 477: More Scroller / DataList issues

### DIFF
--- a/samples/DataListScrollTestbed.js
+++ b/samples/DataListScrollTestbed.js
@@ -49,6 +49,8 @@
                 sup.apply(this,arguments);
                 this.r = this.$.repeater;
                 this.s = this.r.$.scroller;
+                // global reference for easier console testing
+                window._sample = this;
                 //hack
                 if (this.strategy == 'Translate (Optimized)') {
                     this.s.$.strategy.translateOptimized = true;

--- a/source/touch/Thumb.js
+++ b/source/touch/Thumb.js
@@ -167,7 +167,7 @@
 		*/
 		delayHide: function (delay) {
 			if (this.showing) {
-				enyo.job(this.id + 'hide', this.bindSafely('hide'), delay || 0);
+				this.startJob('hide', this.hide, delay || 0);
 			}
 		},
 
@@ -177,7 +177,7 @@
 		* @public
 		*/
 		cancelDelayHide: function () {
-			enyo.job.stop(this.id + 'hide');
+			this.stopJob('hide');
 		}
 	});
 

--- a/source/touch/TouchScrollStrategy.js
+++ b/source/touch/TouchScrollStrategy.js
@@ -645,9 +645,6 @@
 				if (!this.isOverscrolling()) {
 					this.calcBoundaries();
 				}
-				if (this.thumb) {
-					this.showThumbs();
-				}
 			}
 		},
 
@@ -663,7 +660,7 @@
 				this.effectScroll(-sender.x, -sender.y);
 			}
 			if (this.thumb) {
-				this.updateThumbs();
+				this.showThumbs();
 			}
 		},
 

--- a/source/touch/TranslateScrollStrategy.js
+++ b/source/touch/TranslateScrollStrategy.js
@@ -130,9 +130,8 @@
 		setScrollLeft: enyo.inherit(function (sup) {
 			return function(inLeft) {
 				if (this.translateOptimized) {
-					var m = this.$.scrollMath;
-					m.setScrollX(-inLeft);
-					m.stabilize();
+					this.$.scrollMath.setScrollX(-inLeft);
+					this.stabilize();
 				} else {
 					sup.apply(this, arguments);
 				}
@@ -149,9 +148,8 @@
 		setScrollTop: enyo.inherit(function (sup) {
 			return function(inTop) {
 				if (this.translateOptimized) {
-					var m = this.$.scrollMath;
-					m.setScrollY(-inTop);
-					m.stabilize();
+					this.$.scrollMath.setScrollY(-inTop);
+					this.stabilize();
 				} else {
 					sup.apply(this, arguments);
 				}
@@ -183,6 +181,29 @@
 				return this._translated ? this.scrollTop : sup.apply(this, arguments);
 			};
 		}),
+
+		/** 
+		* See [enyo.TouchScrollStrategy.remeasure()]{@link enyo.TouchScrollStrategy#remeasure}.
+		*
+		* @method
+		* @public
+		*/
+		remeasure: enyo.inherit(function (sup) {
+			return function() {
+				sup.apply(this, arguments);
+				if (this.translateOptimized && !this.isScrolling()) this.stabilize();
+			};
+		}),
+
+		/**
+		* @method
+		* @private
+		*/
+		handleResize: function() {
+			if (this.translateOptimized) {
+				this.stabilize();
+			}
+		},
 		
 		/**
 		* @method
@@ -191,7 +212,6 @@
 		scrollMathStart: enyo.inherit(function (sup) {
 			return function(inSender) {
 				sup.apply(this, arguments);
-				this.scrollStarting = true;
 				if (!this._translated) {
 					this.startX = this.getScrollLeft();
 					this.startY = this.getScrollTop();
@@ -215,7 +235,7 @@
 					this.effectScroll(this.startX - this.scrollLeft, this.startY - this.scrollTop);
 				}
 				if (this.thumb) {
-					this.updateThumbs();
+					this.showThumbs();
 				}
 			}
 		},

--- a/source/ui/data/HorizontalDelegate.js
+++ b/source/ui/data/HorizontalDelegate.js
@@ -56,6 +56,17 @@
 		getScrollPosition: function (list) {
 			return list.$.scroller.getScrollLeft();
 		},
+
+		/**
+		* Sets the scroll position on the [scroller]{@link enyo.Scroller}
+		* owned by the given list.
+		*
+		* @private
+		*/
+		setScrollPosition: function (list, pos) {
+			list.$.scroller.setScrollLeft(pos);
+		},
+		
 		/**
 		* Overload to ensure we arbitrarily resize the active container to the width of the buffer.
 		*

--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -82,9 +82,10 @@
 				firstIndex  = list.$.page1.index || 0,
 				secondIndex = list.$.page2.index || 1;
 			pos.firstPage   = (
-				metrics[firstIndex][upperProp] < metrics[secondIndex][upperProp]
-				? list.$.page1
-				: list.$.page2			
+				metrics[firstIndex] && metrics[secondIndex] &&
+				(metrics[secondIndex][upperProp] < metrics[firstIndex][upperProp])
+				? list.$.page2
+				: list.$.page1			
 			);
 			pos.lastPage = (pos.firstPage === list.$.page1? list.$.page2: list.$.page1);
 			return pos;
@@ -257,6 +258,7 @@
 					updatedBounds   = list._updatedBounds,
 					childSize       = list.childSize,
 					perPage         = list.controlsPerPage,
+					prev            = perPage,
 					sizeProp        = list.psizeProp,
 					multi           = list.pageSizeMultiplier || this.pageSizeMultiplier,
 					fn              = this[sizeProp];
@@ -267,6 +269,10 @@
 					childSize = this.childSize(list);
 					// using height/width of the available viewport times our multiplier value
 					perPage   = list.controlsPerPage = Math.ceil(((fn.call(this, list) * multi) / childSize) + 1);
+					if (prev != perPage) {
+						// invalidate our page metrics
+						list.metrics.pages = {};
+					}
 					// update our time for future comparison
 					list._updatedControlsPerPage = enyo.perfNow();
 				}
@@ -529,6 +535,16 @@
 		},
 
 		/**
+		* Sets the scroll position on the [scroller]{@link enyo.Scroller}
+		* owned by the given list.
+		*
+		* @private
+		*/
+		setScrollPosition: function (list, pos) {
+			list.$.scroller.setScrollTop(pos);
+		},
+
+		/**
 		* @private
 		*/
 		scrollHandler: function (list, bounds) {
@@ -548,6 +564,7 @@
 			} else if ((bounds.xDir === -1 || bounds.yDir === -1) && pos.firstPage.index !== 0) {
 				this.generatePage(list, pos.lastPage, pos.firstPage.index - 1);
 				this.adjustPagePositions(list);
+				this.adjustBuffer(list);
 				// note that the reference to the page positions has been udpated by
 				// another method so we trust the actual pages
 				list.triggerEvent('paging', {
@@ -592,24 +609,25 @@
 		* @private
 		*/
 		resetToPosition: function (list, px) {
-			if (px >= 0 && px <= list.bufferSize) {
-				var index = Math.floor(px / this.defaultPageSize(list)),
-					last  = this.pageCount(list) - 1,
-					pos   = this.pagesByPosition(list);
-				if (
-					(px <= pos.firstPage[list.upperProp]) ||
-					(px >= pos.lastPage[list.lowerProp])
-				) {
-					list.$.page1.index = (index = Math.min(index, last));
-					list.$.page2.index = (index === last? (index-1): (index+1));
-					this.refresh(list);
-					list.triggerEvent('paging', {
-						start: list.$.page1.start,
-						end: list.$.page2.end,
-						action: 'reset'
-					});
-				}
-			}
+			var index, last, pos;
+
+			// If we weren't passed a position, use the current position
+			px = (typeof px == 'undefined') ? this.getScrollPosition(list) : px;
+			// Don't try to reset to an out-of-bounds position
+			px = Math.max(0, Math.min(px, list.bufferSize));
+
+			index = Math.floor(px / this.defaultPageSize(list));
+			last  = this.pageCount(list) - 1;
+			pos   = this.pagesByPosition(list);
+
+			list.$.page1.index = (index = Math.min(index, last));
+			list.$.page2.index = (index === last? (index-1): (index+1));
+			this.refresh(list);
+			list.triggerEvent('paging', {
+				start: list.$.page1.start,
+				end: list.$.page2.end,
+				action: 'reset'
+			});
 		},
 		/**
 		* Handles scroll [events]{@glossary event} for the given [list]{@link enyo.DataList}.
@@ -635,7 +653,10 @@
 						if (pos >= lt) {
 							if (pos >= lt + ds) {
 								// big jump
-								this.resetToPosition(list, pos);
+								// Async to avoid a timing issue affecting TranslateScrollStrategy
+								enyo.asyncMethod((function() {
+									this.resetToPosition(list, pos);
+								}).bind(this));
 							} else {
 								// continuous scrolling
 								this.scrollHandler(list, bounds);
@@ -647,7 +668,10 @@
 						if (pos <= ut) {
 							if (pos <= ut - ds) {
 								// big jump
-								this.resetToPosition(list, pos);
+								// Async to avoid a timing issue affecting TranslateScrollStrategy
+								enyo.asyncMethod((function() {
+									this.resetToPosition(list, pos);
+								}).bind(this));
 							} else {
 								//continuous scrolling
 								this.scrollHandler(list, bounds);
@@ -666,7 +690,10 @@
 		didResize: function (list) {
 			list._updateBounds = true;
 			this.updateBounds(list);
-			this.refresh(list);
+			// Need to update our controlsPerPage value immediately,
+			// before any cached metrics are used
+			this.controlsPerPage(list);
+			this.resetToPosition(list);
 		},
 
 		/**


### PR DESCRIPTION
This pull request addresses a number of issues:
- ENYO-473: With TranslateScrollStrategy, it was sometimes possible
  to scroll to an invalid position (outside the actual boundaries
  of the scrollable content) if the size of the content happened to
  change during (perhaps as a result of) the scrolling action. This
  situation could easily occur when using DataList, since DataList
  constantly updates the size of the "buffer" it uses to represent
  the list's full size. When this happened, the contents of the
  scroller would disappear from view. The easiest way to see this
  was to  use DataListScrollTestbed, choose the "Translate
  (Optimized)" option, and tap "Scroll to Bottom" (as described in
  ENYO-473). Although harder to reproduce, you could also make this
  happen on a Mac with Magic Trackpad by choosing either of the two
  Translate options and rapidly scrolling up and down by scrolling
  with the trackpad.
- ENYO-476: DataList was not properly refreshing when resized. This
  was because cached page-size metrics were not being invalidated
  after a resize.
- ENYO-477: In TouchScrollStrategy and subkinds, the scroll thumbs
  would often disappear unexpectedly while scrolling was still
  in progress. This is a regression that occurred between 2.4.0 and
  2.5.0, most likely due to changes in when onScrollStop events
  fire. To ensure that this won't happen, we explicitly show the
  thumbs (thus canceling any scheduled "hide" operations) in our
  onScroll handler, not onScrollStart. Because we were already
  adjusting the thumbs' position on every event and Thumb guards
  against redundant DOM changes in its setShowing() method, there
  seems to be little to no performance penalty for this change.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
