### PR TITLE
ENYO-738: Prevent unnecessary conversion of small values.

### DIFF
--- a/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
+++ b/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
@@ -21,6 +21,11 @@
 	*	resolution-independent units.
 	* @property {String} absoluteUnit - The unit of measurement to ignore for
 	*	resolution-independence conversion, and instead should be 1:1 converted to our `_unit` unit.
+	* @property {Number} minUnitSize The minimum unit size (as an absolute value) that any
+	*	measurement should be valued at the lowest device resolution we wish to support. This allows
+	*	for meaningful measurements that are not unnecessarily scaled down excessively.
+	* @property {Number} minSize The root font-size corresponding to the lowest device resolution we
+	*	wish to support. This is utilized in conjunction with the `minUnitSize` property.
 	*/
 
 	var ResolutionIndependence = function (opts) {
@@ -28,6 +33,8 @@
 		this._riUnit = opts && opts.riUnit || this._riUnit;
 		this._unit = opts && opts.unit || this._unit;
 		this._absoluteUnit = opts && opts.absoluteUnit || this._absoluteUnit;
+		this._minUnitSize = opts && opts.minUnitSize || this._minUnitSize;
+		this._minSize = opts && opts.minSize || this._minSize;
 	};
 
 	ResolutionIndependence.prototype = {
@@ -68,6 +75,28 @@
 		* @private
 		*/
 		_absoluteUnit: 'apx', // "absolute" px
+
+		/**
+		* The minimum unit size (as an absolute value), in our base unit `_unit`, that any
+		* measurement should be set to in the resolution corresponding to our minimum root font-size
+		* `_minSize`.
+		*
+		* @type {Number}
+		* @default 1
+		* @private
+		*/
+		_minUnitSize: 1,
+
+		/**
+		* The root font-size corresponding to the lowest device resolution we wish to support. The
+		* determination for adjusting our measurements based on the minimum unit `_minUnitSize` are
+		* dependent on this value.
+		*
+		* @type {String}
+		* @default 8
+		* @private
+		*/
+		_minSize: 8,
 
 		/*
 		* Entry point
@@ -148,22 +177,33 @@
 		* @private
 		*/
 		parseValue: function (value, unit) {
+			var minScaleFactor = this._minSize / this._baseSize,
+				scaledValue;
 			// String value in our absolute unit
 			if (value && value.toString().slice(-1*this._absoluteUnit.length) == this._absoluteUnit) {
-				return parseInt(value, 10) + this._unit;
+				return parseFloat(value) + this._unit;
 			}
 			// String value in our to-be-converted unit
 			else if (value && value.toString().slice(-1*this._unit.length) == this._unit) {
-				return parseInt(value, 10) / this._baseSize + this._riUnit;
+				value = parseFloat(value);
+				scaledValue = Math.abs(value * minScaleFactor);
+				return (scaledValue && scaledValue <= this._minUnitSize) ?
+					this._minUnitSize * (value < 0 ? -1 : 1) + this._unit : value / this._baseSize + this._riUnit;
 			}
 			// LESS object with separate value and unit properties
 			else if (unit) {
 				// The standard unit to convert
 				if (unit == this._unit) {
-					return {
-						value: value / this._baseSize,
-						unit: this._riUnit
-					};
+					scaledValue = Math.abs(value * minScaleFactor);
+					return (scaledValue && scaledValue <= this._minUnitSize) ? 
+						{
+							value: this._minUnitSize * (value < 0 ? -1 : 1),
+							unit: this._unit
+						} :
+						{
+							value: value / this._baseSize,
+							unit: this._riUnit
+						};
 				}
 				// The absolute unit to convert to our standard unit
 				else if (unit == this._absoluteUnit) {

--- a/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
+++ b/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
@@ -188,7 +188,9 @@
 				value = parseFloat(value);
 				scaledValue = Math.abs(value * minScaleFactor);
 				return (scaledValue && scaledValue <= this._minUnitSize) ?
-					this._minUnitSize * (value < 0 ? -1 : 1) + this._unit : value / this._baseSize + this._riUnit;
+					(Math.abs(value) < this._minUnitSize ?
+						value + this._unit : this._minUnitSize * (value < 0 ? -1 : 1) + this._unit) :
+					value / this._baseSize + this._riUnit;
 			}
 			// LESS object with separate value and unit properties
 			else if (unit) {
@@ -197,7 +199,7 @@
 					scaledValue = Math.abs(value * minScaleFactor);
 					return (scaledValue && scaledValue <= this._minUnitSize) ? 
 						{
-							value: this._minUnitSize * (value < 0 ? -1 : 1),
+							value: Math.abs(value) < this._minUnitSize ? value : this._minUnitSize * (value < 0 ? -1 : 1),
 							unit: this._unit
 						} :
 						{

--- a/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
+++ b/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
@@ -43,7 +43,7 @@
 		* The root font-size we wish to use to base all of our conversions upon.
 		*
 		* @type {Number}
-		* @default 12
+		* @default 24
 		* @private
 		*/
 		_baseSize: 24,
@@ -93,7 +93,7 @@
 		* dependent on this value.
 		*
 		* @type {String}
-		* @default 8
+		* @default 16
 		* @private
 		*/
 		_minSize: 16,


### PR DESCRIPTION
### Issue
Values such as `1px` in FHD resolution were being converted to rem-based units, and would resolve to a value < 1px in HD resolution, which was undesired and caused visual defects.

### Fix
We prevent the conversion of measurements that are less than a specific threshold value (defaulted to `1`), based on a given minimum resolution (defaulted to `8` to correspond to the root font-size of this resolution). Additionally, we fix a latent issue where we are assuming integer values for measurements.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>