### PR TITLE
BHV-19184: Allow for continuation of scroll animation upon a tap.

### DIFF
--- a/source/touch/ScrollStrategy.js
+++ b/source/touch/ScrollStrategy.js
@@ -85,7 +85,16 @@
 			* @default true
 			* @public
 			*/
-			useMouseWheel: true
+			useMouseWheel: true,
+
+			/**
+			* Set to `false` to prevent a tap from stopping the current scroll animation.
+			* 
+			* @type {Boolean}
+			* @default true
+			* @public
+			*/
+			tapToStop: true
 		},
 		
 		/**
@@ -370,10 +379,12 @@
 		* @private
 		*/
 		down: function (sender, e) {
-			if (this.isScrolling()) {
-				e.preventTap();
+			if (this.tapToStop) {
+				if (this.isScrolling()) {
+					e.preventTap();
+				}
+				this.calcStartInfo();
 			}
-			this.calcStartInfo();
 		},
 
 		/**

--- a/source/touch/Scroller.js
+++ b/source/touch/Scroller.js
@@ -164,6 +164,7 @@
 			* @default false
 			* @public
 			*/
+
 			touch: false,
 			/**
 			* Specifies a type of scrolling. The [scroller]{@link enyo.Scroller} will attempt to 
@@ -203,7 +204,16 @@
 			* @default true
 			* @public
 			*/
-			useMouseWheel: true
+			useMouseWheel: true,
+
+			/**
+			* Set to `false` to prevent a tap from stopping the current scroll animation.
+			* 
+			* @type {Boolean}
+			* @default true
+			* @public
+			*/
+			tapToStop: true
 		},
 
 		/**
@@ -405,7 +415,7 @@
 		*/
 		createStrategy: function () {
 			this.createComponents([{name: 'strategy', maxHeight: this.maxHeight,
-				kind: this.strategyKind, thumb: this.thumb,
+				kind: this.strategyKind, thumb: this.thumb, tapToStop: this.tapToStop,
 				preventDragPropagation: this.preventDragPropagation,
 				overscroll:this.touchOverscroll, isChrome: true}]);
 		},
@@ -785,6 +795,15 @@
 		*/
 		useMouseWheelChanged: function () {
 			this.$.strategy.setUseMouseWheel(this.useMouseWheel);
+		},
+
+		/**
+		* Sends the [tapToStop]{@link enyo.Scroller#tapToStop} property to the scroll strategy.
+		*
+		* @private
+		*/
+		tapToStopChanged: function () {
+			this.$.strategy.setTapToStop(this.tapToStop);
 		},
 
 		/**


### PR DESCRIPTION
### Issue

There are situations where we do not want the act of tapping on scrolling content to interrupt the current scroll animation.
### Fix

We add a property `tapToStop` to `enyo.ScrollStrategy` and facade this in `enyo.Scroller`.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
