### PR TITLE
Fixes ENYO-527

### DIFF
--- a/source/ui/data/DataList.js
+++ b/source/ui/data/DataList.js
@@ -148,6 +148,16 @@
 		renderDelay: 250,
 
 		/**
+		* Percentage (as a number between 0 and 1) of a control that must be visible to be counted
+		* by {@link enyo.DataList#getVisibleControls}.
+		*
+		* @type {Number}
+		* @default 0.6
+		* @public
+		*/
+		visibleThreshold: 0.6,
+
+		/**
 		* This is an inclusive list of all methods that can be queued,
 		* and the prefered order they should execute, if a method is
 		* not listed, it will NOT be called ever.
@@ -212,6 +222,19 @@
 					});
 				}
 			}
+		},
+
+		/**
+		* Returns the `start` and `end` indices of the visible controls. Partially visible controls
+		* are included if the amount visible exceeds the {@link enyo.DataList#visibleThreshold}.
+		*
+		* This operation is *layout intesive* and should not be called during scrolling.
+		*
+		* @return {Object}
+		* @public
+		*/
+		getVisibleControlRange: function () {
+			return this.delegate.getVisibleControlRange(this);
 		},
 
 		/**

--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -764,6 +764,131 @@
 			list.boundsCache    = list.getBounds();
 			list._updatedBounds = enyo.perfNow();
 			list._updateBounds  = false;
+		},
+
+		/**
+		* Returns the `start` and `end` indices of the visible controls. Partially visible controls
+		* are included if the amount visible exceeds the {@link enyo.DataList#visibleThreshold}.
+		*
+		* @private
+		*/
+		getVisibleControlRange: function (list) {
+			var ret = {
+					start: -1,
+					end: -1
+				},
+				posProp = list.posProp,
+				sizeProp  = list.psizeProp,
+				size = this[sizeProp](list),
+				scrollPosition = this.getScrollPosition(list),
+				pages = list.pages.slice(0).sort(function (a, b) {
+					return a.start - b.start;
+				}),
+				i = 0,
+				max = list.collection? list.collection.length - 1 : 0,
+				cpp = list.controlsPerPage,
+				p, bounds, ratio;
+
+			// find the first showing page and estimate the start and end indices
+			while ((p = pages[i++])) {
+				bounds = p.getBounds();
+				bounds.right = list.bufferSize - bounds.left - bounds.width;
+
+				if (scrollPosition >= bounds[posProp] && scrollPosition < bounds[posProp] + bounds[sizeProp]) {
+					ratio = cpp/bounds[sizeProp];
+					ret.start = Math.max(0, Math.round((scrollPosition - bounds[posProp])*ratio) + p.start);
+					ret.end = Math.min(max, Math.round(size*ratio) + ret.start);
+					break;
+				}
+			}
+
+			ret.start = this.adjustIndex(list, ret.start, p, bounds, scrollPosition, true);
+			ret.end = Math.max(ret.start, this.adjustIndex(list, ret.end, p, bounds, scrollPosition + size, false));
+
+			return ret;
+		},
+
+		/**
+		* Refines an estimated `index` to a precise index by evaluating the bounds of the control at
+		* the estimated `index` against the visible area and adjusting it up or down based on the
+		* actual bounds and the `list`'s {@link enyo.DataList#visibleThreshold}.
+		*
+		* @param {enyo.DataList} list
+		* @param {Number}        index           Estimated index
+		* @param {enyo.Control}  page            Page control containing control at `index`
+		* @param {Object}        pageBounds      Bounds of `page`
+		* @param {Number}        scrollBoundary  Edge of visible area (top, bottom, left, or right)
+		* @param {Boolean}       start           `true` for start of boundary (top, right), `false`
+		*   for end
+		* @private
+		*/
+		adjustIndex: function (list, index, page, pageBounds, scrollBoundary, start) {
+			var dir = start? -1 : 1,
+				posProp = list.posProp,
+				sizeProp  = list.psizeProp,
+				max = list.collection? list.collection.length - 1 : 0,
+				last, control, bounds,
+
+				// edge of control
+				edge,
+
+				// distance from edge of control to scroll boundary
+				dEdge,
+
+				// distance from visible threshold to scroll boundary
+				dThresh;
+
+			do {
+				control = list.getChildForIndex(index);
+
+				// account for crossing page boundaries
+				if (control.parent != page) {
+					page = control.parent;
+					pageBounds = page.getBounds();
+				}
+
+				bounds = control.getBounds();
+				bounds.right = pageBounds.width - bounds.left - bounds.width;
+
+				edge = bounds[posProp] + pageBounds[posProp] + (start? 0 : bounds[sizeProp]);
+				dEdge = edge - scrollBoundary;
+				dThresh = dEdge - dir*bounds[sizeProp]*(1-list.visibleThreshold)	;
+
+				if ((start && dEdge > 0) || (!start && dEdge < 0)) {
+					// control is fully visible
+					if (last !== index + dir) {
+						last = index;
+						index += dir;
+					} else {
+						// if this control is fully visible but the last was too obscured, use this
+						break;
+					}
+				} else if ((start && dThresh >= 0) || (!start && dThresh <= 0)) {
+					// control is partially obscured but enough is visible
+					break;
+				} else {
+					// control is too obscured
+					if (last !== index - dir) {
+						last = index;
+						index -= dir;
+					} else {
+						// use the last since this is too obscured
+						index = last;
+						break;
+					}
+				}
+
+				// guard against selecting an index that is out of bounds
+				if (index < 0) {
+					index = 0;
+					break;
+				} else if (index > max) {
+					index = max;
+					break;
+				}
+			} while (true);
+
+			return index;
 		}
 	};
 

--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -128,6 +128,8 @@
 			// get our initial sizing cached now since we should actually have
 			// bounds at this point
 			this.updateBounds(list);
+			// calc offset of pages to scroller client
+			this.calcScrollOffset(list);
 			// now if we already have a length then that implies we have a controller
 			// and that we have data to render at this point, otherwise we don't
 			// want to do any more initialization
@@ -794,7 +796,7 @@
 				bounds = p.getBounds();
 				bounds.right = list.bufferSize - bounds.left - bounds.width;
 
-				adjustedScrollPosition = this.adjustScrollPosition(list, p, bounds, scrollPosition);
+				adjustedScrollPosition = scrollPosition - list.scrollPositionOffset;
 
 				if (scrollPosition >= bounds[posProp] && scrollPosition < bounds[posProp] + bounds[sizeProp]) {
 					ratio = cpp/bounds[sizeProp];
@@ -811,32 +813,26 @@
 		},
 
 		/**
-		* Adjusts the scroll position to ignore the dimensions of any controls that are within the
-		* scroller but precede the pages. Accepts the `page` and `pageBounds` to avoid another
-		* call to `getBounds()`.
+		* Calculates the scroll position offset to account for the dimensions of any controls that
+		* are within the scroller but precede the pages.
 		*
 		* @param  {enyo.DataList} list            The instance of enyo.DataList
-		* @param  {enyo.Control}  page            Either of the pages
-		* @param  {Object}        pageBounds      Bounds of `page`
-		* @param  {Number}        scrollPosition  Current scroll position
-		*
-		* @return {Number}                        Adjusted scroll position
 		* @private
 		*/
-		adjustScrollPosition: function (list, page, pageBounds, scrollPosition) {
-			var posProp = list.posProp,
-				offset = list.scrollPositionOffset,
-				pageNode, scrollerNode, position;
+		calcScrollOffset: function (list) {
+			var wrapper = list.pages[0].parent.hasNode(),
+				scroller = list.$.scroller.hasNode(),
+				posProp = list.posProp,
+				position;
 
-			// adjust scroll position for any controls within scroller preceding the pages
-			if (!offset && offset !== 0) {
-				pageNode = list.pages[0].hasNode();
-				scrollerNode = list.$.scroller.hasNode();
-				position = enyo.dom.calcNodePosition(pageNode, scrollerNode);
-				offset = list.scrollPositionOffset = position[posProp] - pageBounds[posProp];
+			// these should always be truthy in production scenarios but since the nodes aren't
+			// actually rendered in mocha, the tests fail so guarding against that.
+			if (wrapper && scroller) {
+				position = enyo.dom.calcNodePosition(wrapper, scroller);
+				list.scrollPositionOffset = position[posProp];
+			} else {
+				list.scrollPositionOffset = 0;
 			}
-
-			return scrollPosition - offset;
 		},
 
 		/**

--- a/source/ui/data/VerticalGridDelegate.js
+++ b/source/ui/data/VerticalGridDelegate.js
@@ -285,7 +285,20 @@
 			// it is necessary to update the content of the list according to our
 			// new sizing
 			this.refresh(list);
-		}
+		},
+
+		/**
+		* @see enyo.VerticalDelegate#adjustIndex
+		* @private
+		*/
+		adjustIndex: enyo.inherit(function (sup) {
+			return function (list, index, page, pageBounds, scrollBoundary, start) {
+				var idx = sup.apply(this, arguments),
+					delta = idx%list.columns;
+
+				return idx - delta + (start? 0 : list.columns - 1);
+			};
+		})
 	}, true);
 
 	enyo.DataGridList.delegates.verticalGrid = p;

--- a/source/ui/data/VerticalGridDelegate.js
+++ b/source/ui/data/VerticalGridDelegate.js
@@ -23,6 +23,8 @@
 			// get our initial sizing cached now since we should actually have
 			// bounds at this point
 			this.updateMetrics(list);
+			// calc offset of pages to scroller client
+			this.calcScrollOffset(list);
 			// now if we already have a length then that implies we have a controller
 			// and that we have data to render at this point, otherwise we don't
 			// want to do any more initialization


### PR DESCRIPTION
## Issue
Need to provide API to determine which controls are visible for a DataList and DataGridList.

## Fix
Add `getVisibleControlRange()` to enyo.DataList which returns the `start` and `end` index of the visible controls. For a control to be considered visible, a certain percentage (established by the `visibleThreshold` property) must be visible.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)