### PR TITLE
ENYO-655: DataList page-positioning issue after adding models

### DIFF
--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -253,17 +253,11 @@
 			} else {
 				var updatedControls = list._updatedControlsPerPage,
 					updatedBounds   = list._updatedBounds,
-					perPage         = list.controlsPerPage,
-					prev            = perPage;
+					perPage         = list.controlsPerPage;
 				// if we've never updated the value or it was done longer ago than the most
 				// recent updated sizing/bounds we need to update
 				if (!updatedControls || (updatedControls < updatedBounds)) {
 					perPage = list.controlsPerPage = this.calculateControlsPerPage(list);
-					if (prev !== perPage) {
-						// since we are now using a different number of controls per page,
-						// we need to invalidate our cached page metrics
-						list.metrics.pages = {};
-					}
 					// update our time for future comparison
 					list._updatedControlsPerPage = enyo.perfNow();
 				}
@@ -725,11 +719,18 @@
 		* @private
 		*/
 		didResize: function (list) {
+			var prevCPP = list.controlsPerPage;
+
 			list._updateBounds = true;
 			this.updateBounds(list);
 			// Need to update our controlsPerPage value immediately,
 			// before any cached metrics are used
 			this.controlsPerPage(list);
+			if (prevCPP !== list.controlsPerPage) {
+				// since we are now using a different number of controls per page,
+				// we need to invalidate our cached page metrics
+				list.metrics.pages = {};
+			}
 			this.resetToPosition(list);
 		},
 


### PR DESCRIPTION
In some circumstances, the vertical delegate's page-positioning
logic was failing after adding models to a DataList's collection.

Specifically, there is an optimization in modelsAdded() to avoid
regenerating list pages in the case where the models added are all
later in the list than the currently rendered pages. In this case,
we skip page generation and merely adjust page positions, using
cached metrics to calculate the position of each page.

It turns out that this approach has recently been positioning pages
inaccurately, due to a fix we made for another page-positioning
issue. We recently started invalidating our cached page metrics
whenever we updated our controlsPerPage calculation to ensure that
pages are positioned properly during / after a list resize. While
this fixed the resize issue, it ended up causing the problem
observed in ENYO-655.

In this fix, we move our cache-invalidation logic from
controlsPerPage() to didResize(), preserving the fix for the
resizing issue while fixing the modelsAdded() issue.

It's possible that this change is swinging too far back in the
other direction; in theory, the cached page size metrics should be
flushed whenever controlsPerPage changes, since they can no longer
be valid. However, it looks like we would need to do some more
significant reworking of the fairly complicated measurement and
page generation logic in vertical delegate to flush the cache at
this point in time without unwanted effects. The fix I'm submitting
addresses known issues and should be relatively low-risk.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
