### PR TITLE
Fixes ENYO-785

### DIFF
--- a/source/ui/Popup.js
+++ b/source/ui/Popup.js
@@ -526,6 +526,19 @@
 		},
 
 		/**
+		* Prevent taps from cascading to controls covered by the popup
+		*
+		* @private
+		*/
+		tap: enyo.inherit(function (sup) {
+			return function (sender, event) {
+				if (!this.showing) {
+					event.preventDefault();
+				}
+			};
+		}),
+
+		/**
 		* If a drag event occurs outside a [popup]{@link enyo.Popup}, hide.
 		*
 		* @private


### PR DESCRIPTION
## Issue
Taps on controls within a popup that close the popup would be triggered on controls under the popup.

## Fix
Prevent taps from cascading to controls under a Popup by calling `event.preventDefault()`

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)