### PR TITLE
ENYO-671: Return the getAbsoluteBounds object as a fresh mutable object.

### DIFF
--- a/source/dom/dom.js
+++ b/source/dom/dom.js
@@ -503,7 +503,7 @@
 		* @public
 		*/
 		getAbsoluteBounds: function(targetNode) {
-			return targetNode.getBoundingClientRect();
+			return enyo.clone(targetNode.getBoundingClientRect());
 		},
 
 		/**


### PR DESCRIPTION
Previously it was returning an immutable object reference which, when other code tried to modify, wouldn't get modified. Now it can be.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
