### PR TITLE
BHV-19913: Don't fire spotlightSelect event while holdpulse event fires.

### DIFF
--- a/source/dom/drag.js
+++ b/source/dom/drag.js
@@ -592,6 +592,10 @@
 		},
 
 		/**
+		* Determines whether or not we are currently pulsing.
+		* 
+		* @returns {Boolean} Is `true` if we are currently sending `holdpulse` events, otherwise
+		*	`false`.
 		* @public
 		*/
 		isPulsing: function() {


### PR DESCRIPTION
Issue:
We don't want to fire spotlightSelect event while holdpulse event fire. Because these event can have very short time gap for some times.

Fix:
Added a function isPulsing() in drag.js and based on this._pulsing firing the spotlightSelect event

DCO-1.1-Signed-Off-By: Anshu Agrawal anshu.agrawal@lge.com
