### PR TITLE
BHV-18217: Avoid generating invalid page index for one-page list

### DIFF
--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -609,7 +609,7 @@
 		* @private
 		*/
 		resetToPosition: function (list, px) {
-			var index, last, pos;
+			var index, pc, last;
 
 			// If we weren't passed a position, use the current position
 			px = (typeof px == 'undefined') ? this.getScrollPosition(list) : px;
@@ -617,11 +617,11 @@
 			px = Math.max(0, Math.min(px, list.bufferSize));
 
 			index = Math.floor(px / this.defaultPageSize(list));
-			last  = this.pageCount(list) - 1;
-			pos   = this.pagesByPosition(list);
+			pc = this.pageCount(list);
+			last  = pc - 1;
 
 			list.$.page1.index = (index = Math.min(index, last));
-			list.$.page2.index = (index === last? (index-1): (index+1));
+			list.$.page2.index = (index === last && pc > 1? (index-1): (index+1));
 			this.refresh(list);
 			list.triggerEvent('paging', {
 				start: list.$.page1.start,


### PR DESCRIPTION
We recently updated the logic in VerticalDelegate's resetToPosition
method to fix a bug and support additional use cases, but
introduced a new issue in the case where a list only has enough
items to fill a single page.

This commit adds logic to ensure that we don't calculate an invalid
page index (-1) in this case.

Also removing no-longer-needed call to pagesByPosition, which
was left over from a previous implementation of resetToPosition.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
