### PR TITLE
ENYO-720: Reassigned the base unit to 24 (as in 16,24,48) for better rem numbers...

### DIFF
--- a/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
+++ b/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
@@ -39,7 +39,7 @@
 		* @default 12
 		* @private
 		*/
-		_baseSize: 12,
+		_baseSize: 24,
 
 		/**
 		* The unit of measurement to we wish to use for resolution-independent units.


### PR DESCRIPTION
...to work with, and support for browsers with a minimum font-size setting defined.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
