### PR TITLE
ENYO-643: Synchronize selection states.

### DIFF
--- a/source/ui/data/DataRepeater.js
+++ b/source/ui/data/DataRepeater.js
@@ -43,8 +43,8 @@
 		* selection and deselection of a single item at a time. The 'multi' selection mode allows
 		* multiple children to be selected simultaneously, while the 'group' selection mode allows
 		* group-selection behavior such that only one child may be selected at a time and, once a
-		* child is selected, it cannot be selected via user input. The child may still be deselected
-		* via the selection API methods.
+		* child is selected, it cannot be deselected via user input. The child may still be 
+		* deselected via the selection API methods.
 		* 
 		* @type {String}
 		* @default 'single'
@@ -223,6 +223,10 @@
 		* @private
 		*/
 		selectionTypeChanged: function (was) {
+			// Synchronizing our deprecated properties
+			this.groupSelection = this.selectionType == 'group';
+			this.multipleSelection = this.selectionType == 'multi';
+
 			if (was == 'multi') {
 				if (this._selection.length > 1) {
 					this.deselectAll();

--- a/source/ui/data/RepeaterChildSupport.js
+++ b/source/ui/data/RepeaterChildSupport.js
@@ -76,7 +76,7 @@
 		*/
 		_selectionHandler: function () {
 			if (this.repeater.selection && !this.get('disabled')) {
-				if (!this.repeater.groupSelection || !this.selected) {
+				if (this.repeater.selectionType != 'group' || !this.selected) {
 					this.set('selected', !this.selected);
 				}
 			}

--- a/tools/mocha-tests/tests/DataGridList.js
+++ b/tools/mocha-tests/tests/DataGridList.js
@@ -136,7 +136,7 @@ describe('enyo.DataGridList', function () {
 				
 				var selected;
 				
-				repeater.set('multipleSelection', true);
+				repeater.set('selectionType', 'multi');
 				repeater.select(0);
 				repeater.select(1);
 				selected = repeater.get('selected');
@@ -174,14 +174,14 @@ describe('enyo.DataGridList', function () {
 				expect(selected).to.exist.and.to.have.length(collection.length);
 			});
 			
-			it ('should select all available indices when multipleSelection is true and the ' +
+			it ('should select all available indices when selectionType is "multi" and the ' +
 				'selectAll method is called', function () {
 				
 				repeater.selectAll();
 				expect(repeater.get('selected')).to.exist.and.to.have.length(collection.length);
 			});
 			
-			it ('should deselect all available indices when multipleSelection is true and the ' +
+			it ('should deselect all available indices when selectionType is "multi" and the ' +
 				'deselectAll method is called', function () {
 				
 				repeater.deselectAll();
@@ -191,7 +191,7 @@ describe('enyo.DataGridList', function () {
 			it ('should deselect a model that was selected and destroyed in single select mode',
 				function () {
 				
-				repeater.set('multipleSelection', false);
+				repeater.set('selectionType', 'single');
 				repeater.select(3);
 				
 				// ensure that we had a selection to begin with for the sake of the test

--- a/tools/mocha-tests/tests/DataList.js
+++ b/tools/mocha-tests/tests/DataList.js
@@ -136,7 +136,7 @@ describe('enyo.DataList', function () {
 				
 				var selected;
 				
-				repeater.set('multipleSelection', true);
+				repeater.set('selectionType', 'multi');
 				repeater.select(0);
 				repeater.select(1);
 				selected = repeater.get('selected');
@@ -174,14 +174,14 @@ describe('enyo.DataList', function () {
 				expect(selected).to.exist.and.to.have.length(collection.length);
 			});
 			
-			it ('should select all available indices when multipleSelection is true and the ' +
+			it ('should select all available indices when selectionType is "multi" and the ' +
 				'selectAll method is called', function () {
 				
 				repeater.selectAll();
 				expect(repeater.get('selected')).to.exist.and.to.have.length(collection.length);
 			});
 			
-			it ('should deselect all available indices when multipleSelection is true and the ' +
+			it ('should deselect all available indices when selectionType is "multi" and the ' +
 				'deselectAll method is called', function () {
 				
 				repeater.deselectAll();
@@ -191,7 +191,7 @@ describe('enyo.DataList', function () {
 			it ('should deselect a model that was selected and destroyed in single select mode',
 				function () {
 				
-				repeater.set('multipleSelection', false);
+				repeater.set('selectionType', 'single');
 				repeater.select(3);
 				
 				// ensure that we had a selection to begin with for the sake of the test
@@ -211,7 +211,7 @@ describe('enyo.DataList', function () {
 			it ('should deselect a model that was selected and destroyed in multiple select mode',
 				function () {
 				
-				repeater.set('multipleSelection', true);
+				repeater.set('selectionType', 'multi');
 				repeater.selectAll();
 				
 				// for sanity of the test

--- a/tools/mocha-tests/tests/DataRepeater.js
+++ b/tools/mocha-tests/tests/DataRepeater.js
@@ -136,7 +136,7 @@ describe('enyo.DataRepeater', function () {
 				
 				var selected;
 				
-				repeater.set('multipleSelection', true);
+				repeater.set('selectionType', 'multi');
 				repeater.select(0);
 				repeater.select(1);
 				selected = repeater.get('selected');
@@ -174,14 +174,14 @@ describe('enyo.DataRepeater', function () {
 				expect(selected).to.exist.and.to.have.length(collection.length);
 			});
 			
-			it ('should select all available indices when multipleSelection is true and the ' +
+			it ('should select all available indices when selectionType is "multi" and the ' +
 				'selectAll method is called', function () {
 				
 				repeater.selectAll();
 				expect(repeater.get('selected')).to.exist.and.to.have.length(collection.length);
 			});
 			
-			it ('should deselect all available indices when multipleSelection is true and the ' +
+			it ('should deselect all available indices when selectionType is "multi" and the ' +
 				'deselectAll method is called', function () {
 				
 				repeater.deselectAll();
@@ -191,7 +191,7 @@ describe('enyo.DataRepeater', function () {
 			it ('should deselect a model that was selected and destroyed in single select mode',
 				function () {
 				
-				repeater.set('multipleSelection', false);
+				repeater.set('selectionType', 'single');
 				repeater.select(3);
 				
 				// ensure that we had a selection to begin with for the sake of the test


### PR DESCRIPTION
### Issue
We had various selection states (`selection`, `multipleSelection`, `groupSelection`) which were becoming out of sync due to mutual exclusion and some coupling. This was somewhat evidenced in the DataGridListSample when toggling the various selection states.

### Fix
We have introduced a new property called `selectionType`, which can be of the value `single` (the default), `multi`, or `group`. Because there was never any logic previously enforcing the fact that multiple selection automatically enables selection in general, we ignore this logic and do not make any assumptions about setting `selection` based on `selectionType`, to keep a cleaner separation between the properties. The `selectionType` property is effectively set via the deprecated selection properties (`multipleSelection` and `groupSelection`), so this should not break existing code. There is a pre-existing issue I noticed where multiple items are selected and `selection` is disabled, resulting in some CSS classes not being properly removed - this seemed better handled in a separate PR.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>