### PR TITLE
ENYO-690: Handle non-LESS styles with multiple measurement values.

### DIFF
--- a/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
+++ b/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
@@ -24,34 +24,47 @@
             return this._visitor.visit(root);
         },
         visitRule: function (node) {
-            var values = node && !node.inline && node.value && node.value.value && node.value.value.length && node.value.value[0],
+            var valueNode = node && !node.inline && node.value && node.value.value && node.value.value.length && node.value.value[0],
+                stringValues,
+                convertedStringValues,
                 i;
 
-            if (values) {
-                if (Array.isArray(values.args)) {
-                    for (i = 0; i < values.args.length; i++) {
-                        this.parseValue(values.args[i]);
-                    }
-                } else if (Array.isArray(values.value)) {
-                    for (i = 0 ; i < values.value.length; i++) {
-                        this.parseValue(values.value[i]);
-                    }
-                } else {
-                    this.parseValue(values);
+            if (Array.isArray(valueNode.args)) {
+                for (i = 0; i < valueNode.args.length; i++) {
+                    this.parseValue(valueNode.args[i]);
                 }
+            } else if (Array.isArray(valueNode.value)) {
+                for (i = 0; i < valueNode.value.length; i++) {
+                    this.parseValue(valueNode.value[i]);
+                }
+            } else if (typeof valueNode.value == 'string') {
+                stringValues = valueNode.value.split(/(\s+)/);
+                stringValues = stringValues.map(function (val) {
+                    return {value: val};
+                });
+                convertedStringValues = stringValues.map(this.parseValue.bind(this));
+                valueNode.value = convertedStringValues.join('');
+            } else {
+                this.parseValue(valueNode);
             }
+
             return node;
         },
         parseValue: function (valueNode) {
             if (valueNode.value && valueNode.value.toString().indexOf(this._ignoreUnit) != -1) {
-                valueNode.value = parseInt(valueNode.value, 10) + this._unit;
+                /*jshint -W093 */
+                return (valueNode.value = parseInt(valueNode.value, 10) + this._unit);
             } else if (valueNode.value && valueNode.value.toString().indexOf(this._unit) != -1) {
-                valueNode.value = parseInt(valueNode.value, 10) / this._baseSize + this._riUnit;
+                /*jshint -W093 */
+                return (valueNode.value = parseInt(valueNode.value, 10) / this._baseSize + this._riUnit);
             } else if (valueNode.unit && valueNode.unit.numerator && valueNode.unit.numerator.length &&
                 valueNode.unit.numerator[0] == this._unit) {
                 valueNode.value = valueNode.value / this._baseSize;
                 valueNode.unit.numerator[0] = this._riUnit;
+                return valueNode.value + valueNode.unit.numerator[0];
             }
+
+            return valueNode.value;
         }
     };
 


### PR DESCRIPTION
### Issue

Only LESS variables with multiple measurements were being properly parsed, resulting in only the first measurement of a CSS rule involving multiple measurements being used.
### Fix

We now fully parse directly-set CSS rules that involve multiple measurements.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
