### PR TITLE
ENYO-591: Clean up DataList page assignment logic

### DIFF
--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -271,6 +271,19 @@
 			var perPage = list.controlsPerPage || this.controlsPerPage(list);
 			return Math.floor(i / (perPage || 1));
 		},
+
+		/**
+		* An indirect interface to the list's scroller's scrollToControl()
+		* method. We provide this to create looser coupling between the
+		* delegate and the list / scroller, and to enable subkinds of the
+		* delegate to easily override scrollToControl() functionality to
+		* include options specific to the scroller being used.
+		*
+		* @private
+		*/
+		scrollToControl: function (list, control) {
+			list.$.scroller.scrollToControl(control);
+		},
 		
 		/**
 		* Attempts to scroll to the given index.
@@ -279,22 +292,19 @@
 		* @param {Number} i - The index to scroll to.
 		* @private
 		*/
-		scrollToIndex: function (list, i, scrollerArgs) {
+		scrollToIndex: function (list, i) {
 				// first see if the child is already available to scroll to
 			var c = this.childForIndex(list, i),
 				// but we also need the page so we can find its position
-				p = this.pageForIndex(list, i),
-				s = list.$.scroller;
+				p = this.pageForIndex(list, i);
 			// if there is no page then the index is bad
 			if (p < 0 || p > this.pageCount(list)) { return; }
 			// if there isn't one, then we know we need to go ahead and
 			// update, otherwise we should be able to use the scroller's
 			// own methods to find it
-			s.stop();
+			list.$.scroller.stop();
 			if (c) {
-				scrollerArgs = scrollerArgs || [];
-				scrollerArgs.unshift(c);
-				s.scrollToControl.apply(s, scrollerArgs);
+				this.scrollToControl(list, c);
 			} else {
 				// we do this to ensure we trigger the paging event when necessary
 				this.resetToPosition(list, this.pagePosition(list, p));


### PR DESCRIPTION
We have recently had some issues (e.g. ENYO-575, BHV-18217) that
arose because DataList would sometimes assign invalid (negative)
page indices.

We made point fixes to address these specific issues (including
one fix that we knew was just a quickfix for a deeper issue), but
in the process it became apparent that some general cleanup in this
area would yield more understandable / maintainable code and
probably nip similar issues in the bud.

In this change, we:
- Consolidate page assignment logic, which was formerly done
  partially in refresh() and partially in resetToPosition(), into
  a single new  method, assignPageIndices()
- Incorporate logic originally implemented in Moonstone to be
  smarter about choosing whether to generate the preceding or
  following page along with our target page
- Document page assignment logic thoroughly with inline comments
- Refactor reset(), refresh() and resetToPosition() to be
  independent of one another while sharing common functionality
- Add a new optional argument, scrollerArgs, to scrollToIndex().
  This allows scrollToIndex() to be easily overridden in Moonstone
  (and potentially other libraries) without copying and pasting a lot of code.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
