### PR TITLE
Fixes ENYO-787

### DIFF
--- a/source/ajax/Ajax.js
+++ b/source/ajax/Ajax.js
@@ -320,15 +320,19 @@
 		* @private
 		*/
 		updateProgress: function (event) {
-			// filter out 'input' as it causes exceptions on some Firefox versions
-			// due to unimplemented internal APIs
-			var ev = {};
-			for (var k in event) {
-				if (k !== 'input') {
-					ev[k] = event[k];
+			// IE8 doesn't properly support progress events and doesn't pass an object to the
+			// handlers so we'll check that before continuing.
+			if (event) {
+				// filter out 'input' as it causes exceptions on some Firefox versions
+				// due to unimplemented internal APIs
+				var ev = {};
+				for (var k in event) {
+					if (k !== 'input') {
+						ev[k] = event[k];
+					}
 				}
+				this.sendProgress(event.loaded, 0, event.total, ev);
 			}
-			this.sendProgress(event.loaded, 0, event.total, ev);
 		},
 		
 		/**


### PR DESCRIPTION
## Issue
IE8 doesn't property support `onprogress` events so enyo.Ajax.updateProgress errors when attempting to reference properties on the event object (which isn't passed for IE8).

## Fix
Suppress calls to progress handlers for IE8 by guarding for undefined event

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)