### PR TITLE
ENYO-575: Guard against invalid page index

### DIFF
--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -176,7 +176,7 @@
 			
 			// if generating a control we need to use the correct page as the control parent
 			list.controlParent = page;
-			for (var i=page.start; i <= page.end && i < data.length; ++i) {
+			for (var i=page.start; i != null && i <= page.end && i < data.length; ++i) {
 				view = (page.children[i - page.start] || list.createComponent({}));
 				// disable notifications until all properties to be updated
 				// have been


### PR DESCRIPTION
Temporary fix for bogus page index problem that can cause invalid
elements to render in DataList. Permanent fix coming soon...

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
