### PR TITLE
ENYO-544: Don't call stabilize() on every setScroll[X|Y]

### DIFF
--- a/source/touch/ScrollMath.js
+++ b/source/touch/ScrollMath.js
@@ -370,7 +370,6 @@
 				t = this.simulate(t);
 				// scroll if we have moved, otherwise the animation is stalled and we can stop
 				if (y0 != this.y || x0 != this.x) {
-					//this.log(this.y, y0);
 					this.scroll();
 				} else if (!this.dragging) {
 					// set final values
@@ -569,7 +568,6 @@
 		*/
 		setScrollX: function (x) {
 			this.x = this.x0 = x;
-			this.stabilize();
 		},
 
 		/**
@@ -581,7 +579,6 @@
 		*/
 		setScrollY: function (y) {
 			this.y = this.y0 = y;
-			this.stabilize();
 		},
 
 		/**

--- a/source/touch/TouchScrollStrategy.js
+++ b/source/touch/TouchScrollStrategy.js
@@ -684,6 +684,7 @@
 				this.showThumbs();
 				this.delayHideThumbs(100);
 			}
+			return true;
 		},
 
 		/**

--- a/source/touch/TranslateScrollStrategy.js
+++ b/source/touch/TranslateScrollStrategy.js
@@ -146,10 +146,8 @@
 					p = this.scrollLeft;
 					m = this.$.scrollMath;
 					this.stop(true);
-					// This will result in a call to
-					// ScrollMath.stabilize(), ensuring
-					// that we stay in bounds
 					m.setScrollX(-inLeft);
+					m.stabilize();
 					if (p != -m.x) {
 						// We won't get a native scroll event,
 						// so need to make one ourselves
@@ -176,10 +174,8 @@
 					p = this.scrollTop;
 					m = this.$.scrollMath;
 					this.stop(true);
-					// This will result in a call to
-					// ScrollMath.stabilize(), ensuring
-					// that we stay in bounds
 					m.setScrollY(-inTop);
+					m.stabilize();
 					if (p != -m.y) {
 						// We won't get a native scroll event,
 						// so need to make one ourselves
@@ -278,8 +274,9 @@
 					this.scrollLeft = -sender.x;
 					this.scrollTop = -sender.y;
 					this.effectScroll(-sender.x, -sender.y);
+					return true;
 				} else {
-					sup.apply(this, arguments);
+					return sup.apply(this, arguments);
 				}
 			};
 		}),


### PR DESCRIPTION
In the fix for ENYO-483, we introduced a call to stabilize()
every time setScrollX() or setScrollY() was called. This seemed
like a logical place to clamp the scroll position and eliminated
the need for some manual calls to stabilize() elsewhere, but it
turns out that some existing behavior in moon.ScrollStrategy
depends on allowing the position to be temporarily out of bounds.

The Moonstone behavior is complicated, but seems to be reasonable,
so reverting this particular change (affecting ScrollMath,
TouchScrollStrategy and TranslateScrollStrategy). The corresponding
change is also being made in moon.ScrollStrategy.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
