### PR TITLE
ENYO-690: Convert arguments of CSS functions.

### DIFF
--- a/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
+++ b/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
@@ -28,7 +28,11 @@
                 i;
 
             if (values) {
-                if (Array.isArray(values.value)) {
+                if (Array.isArray(values.args)) {
+                    for (i = 0; i < values.args.length; i++) {
+                        this.parseValue(values.args[i]);
+                    }
+                } else if (Array.isArray(values.value)) {
                     for (i = 0 ; i < values.value.length; i++) {
                         this.parseValue(values.value[i]);
                     }


### PR DESCRIPTION
### Issue

Rules that consisted of CSS functions, such as `clip: rect(10px, 5px, 20px, 10px)` were not being converted to resolution-independent units.
### Fix

We update our plugin to convert the arguments of these CSS functions.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
