### PR TITLE
ENYO-720: Reassigned the base unit to 12

### DIFF
--- a/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
+++ b/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
@@ -39,7 +39,7 @@
 		* @default 12
 		* @private
 		*/
-		_baseSize: 24,
+		_baseSize: 12,
 
 		/**
 		* The unit of measurement to we wish to use for resolution-independent units.


### PR DESCRIPTION
Revert https://github.com/enyojs/enyo/pull/985/files

Issue:
webOS Lite version needs previous base unit of rem for Demo.

Fix:
We temporally revert the fix for Demo.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
