### PR TITLE
ENYO-593: Scroll thumb doesn't properly hide in some cases

### DIFF
--- a/source/touch/TouchScrollStrategy.js
+++ b/source/touch/TouchScrollStrategy.js
@@ -661,6 +661,7 @@
 			}
 			if (this.thumb) {
 				this.showThumbs();
+				this.delayHideThumbs(100);
 			}
 		},
 


### PR DESCRIPTION
We recently made a change to the thumb-showing and -hiding logic
in TouchScrollStrategy, calling showThumbs() from the
onScrollMathScroll handler. We neglected to call delayHideThumbs(),
however, which resulted in the thumb not properly disappearing in
some edge cases.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
