### PR TITLE
ENYO-549: VerticalGridDelegate doesn't trigger scroller remeasure

### DIFF
--- a/source/ui/data/VerticalGridDelegate.js
+++ b/source/ui/data/VerticalGridDelegate.js
@@ -261,6 +261,7 @@
 				list.bufferSize = bs;
 				n.style[sp] = bs + 'px';
 				n.style[ss] = this[ss](list) + 'px';
+				list.$.scroller.remeasure();
 			}
 		},
 		


### PR DESCRIPTION
# Issue

`enyo.VerticalDelgate` (in its `adjustBuffer()` method) triggers the list's scroller to measure its bounds after list pages have been generated / regenerated. However, `enyo.VerticalDelegate` overrides `adjustBuffer()` without calling the super method, so this measurement doesn't occur.

Under some circumstances, this doesn't matter, since scroller measurement is also triggered by other events (e.g. wheel scrolling, starting a drag, etc.) – but it is problematic in other cases (where there's a persistent, manipulatable scroll controller like a draggable thumb; or when the list generates pages in the middle of a long animated scroll).
# Fix

To fix, we'll just add the trigger to `VerticalGridDelegate` as well.

`HorizontalDelegate.adjustBuffer()` does call the super method, so no need to add it explicitly in that case.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
