### PR TITLE
Fixes ENYO-785

### DIFF
--- a/source/ui/Popup.js
+++ b/source/ui/Popup.js
@@ -219,6 +219,7 @@
 		* @private
 		*/
 		handlers: {
+			tap: 'tap',
 			onkeydown: 'keydown',
 			ondragstart: 'dragstart',
 			onfocus: 'focus',
@@ -523,6 +524,15 @@
 				this.hide();
 			}
 			return this.modal;
+		},
+
+		/**
+		* Prevent taps from cascading to controls covered by the popup
+		*
+		* @private
+		*/
+		tap: function (sender, event) {
+			event.preventDefault();
 		},
 
 		/**


### PR DESCRIPTION
## Issue
Taps on controls within a popup that close the popup would be triggered on controls under the popup.

## Fix
Prevent taps from cascading to controls under a Popup by calling `event.preventDefault()`

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)