### PR TITLE
BHV-18751: Prevent thumbs from showing when content is not scrollable.

### DIFF
--- a/source/touch/TouchScrollStrategy.js
+++ b/source/touch/TouchScrollStrategy.js
@@ -646,6 +646,9 @@
 					this.calcBoundaries();
 				}
 			}
+			if (this.thumb) {
+				this.showThumbs();
+			}
 		},
 
 		/**
@@ -660,7 +663,7 @@
 				this.effectScroll(-sender.x, -sender.y);
 			}
 			if (this.thumb) {
-				this.showThumbs();
+				this.updateThumbs();
 			}
 		},
 


### PR DESCRIPTION
### Issue

Due to some recent scroller changes, we were making a call to `showThumbs` for each `onScroll` event from ScrollMath. This caused the scroll thumb to be visible even when there was no content to scroll.
### Fix

We only make a call to `showThumbs` when we start scrolling, and make a call to `updateThumbs` for each ScrollMath `onScroll` event in order to hide as appropriate.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
