### PR TITLE
Including our resolution-independence plugin in our custom LESS script.

### DIFF
--- a/tools/less.js
+++ b/tools/less.js
@@ -12,4 +12,15 @@
 	script.src = "enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js";
 	script.charset = "utf-8";
 	document.getElementsByTagName('head')[0].appendChild(script);
+
+	script = document.createElement('script');
+	script.src = "enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js";
+	script.charset = "utf-8";
+	script.onload = function () {
+		var less = window.less || {};
+		var ri = new enyoLessRiPlugin();
+		less.plugins = [ri];
+		window.less = less;
+	}
+	document.getElementsByTagName('head')[0].appendChild(script);
 })();


### PR DESCRIPTION
### Issue

We are currently making ourselves version-independent for LESS. To promote the use of this script, we should also include our resolution-independence plugin and encapsulate all of this in a neat little package.
### Fix

We inject the resolution-independence plugin script and then initialize LESS to use this plugin when it's been loaded.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
