### PR TITLE
ENYO-571: Prevent poisoning of other DataLists after explicitly specifying controlsPerPage.

### DIFF
--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -40,7 +40,7 @@
 			so.horizontal  = so.horizontal || 'hidden';
 			// determine if the _controlsPerPage_ property has been set on the list
 			if (list.controlsPerPage !== null && !isNaN(list.controlsPerPage)) {
-				this._staticControlsPerPage = true;
+				list._staticControlsPerPage = true;
 			}
 		},
 		
@@ -251,7 +251,7 @@
 		* @private
 		*/
 		controlsPerPage: function (list) {
-			if (this._staticControlsPerPage) {
+			if (list._staticControlsPerPage) {
 				return list.controlsPerPage;
 			} else {
 				var updatedControls = list._updatedControlsPerPage,


### PR DESCRIPTION
### Issue

We had previously added the ability to specify `controlsPerPage` at create time. This had the side effect of setting a flag capturing this, but this flag was set on the delegate instead of the specific list. This could result in other DataList controls utilizing an unspecified value for `controlsPerPage`, i.e. `undefined`.
### Fix

We set this flag on the list instead of the delegate.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
