### PR TITLE
ENYO-733: Default to building resolution-independent CSS.

### DIFF
--- a/tools/deploy.js
+++ b/tools/deploy.js
@@ -105,7 +105,7 @@ process.on('message', function(msg) {
 var node = process.argv[0],
 	deploy = process.argv[1],
 	less = true, // LESS compilation, turned on by default
-	ri = false, // LESS resolution-independence conversion, turned off by default
+	rd = false, // standard LESS compilation (vs. resolution-independent conversion), turned off by default
 	verbose = false,
 	beautify = false,
 	noexec = false,
@@ -117,17 +117,17 @@ function printUsage() {
 		'Usage: ' + node + ' ' + deploy + ' [-c][-g][-v][-B][-e enyo_dir][-l lib_dir][-b build_dir][-o out_dir][-p package_js][-s source_dir][-f map_from -t map_to ...]\n' +
 		'\n' +
 		'Options:\n' +
-		'  -v  verbose operation                         [boolean]  [default: ' + verbose + ']\n' +
-		'  -b  build directory sub-folder                [default: "./build"]\n' +
-		'  -c  do not run the LESS compiler              [boolean]  [default: ' + less + ']\n' +
-		'  -r  perform LESS resolution-independence      [boolean]  [default: ' + ri + ']\n' +
-		'  -e  enyo framework sub-folder                 [default: "./enyo"]\n' +
-		'  -l  libs sub-folder                           [default: "./lib"]\n' +
-		'  -o  alternate output directory                [default: "PWD/deploy/APPNAME"]\n' +
-		'  -p  main package.js file (relative)           [default: "./package.js"]\n' +
-		'  -s  source code root directory                [default: "PWD"]\n' +
-		'  -B  pretty-print (beautify) JS output         [boolean]  [default: ' + beautify + ']\n' +
-		'  -g  gather libs to default location           [boolean]  [default: ' + gather + ']\n' +
+		'  -v  verbose operation                                                [boolean]  [default: ' + verbose + ']\n' +
+		'  -b  build directory sub-folder                                       [default: "./build"]\n' +
+		'  -c  do not run the LESS compiler                                     [boolean]  [default: ' + less + ']\n' +
+		'  -d  perform standard (not resolution-independent) LESS compilation   [boolean]  [default: ' + rd + ']\n' +
+		'  -e  enyo framework sub-folder                                        [default: "./enyo"]\n' +
+		'  -l  libs sub-folder                                                  [default: "./lib"]\n' +
+		'  -o  alternate output directory                                       [default: "PWD/deploy/APPNAME"]\n' +
+		'  -p  main package.js file (relative)                                  [default: "./package.js"]\n' +
+		'  -s  source code root directory                                       [default: "PWD"]\n' +
+		'  -B  pretty-print (beautify) JS output                                [boolean]  [default: ' + beautify + ']\n' +
+		'  -g  gather libs to default location                                  [boolean]  [default: ' + gather + ']\n' +
 		'  -f  remote source mapping: from local path\n' +
 		'  -t  remote source mapping: to remote path\n' +
 		'  -E|--noexec disallow execution of application-provided scripts [default: false]\n' +
@@ -138,7 +138,7 @@ function printUsage() {
 var opt = nopt(/*knownOpts*/ {
 	"build": String,	// relative path
 	"less": Boolean,
-	"ri": Boolean,
+	"rd": Boolean,
 	"enyo": String,		// relative path
 	"lib": String,		// relative path
 	"out": path,		// absolute path
@@ -155,7 +155,7 @@ var opt = nopt(/*knownOpts*/ {
 }, /*shortHands*/ {
 	"b": "--build",
 	"c": "--no-less",
-	"r": "--ri",
+	"d": "--rd",
 	"e": "--enyo",
 	"l": "--lib",
 	"o": "--out",
@@ -223,7 +223,7 @@ opt.enyo = opt.enyo || manifest.enyo || "enyo"; // from top-level folder
 log("opt:", opt);
 
 less = (opt.less !== false) && less;
-ri = opt.ri;
+rd = opt.rd;
 gather = (opt.gather !== false) && gather;
 beautify = opt.beautify;
 noexec = opt.noexec;
@@ -244,7 +244,7 @@ log("Using: opt.enyo=" + opt.enyo);
 log("Using: opt.packagejs=" + opt.packagejs);
 log("Using: opt.test=" + opt.test);
 log("Using: less=" + less);
-log("Using: ri=" + ri);
+log("Using: rd=" + rd);
 log("Using: beautify=" + beautify);
 log("Using: noexec=" + noexec);
 log("Using: gather=" + gather);
@@ -281,7 +281,7 @@ if (!opt.mapfrom || opt.mapfrom.indexOf("enyo") < 0) {
 		'-enyo', opt.enyo,
 		'-destdir', opt.out,
 		'-output', path.join(opt.build, 'enyo'),
-		(ri ? '-ri' : '-no-ri'),
+		(rd ? '-rd' : '-no-rd'),
 		(beautify ? '-beautify' : '-no-beautify'),
 		path.join(opt.enyo, 'minify', 'package.js')];
 	if (opt.mapfrom) {
@@ -301,7 +301,7 @@ args = [node, minifier,
 	'-destdir', opt.out,
 	'-output', path.join(opt.build, 'app'),
 	(less ? '-less' : '-no-less'),
-	(ri ? '-ri' : '-no-ri'),
+	(rd ? '-rd' : '-no-rd'),
 	(beautify ? '-beautify' : '-no-beautify'),
 	opt.packagejs];
 if (opt.mapfrom) {

--- a/tools/minifier/lessc.js
+++ b/tools/minifier/lessc.js
@@ -20,7 +20,7 @@ function printUsage() {
 	w("<package-file>\t", "Path to package file to walk; all LESS files encountered will be compiled");
 	w("-enyo <path>\t", "Path to enyo loader (enyo/enyo.js)");
 	w("-w\t", "Watch the file and any dependencies, and re-compile on changes");
-	w("-ri\t", "Perform resolution-independence conversion of measurements i.e. px -> rem");
+	w("-d\t", "Perform standard LESS compilation, otherwise will perform resolution-independent conversion of measurements i.e. px -> rem");
 	w("-h, -?, -help\t", "Show this message");
 }
 
@@ -39,12 +39,11 @@ function finish(loader, objs, doneCB) {
 			} else {
 				try {
 					var generatedCss, ri;
-					if (opt.ri) {
-						ri = new RezInd();
-						// console.log("ri:", RezInd, ri);
-						generatedCss = tree.toCSS({plugins: [ri]});
-					} else {
+					if (opt.rd) {
 						generatedCss = tree.toCSS();
+					} else {
+						ri = new RezInd();
+						generatedCss = tree.toCSS({plugins: [ri]});
 					}
 
 					var css =
@@ -154,7 +153,7 @@ var knownOpts = {
 	"output": String,
 	"watch": Boolean,
 	"help": Boolean,
-	"ri": Boolean
+	"rd": Boolean
 };
 
 var shortHands = {
@@ -164,7 +163,7 @@ var shortHands = {
 	"h": ['--help'],
 	"?": ['--help'],
 	"help": ['--help'],
-	"ri": ['--ri']
+	"d": ['--rd']
 };
 
 var opt = nopt(knownOpts, shortHands, process.argv, 2);

--- a/tools/minifier/minify.js
+++ b/tools/minifier/minify.js
@@ -26,7 +26,7 @@
 		w("Usage: " + __filename + " [Flags] [path/to/package.js]");
 		w("Flags:");
 		w("-no-less:", "Don't compile less; instead substitute css for less");
-		w("-ri", "Perform LESS resolution-independence conversion of measurements i.e. px to rem");
+		w("-d, -rd:", "Perform standard LESS compilation, instead of resolution-independence conversion of measurements i.e. px to rem");
 		w("-no-alias:", "Don't use path macros");
 		w("-alias:", "Give paths a macroized alias");
 		w("-enyo ENYOPATH:", "Relative path to enyo folder (enyo)");
@@ -109,10 +109,10 @@
 							console.error(err);
 						} else {
 							var generatedCss;
-							if (opt.ri) {
-								generatedCss = tree.toCSS({plugins: [ri]});
-							} else {
+							if (opt.rd) {
 								generatedCss = tree.toCSS();
+							} else {
+								generatedCss = tree.toCSS({plugins: [ri]});
 							}
 							addToBlob(sheet, generatedCss);
 						}
@@ -238,7 +238,7 @@
 		"mapfrom": [String, Array],
 		"mapto": [String, Array],
 		"gathering": Boolean,
-		"ri": Boolean
+		"rd": Boolean
 	};
 
 	var shortHands = {
@@ -254,7 +254,8 @@
 		"beautify": ['--beautify'],
 		"f": ['--mapfrom'],
 		"t": ['--mapto'],
-		"ri": ['--ri']
+		"d": ['--rd'],
+		"rd": ['--rd']
 	};
 
 	opt = nopt(knownOpts, shortHands, process.argv, 2);


### PR DESCRIPTION
### Issue
We are currently making resolution-independence opt-in via the deploy process, which requires the specification of the `-r` or `--ri` flag, requiring the potential addition of additional switching logic at the build level.

### Fix
Because we have validated our earlier work and we know that we always want resolution-independence in `2.5-gordon`, we default the compilation of resolution-independent CSS to true and make this feature opt-out. This includes changing the flag to `-d` (dependence), which is the shorthand flag for `--rd` (resolution-dependence). Additionally, we make updates to consistently use the shorthand flags where appropriate.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>