### PR TITLE
ENYO-772: Allow specification of measurement precision.

### DIFF
--- a/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
+++ b/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
@@ -26,6 +26,8 @@
 	*	for meaningful measurements that are not unnecessarily scaled down excessively.
 	* @property {Number} minSize The root font-size corresponding to the lowest device resolution we
 	*	wish to support. This is utilized in conjunction with the `minUnitSize` property.
+	* @property {Number} precision - How precise our measurements will be, namely the maximum amount
+	*	of fractional digits that will appear in our converted measurements.
 	*/
 
 	var ResolutionIndependence = function (opts) {
@@ -35,6 +37,7 @@
 		this._absoluteUnit = opts && opts.absoluteUnit || this._absoluteUnit;
 		this._minUnitSize = opts && opts.minUnitSize || this._minUnitSize;
 		this._minSize = opts && opts.minSize || this._minSize;
+		this._precision = opts && opts.precision || this._precision;
 	};
 
 	ResolutionIndependence.prototype = {
@@ -98,6 +101,20 @@
 		*/
 		_minSize: 16,
 
+		/**
+		* This number is a representation of how precise our measurements should be. More
+		* specifically, this number corresponds to the maximum number of fractional digits in our
+		* computed measurements. This will not affect measurements that utilize the `_absoluteUnit`
+		* unit, or measurements that are adjusted to the minimum unit size, in the event that
+		* `_minUnitSize` has more precision than what is specified here, as `_minUnitSize` would be
+		* user-overridden and assumed intentional.
+		* 
+		* @type {Number}
+		* @default 5
+		* @private
+		*/
+		_precision: 5,
+
 		/*
 		* Entry point
 		*/
@@ -117,12 +134,12 @@
 
 			// The value(s) of a CSS function call
 			if (Array.isArray(valueNode.args)) {
-				valueNode.args.forEach(this.convertValue.bind(this));
+				valueNode.args.forEach(this.updateNode.bind(this));
 			}
 			// Multiple property values where at least one value is a LESS variable (LESS
 			// automatically converts all of the values into array items)
 			else if (Array.isArray(valueNode.value)) {
-				valueNode.value.forEach(this.convertValue.bind(this));
+				valueNode.value.forEach(this.updateNode.bind(this));
 			}
 			// Directly set string values that have a number
 			else if (typeof valueNode.value == 'string' && valueNode.value.match(/\d+/g)) {
@@ -131,7 +148,7 @@
 			}
 			// A single value
 			else {
-				this.convertValue(valueNode);
+				this.updateNode(valueNode);
 			}
 
 			return node;
@@ -146,7 +163,7 @@
 		* @param {Object} valueNode - The rule node we are currently examining and will convert.
 		* @private
 		*/
-		convertValue: function (valueNode) {
+		updateNode: function (valueNode) {
 			var value = valueNode.value,
 				unitNode = valueNode.unit,
 				unit = unitNode && unitNode.numerator && unitNode.numerator.length && unitNode.numerator[0],
@@ -190,7 +207,7 @@
 				return (scaledValue && scaledValue <= this._minUnitSize) ?
 					(Math.abs(value) < this._minUnitSize ?
 						value + this._unit : this._minUnitSize * (value < 0 ? -1 : 1) + this._unit) :
-					value / this._baseSize + this._riUnit;
+					this.convertValue(value) + this._riUnit;
 			}
 			// LESS object with separate value and unit properties
 			else if (unit) {
@@ -203,7 +220,7 @@
 							unit: this._unit
 						} :
 						{
-							value: value / this._baseSize,
+							value: this.convertValue(value),
 							unit: this._riUnit
 						};
 				}
@@ -217,6 +234,18 @@
 			}
 
 			return value;
+		},
+
+		/**
+		* Converts a value from our base unit to a value in resolution-independent units.
+		* 
+		* @param {Number} value - The value, in base units, to be converted to a value that is in
+		*	resolution-independent units.
+		* @returns {Number} - The converted value in resolution-independent units.
+		* @private
+		*/
+		convertValue: function (value) {
+			return parseFloat((value / this._baseSize).toFixed(this._precision));
 		}
 	};
 

--- a/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
+++ b/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
@@ -21,11 +21,11 @@
 	*	resolution-independent units.
 	* @property {String} absoluteUnit - The unit of measurement to ignore for
 	*	resolution-independence conversion, and instead should be 1:1 converted to our `_unit` unit.
-	* @property {Number} minUnitSize The minimum unit size (as an absolute value) that any
+	* @property {Number} minUnitSize - The minimum unit size (as an absolute value) that any
 	*	measurement should be valued at the lowest device resolution we wish to support. This allows
 	*	for meaningful measurements that are not unnecessarily scaled down excessively.
-	* @property {Number} minSize The root font-size corresponding to the lowest device resolution we
-	*	wish to support. This is utilized in conjunction with the `minUnitSize` property.
+	* @property {Number} minSize - The root font-size corresponding to the lowest device resolution
+	*	we wish to support. This is utilized in conjunction with the `minUnitSize` property.
 	* @property {Number} precision - How precise our measurements will be, namely the maximum amount
 	*	of fractional digits that will appear in our converted measurements.
 	*/
@@ -38,6 +38,10 @@
 		this._minUnitSize = opts && opts.minUnitSize || this._minUnitSize;
 		this._minSize = opts && opts.minSize || this._minSize;
 		this._precision = opts && opts.precision || this._precision;
+
+		// One-time computation of the minimum scale factor that will be used for determining
+		// whether or not to clamp measurement values to the minimum unit size `_minUnitSize`.
+		this._minScaleFactor = this._minSize / this._baseSize;
 	};
 
 	ResolutionIndependence.prototype = {
@@ -129,73 +133,105 @@
 		* @private
 		*/
 		visitRule: function (node) {
-			var valueNode = node && !node.inline && node.value && node.value.value && node.value.value.length && node.value.value[0],
+			var ruleNode = node && !node.inline && node.value && node.value.value && node.value.value.length && node.value.value[0],
 				stringValues;
 
 			// The value(s) of a CSS function call
-			if (Array.isArray(valueNode.args)) {
-				valueNode.args.forEach(this.updateNode.bind(this));
+			if (Array.isArray(ruleNode.args)) {
+				ruleNode.args.forEach(this.updateNode.bind(this));
 			}
 			// Multiple property values where at least one value is a LESS variable (LESS
 			// automatically converts all of the values into array items)
-			else if (Array.isArray(valueNode.value)) {
-				valueNode.value.forEach(this.updateNode.bind(this));
+			else if (Array.isArray(ruleNode.value)) {
+				ruleNode.value.forEach(this.updateNode.bind(this));
 			}
 			// Directly set string values that have a number
-			else if (typeof valueNode.value == 'string' && valueNode.value.match(/\d+/g)) {
-				stringValues = valueNode.value.match(/\S+/g) || [];
-				valueNode.value = stringValues.map(this.parseValue.bind(this)).join(' ');
+			else if (typeof ruleNode.value == 'string' && ruleNode.value.match(/\d+/g)) {
+				stringValues = ruleNode.value.match(/\S+/g) || [];
+				ruleNode.value = stringValues.map(this.parseValueString.bind(this)).join(' ');
 			}
 			// A single value
 			else {
-				this.updateNode(valueNode);
+				this.updateNode(ruleNode);
 			}
-
-			return node;
 		},
 
 		/**
-		* Takes a LESS rule node and converts the value to a resolution-independent measurement. If
+		* Takes a LESS rule node and updates the value to a resolution-independent measurement. If
 		* the rule node's value is a string value, the value and unit will be set as the updated
 		* value of this node. If the rule node consists of a value object and unit object, both of
 		* these objects will be updated with the appropriate values.
 		*
-		* @param {Object} valueNode - The rule node we are currently examining and will convert.
+		* @param {Object} ruleNode - The rule node we are currently examining and will convert.
 		* @private
 		*/
-		updateNode: function (valueNode) {
-			var value = valueNode.value,
-				unitNode = valueNode.unit,
-				unit = unitNode && unitNode.numerator && unitNode.numerator.length && unitNode.numerator[0],
-				result;
+		updateNode: function (ruleNode) {
+			if (ruleNode) {
+				var value = ruleNode.value,
+					unitNode = ruleNode.unit,
+					result;
 
-			result = this.parseValue(value, unit);
-
-			if (unit && result && result.unit) {
-				valueNode.value = result.value;
-				unitNode.numerator[0] = result.unit;
-			} else if (result) {
-				valueNode.value = result;
+				if (unitNode) {
+					result = this.parseValueObject(value, unitNode);
+					ruleNode.value = result.value;
+					unitNode.numerator[0] = result.unit;
+				} else {
+					ruleNode.value = this.parseValueString(value);
+				}
 			}
 		},
 
 		/**
-		* Examines a value and optional unit, and converts to a resolution-independent measurement.
-		*
-		* @param {String} value - The value, usually a number, to be converted.
-		* @param {String} [unit] - The current unit of our value measurement. If this is provided,
-		*	we assume that we are dealing with a value object and a unit object and will return an
-		*	object instead of a string.
-		* @returns {String | Object} If we are converting a string value, we return a concatenated
-		*	string value consisting of the converted value and unit. If we are converting an object,
-		*	such as when we have separate value and unit values, we return an object consisting of
-		*	the converted value and unit as separate properties. If no conversion occurs, we return
-		*	the original value that was provided.
+		* Parses measurement values that have a separate unit object.
+		* 
+		* @param {Number} value - The measurement value we wish to convert.
+		* @param {Object} unitNode - An object representing the unit associated with the measurement
+		*	value.
+		* @returns {Object} An object with `value` and `unit` properties that represent the
+		*	measurement in resolution-independent units.
 		* @private
 		*/
-		parseValue: function (value, unit) {
-			var minScaleFactor = this._minSize / this._baseSize,
+		parseValueObject: function (value, unitNode) {
+			var unit = (unitNode && unitNode.numerator && unitNode.numerator.length && unitNode.numerator[0]) || unitNode.backupUnit,
 				scaledValue;
+
+			// The standard unit to convert (if no unit, we assume the base unit)
+			if (unit == this._unit) {
+				scaledValue = Math.abs(value * this._minScaleFactor);
+				return (scaledValue && scaledValue <= this._minUnitSize) ? 
+					{
+						value: Math.abs(value) < this._minUnitSize ? value : this._minUnitSize * (value < 0 ? -1 : 1),
+						unit: this._unit
+					} :
+					{
+						value: this.convertValue(value),
+						unit: this._riUnit
+					};
+			}
+			// The absolute unit to convert to our standard unit
+			else if (unit == this._absoluteUnit) {
+				return {
+					value: value,
+					unit: this._unit
+				};
+			}
+
+			return {
+				value: value,
+				unit: unit
+			};
+		},
+
+		/**
+		* Parses measurements that contain both the value and unit as a single string.
+		* 
+		* @param {String} value - The measurement in the base unit which we wish to convert.
+		* @returns {String} The measurement, in resolution-independent units.
+		* @private
+		*/
+		parseValueString: function (value) {
+			var scaledValue;
+
 			// String value in our absolute unit
 			if (value && value.toString().slice(-1*this._absoluteUnit.length) == this._absoluteUnit) {
 				return parseFloat(value) + this._unit;
@@ -203,34 +239,11 @@
 			// String value in our to-be-converted unit
 			else if (value && value.toString().slice(-1*this._unit.length) == this._unit) {
 				value = parseFloat(value);
-				scaledValue = Math.abs(value * minScaleFactor);
+				scaledValue = Math.abs(value * this._minScaleFactor);
 				return (scaledValue && scaledValue <= this._minUnitSize) ?
 					(Math.abs(value) < this._minUnitSize ?
 						value + this._unit : this._minUnitSize * (value < 0 ? -1 : 1) + this._unit) :
 					this.convertValue(value) + this._riUnit;
-			}
-			// LESS object with separate value and unit properties
-			else if (unit) {
-				// The standard unit to convert
-				if (unit == this._unit) {
-					scaledValue = Math.abs(value * minScaleFactor);
-					return (scaledValue && scaledValue <= this._minUnitSize) ? 
-						{
-							value: Math.abs(value) < this._minUnitSize ? value : this._minUnitSize * (value < 0 ? -1 : 1),
-							unit: this._unit
-						} :
-						{
-							value: this.convertValue(value),
-							unit: this._riUnit
-						};
-				}
-				// The absolute unit to convert to our standard unit
-				else if (unit == this._absoluteUnit) {
-					return {
-						value: value,
-						unit: this._unit
-					};
-				}
 			}
 
 			return value;


### PR DESCRIPTION
### Issue
We are not currently limiting the number of decimal places for our converted resolution-independent measurements, resulting in long floating point numbers.

### Fix
A new property `precision` has been added to the resolution-independence plugin, that defaults to a value of `5`. Additionally, general clean-up and refactoring was done to improve semantics and specifically to separate out the logic for parsing a rule with a string value vs. a rule with separate value and unit objects. Lastly, some hardening was done to catch some other edge cases with unit parsing, and an unnecessary return statement was removed from `visitRule` as we are not specifying `isReplacing:true` in our plugin.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>