### PR TITLE
ENYO-339: getAbsoluteBounds now exactly mirrors getBoundingClientRect

### DIFF
--- a/source/dom/dom.js
+++ b/source/dom/dom.js
@@ -503,17 +503,7 @@
 		* @public
 		*/
 		getAbsoluteBounds: function(targetNode) {
-			var rect           = targetNode.getBoundingClientRect(),
-				width          = targetNode.offsetWidth,
-				height         = targetNode.offsetHeight;
-			return {
-				top     : rect.top,
-				left    : rect.left,
-				bottom  : document.body.offsetHeight - rect.top  - height,
-				right   : document.body.offsetWidth  - rect.left - width,
-				height  : height,
-				width   : width
-			};
+			return targetNode.getBoundingClientRect();
 		},
 
 		/**


### PR DESCRIPTION
This includes rotation and complex transformations. For basic measurements, which disregard for transformed size, just basic DOM measurement, use `enyo.dom.getBounds()`.

_See JIRA2 issue for complete description and images_

Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
