### PR TITLE
ENYO-750: Properly handle fractional measurements.

### DIFF
--- a/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
+++ b/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
@@ -150,11 +150,11 @@
 		parseValue: function (value, unit) {
 			// String value in our absolute unit
 			if (value && value.toString().slice(-1*this._absoluteUnit.length) == this._absoluteUnit) {
-				return parseInt(value, 10) + this._unit;
+				return parseFloat(value) + this._unit;
 			}
 			// String value in our to-be-converted unit
 			else if (value && value.toString().slice(-1*this._unit.length) == this._unit) {
-				return parseInt(value, 10) / this._baseSize + this._riUnit;
+				return parseFloat(value) / this._baseSize + this._riUnit;
 			}
 			// LESS object with separate value and unit properties
 			else if (unit) {


### PR DESCRIPTION
### Issue
The resolution-independence plugin had been assuming integer measurement values.

### Fix
We utilize `parseFloat` to account for fractional measurement values.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>