### PR TITLE
BHV-21381: InputSample: Removed unnecessary accumulation of directionality in style...

### DIFF
--- a/source/ui/Input.js
+++ b/source/ui/Input.js
@@ -174,7 +174,6 @@
 				if (this.type) {
 					this.typeChanged();
 				}
-				this.valueChanged();
 			};
 		}),
 


### PR DESCRIPTION
... at the time of creation

Issue:
In Input, directionality property in style is getting appended twice at the time of creation.

Fix:
No necessity of calling "this.valueChanged" twice in create function of Input.js, as it is already been invoked from "this.placeholderChanged" function. Removed "this.valueChanged" call from create function.

Enyo-DCO-1.1-Signed-off-by: Rakesh kumar rakesh25.kumar@lge.com