### PR TITLE
ENYO-735: Handle measurements with negative apx values.

### DIFF
--- a/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
+++ b/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
@@ -19,15 +19,15 @@
 	*	resolution-independent units.
 	* @property {String} unit - The unit of measurement to that we wish to convert to
 	*	resolution-independent units.
-	* @property {String} unit - The unit of measurement to ignore for resolution-independence
-	*	conversion, and instead should be 1:1 converted to our `_unit` unit.
+	* @property {String} absoluteUnit - The unit of measurement to ignore for
+	*	resolution-independence conversion, and instead should be 1:1 converted to our `_unit` unit.
 	*/
 
 	var ResolutionIndependence = function (opts) {
 		this._baseSize = opts && opts.baseSize || this._baseSize;
 		this._riUnit = opts && opts.riUnit || this._riUnit;
 		this._unit = opts && opts.unit || this._unit;
-		this._ignoreUnit = opts && opts.ignoreUnit || this._ignoreUnit;
+		this._absoluteUnit = opts && opts.absoluteUnit || this._absoluteUnit;
 	};
 
 	ResolutionIndependence.prototype = {
@@ -67,7 +67,7 @@
 		* @default 'apx'
 		* @private
 		*/
-		_ignoreUnit: 'apx', // "absolute" px
+		_absoluteUnit: 'apx', // "absolute" px
 
 		/*
 		* Entry point
@@ -148,15 +148,30 @@
 		* @private
 		*/
 		parseValue: function (value, unit) {
-			if (value && value.toString().slice(-1*this._ignoreUnit.length) == this._ignoreUnit) {
+			// String value in our absolute unit
+			if (value && value.toString().slice(-1*this._absoluteUnit.length) == this._absoluteUnit) {
 				return parseInt(value, 10) + this._unit;
-			} else if (value && value.toString().slice(-1*this._unit.length) == this._unit) {
+			}
+			// String value in our to-be-converted unit
+			else if (value && value.toString().slice(-1*this._unit.length) == this._unit) {
 				return parseInt(value, 10) / this._baseSize + this._riUnit;
-			} else if (unit && unit == this._unit) {
-				return {
-					value: value / this._baseSize,
-					unit: this._riUnit
-				};
+			}
+			// LESS object with separate value and unit properties
+			else if (unit) {
+				// The standard unit to convert
+				if (unit == this._unit) {
+					return {
+						value: value / this._baseSize,
+						unit: this._riUnit
+					};
+				}
+				// The absolute unit to convert to our standard unit
+				else if (unit == this._absoluteUnit) {
+					return {
+						value: value,
+						unit: this._unit
+					};
+				}
 			}
 
 			return value;


### PR DESCRIPTION
### Issue
It appears that negatively-valued measurements with a non-standard unit, such as `apx`, will be handled by LESS as a combination of a string value and a unit object. This differs from how a positively-valued measurement with the same non-standard unit is handled (the entire measurement, including the unit, is treated as a single string).

### Fix
We add an additional conditional to handle the case where the value and absolute unit are separated. Additionally, we change the name of this absolute unit property from `_ignoreUnit` to the more-appropriate and clearly-named `_absoluteUnit`. Lastly, we fix a latent documentation issue with the options that can be passed into our resolution-independence LESS plugin.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>