### PR TITLE
ENYO-573: Synchronize up/down events based on button.

### DIFF
--- a/source/dom/gesture.js
+++ b/source/dom/gesture.js
@@ -130,6 +130,10 @@
 		up: function(evt) {
 			var e = this.makeEvent('up', evt);
 
+			// We have added some logic to synchronize up and down events in certain scenarios (i.e.
+			// clicking multiple buttons with a mouse) and to generally guard against any potential
+			// asymmetry, but a full solution would be to maintain a map of up/down events as an 
+			// ideal solution, for future work.
 			e._tapPrevented = this.downEvent && this.downEvent._tapPrevented && this.downEvent.which == e.which;
 			e.preventTap = function() {
 				e._tapPrevented = true;


### PR DESCRIPTION
### Issue

There can be situations where a mouse button is pressed down, and another mouse button is pressed down (a two-finger tap in an Android WebView, or using a multi-button mouse). When releasing one of the mouse buttons, `downEvent` is dereferenced when we handle `mouseup`, so when the remaining down-pressed mouse button is released, we are attempting to access a property of a `null` object. Additionally, when interacting with select controls, with the select control displaying its options list, a mouse button press outside of this list only generates a `mouseup` event and not a `mousedown` event, resulting in the same symptom. Please refer to http://www.quirksmode.org/dom/events/click.html, specifically the "On form fields and links" section.
### Fix

We now guard against a falsy `downEvent` object, but I wanted to also synchronize the up/down events when possible, by examining the `which` property of the event. This is pertinent when using a mouse with distinct buttons, where now the tap prevention property properly propagates (check out that alliteration) from the `mousedown` event to its corresponding `mouseup` event. In the case of Android's WebView, each tap registers as the same button, so effectively the fix just guards against a dereferenced `downEvent` before accessing its properties, as `downEvent` is dereferenced each time we handle `mouseup`. If this change seems too risky or unnecessary, we can tweak the PR and only keep the guard code.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
