### PR TITLE
ENYO-4124: deploy.js should work regardless of icon.png or index.html existence

### DIFF
--- a/tools/deploy.js
+++ b/tools/deploy.js
@@ -1,4 +1,4 @@
-index.html#!/usr/bin/env node
+#!/usr/bin/env node
 /* jshint node: true */
 /**
 # deploy.js - portable deployment script

--- a/tools/deploy.js
+++ b/tools/deploy.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+index.html#!/usr/bin/env node
 /* jshint node: true */
 /**
 # deploy.js - portable deployment script
@@ -318,8 +318,13 @@ if(!manifest._default) {
 } else {
 	/* Use legacy built-in list of files & folders to copy */
 	shell.mkdir('-p', path.join(opt.out, 'lib'));
-	shell.cp('index.html', opt.out);
-	shell.cp('icon.png', opt.out);
+	if (shell.test('-f', 'index.html')) {
+		shell.cp('index.html', opt.out);
+	}
+
+	if (shell.test('-f', 'icon.png')) {
+		shell.cp('icon.png', opt.out);
+	}
 
 	if(shell.test('-d', 'assets')) {
 		shell.cp('-r', 'assets', opt.out);


### PR DESCRIPTION
# Issue
Current deploy.js aborts if app directory does not have icon.png or index.html in case that it does not have a extra deploy.json file.

Enyo-DCO-1.1-Signed-off-by Junil Kim <logyourself@gmail.com>