### PR TITLE
ENYO-642: TranslateScrollStrategy: Scroll thumb is not updated

### DIFF
--- a/source/touch/TouchScrollStrategy.js
+++ b/source/touch/TouchScrollStrategy.js
@@ -831,8 +831,10 @@
 		},
 
 		/**
-		* Syncs and shows both the vertical and horizontal scroll indicators.
-		* Sync after deciding to show/hide so thumb.update doesn't calculate if uneeded.
+		* Syncs and shows both the vertical and horizontal scroll indicators. We only sync after we
+		* have checked if the vertical and/or horizontal scroll indicators are to be shown, so that
+		* {@link enyo.ScrollThumb#update} accurately makes calculations when the indicators are
+		* visible.
 		*
 		* @public
 		*/


### PR DESCRIPTION
Issue.

When using strategies other than `Native`, the thumb position was not updated correctly, when scrolling items into view.

Solution.

Move the call to Sync the thumb, after it had been determined if the thumb should be visible or hidden.

Also cleaned up blank spaces at the end of the file.

Enyo-DCO-1.1-Signed-off-by: Derek Anderson derek.anderson@lge.com
