### PR TITLE
ENYO-872: Merge 2.5-gordon into 2.5-upkeep

### DIFF
--- a/source/boot/version.js
+++ b/source/boot/version.js
@@ -19,5 +19,5 @@
 * @public
 */
 enyo.version = {
-	enyo: '2.5.3-pre.4.lite.1'
+	enyo: '2.5.4-pre.1.lite.1'
 };

--- a/source/boot/version.js
+++ b/source/boot/version.js
@@ -19,5 +19,5 @@
 * @public
 */
 enyo.version = {
-	enyo: '2.5.4-pre.3'
+	enyo: '2.5.4-pre.4'
 };

--- a/source/boot/version.js
+++ b/source/boot/version.js
@@ -19,5 +19,5 @@
 * @public
 */
 enyo.version = {
-	enyo: '2.5.3-pre.7'
+	enyo: '2.5.4-pre.2'
 };

--- a/source/boot/version.js
+++ b/source/boot/version.js
@@ -19,5 +19,5 @@
 * @public
 */
 enyo.version = {
-	enyo: '2.5.4-pre.1.lite.1'
+	enyo: '2.5.4-pre.1.lite.2'
 };

--- a/source/boot/version.js
+++ b/source/boot/version.js
@@ -19,5 +19,5 @@
 * @public
 */
 enyo.version = {
-	enyo: '2.5.4-pre.2'
+	enyo: '2.5.4-pre.3'
 };

--- a/source/boot/version.js
+++ b/source/boot/version.js
@@ -19,5 +19,5 @@
 * @public
 */
 enyo.version = {
-	enyo: '2.5.3-pre.6'
+	enyo: '2.5.3-pre.4.lite.1'
 };

--- a/source/boot/version.js
+++ b/source/boot/version.js
@@ -19,5 +19,5 @@
 * @public
 */
 enyo.version = {
-	enyo: '2.5.4-pre.1.lite.2'
+	enyo: '2.5.3-pre.7'
 };

--- a/source/dom/dom.js
+++ b/source/dom/dom.js
@@ -531,7 +531,45 @@
 		/**
 		* @private
 		*/
-		_bodyClasses: null
+		_bodyClasses: null,
+
+		/**
+		* Convert to various unit formats. Useful for converting pixels to a resolution-independent
+		* measurement method, like "rem". Other units are available if defined in the
+		* [enyo.dom.unitToPixelFactors]{@link enyo.dom.unitToPixelFactors} object.
+		*
+		* ```javascript
+		* // Do calculations and get back the desired CSS unit.
+		* var frameWidth = 250,
+		*     frameWithMarginInches = enyo.dom.unit( 10 + frameWidth + 10, 'in' ),
+		*     frameWithMarginRems = enyo.dom.unit( 10 + frameWidth + 10, 'rem' );
+		* // '2.8125in' == frameWithMarginInches
+		* // '22.5rem' == frameWithMarginRems
+		* ```
+		*
+		* @param {(String|Number)} pixels - The the pixels or math to convert to the unit.
+		*	("px" suffix in String format is permitted. ex: `'20px'`)
+		* @param {(String)} toUnit - The name of the unit to convert to.
+		* @returns {(Number|undefined)} Resulting conversion, in case of malformed input, `undefined`
+		* @public
+		*/
+		unit: function (pixels, toUnit) {
+			if (!toUnit || !this.unitToPixelFactors[toUnit]) return;
+			if (typeof pixels == 'string' && pixels.substr(-2) == 'px') pixels = parseInt(pixels.substr(0, pixels.length - 2), 10);
+			if (typeof pixels != 'number') return;
+
+			return (pixels / this.unitToPixelFactors[toUnit]) + '' + toUnit;
+		},
+
+		/**
+		* Object that stores all of the pixel conversion factors to each keyed unit.
+		*
+		* @public
+		*/
+		unitToPixelFactors: {
+			'rem': 12,
+			'in': 96
+		}
 	};
 
 	// override setInnerHtml for Windows 8 HTML applications

--- a/source/ui/Animator.js
+++ b/source/ui/Animator.js
@@ -206,6 +206,23 @@
 			}
 		},
 
+		/**
+		* Stops the animation after a final step
+		*
+		* @returns {this} The callee for chaining
+		* @public
+		*/
+		complete: function () {
+			if (this.isAnimating()) {
+				// set the start time such that the delta will always be greater than the duration
+				// causing the animation to complete immediately
+				this.t0 = -this.duration - 1;
+				this.next();
+			}
+
+			return this;
+		},
+
 		/** 
 		* Reverses the direction of a running animation.
 		* 

--- a/tools/deploy.js
+++ b/tools/deploy.js
@@ -326,9 +326,11 @@ if(!manifest._default) {
 } else {
 	/* Use legacy built-in list of files & folders to copy */
 	shell.mkdir('-p', path.join(opt.out, 'lib'));
-	shell.cp('index.html', opt.out);
+	if (shell.test('-f', 'index.html')) {
+		shell.cp('index.html', opt.out);
+	}
 
-	if(shell.test('-f', 'icon.png')) {
+	if (shell.test('-f', 'icon.png')) {
 		shell.cp('icon.png', opt.out);
 	}
 

--- a/tools/deploy.js
+++ b/tools/deploy.js
@@ -327,7 +327,10 @@ if(!manifest._default) {
 	/* Use legacy built-in list of files & folders to copy */
 	shell.mkdir('-p', path.join(opt.out, 'lib'));
 	shell.cp('index.html', opt.out);
-	shell.cp('icon.png', opt.out);
+
+	if(shell.test('-f', 'icon.png')) {
+		shell.cp('icon.png', opt.out);
+	}
 
 	if(shell.test('-d', 'assets')) {
 		shell.cp('-r', 'assets', opt.out);

--- a/tools/deploy.js
+++ b/tools/deploy.js
@@ -105,6 +105,7 @@ process.on('message', function(msg) {
 var node = process.argv[0],
 	deploy = process.argv[1],
 	less = true, // LESS compilation, turned on by default
+	ri = false, // LESS resolution-independence conversion, turned off by default
 	verbose = false,
 	beautify = false,
 	noexec = false,
@@ -116,16 +117,17 @@ function printUsage() {
 		'Usage: ' + node + ' ' + deploy + ' [-c][-g][-v][-B][-e enyo_dir][-l lib_dir][-b build_dir][-o out_dir][-p package_js][-s source_dir][-f map_from -t map_to ...]\n' +
 		'\n' +
 		'Options:\n' +
-		'  -v  verbose operation                     [boolean]  [default: ' + verbose + ']\n' +
-		'  -b  build directory sub-folder            [default: "./build"]\n' +
-		'  -c  do not run the LESS compiler          [boolean]  [default: ' + less + ']\n' +
-		'  -e  enyo framework sub-folder             [default: "./enyo"]\n' +
-		'  -l  libs sub-folder                       [default: "./lib"]\n' +
-		'  -o  alternate output directory            [default: "PWD/deploy/APPNAME"]\n' +
-		'  -p  main package.js file (relative)       [default: "./package.js"]\n' +
-		'  -s  source code root directory            [default: "PWD"]\n' +
-		'  -B  pretty-print (beautify) JS output     [boolean]  [default: ' + beautify + ']\n' +
-		'  -g  gather libs to default location       [boolean]  [default: ' + gather + ']\n' +
+		'  -v  verbose operation                         [boolean]  [default: ' + verbose + ']\n' +
+		'  -b  build directory sub-folder                [default: "./build"]\n' +
+		'  -c  do not run the LESS compiler              [boolean]  [default: ' + less + ']\n' +
+		'  -r  perform LESS resolution-independence      [boolean]  [default: ' + ri + ']\n' +
+		'  -e  enyo framework sub-folder                 [default: "./enyo"]\n' +
+		'  -l  libs sub-folder                           [default: "./lib"]\n' +
+		'  -o  alternate output directory                [default: "PWD/deploy/APPNAME"]\n' +
+		'  -p  main package.js file (relative)           [default: "./package.js"]\n' +
+		'  -s  source code root directory                [default: "PWD"]\n' +
+		'  -B  pretty-print (beautify) JS output         [boolean]  [default: ' + beautify + ']\n' +
+		'  -g  gather libs to default location           [boolean]  [default: ' + gather + ']\n' +
 		'  -f  remote source mapping: from local path\n' +
 		'  -t  remote source mapping: to remote path\n' +
 		'  -E|--noexec disallow execution of application-provided scripts [default: false]\n' +
@@ -136,6 +138,7 @@ function printUsage() {
 var opt = nopt(/*knownOpts*/ {
 	"build": String,	// relative path
 	"less": Boolean,
+	"ri": Boolean,
 	"enyo": String,		// relative path
 	"lib": String,		// relative path
 	"out": path,		// absolute path
@@ -152,6 +155,7 @@ var opt = nopt(/*knownOpts*/ {
 }, /*shortHands*/ {
 	"b": "--build",
 	"c": "--no-less",
+	"r": "--ri",
 	"e": "--enyo",
 	"l": "--lib",
 	"o": "--out",
@@ -219,6 +223,7 @@ opt.enyo = opt.enyo || manifest.enyo || "enyo"; // from top-level folder
 log("opt:", opt);
 
 less = (opt.less !== false) && less;
+ri = opt.ri;
 gather = (opt.gather !== false) && gather;
 beautify = opt.beautify;
 noexec = opt.noexec;
@@ -239,6 +244,7 @@ log("Using: opt.enyo=" + opt.enyo);
 log("Using: opt.packagejs=" + opt.packagejs);
 log("Using: opt.test=" + opt.test);
 log("Using: less=" + less);
+log("Using: ri=" + ri);
 log("Using: beautify=" + beautify);
 log("Using: noexec=" + noexec);
 log("Using: gather=" + gather);
@@ -275,6 +281,7 @@ if (!opt.mapfrom || opt.mapfrom.indexOf("enyo") < 0) {
 		'-enyo', opt.enyo,
 		'-destdir', opt.out,
 		'-output', path.join(opt.build, 'enyo'),
+		(ri ? '-ri' : '-no-ri'),
 		(beautify ? '-beautify' : '-no-beautify'),
 		path.join(opt.enyo, 'minify', 'package.js')];
 	if (opt.mapfrom) {
@@ -294,6 +301,7 @@ args = [node, minifier,
 	'-destdir', opt.out,
 	'-output', path.join(opt.build, 'app'),
 	(less ? '-less' : '-no-less'),
+	(ri ? '-ri' : '-no-ri'),
 	(beautify ? '-beautify' : '-no-beautify'),
 	opt.packagejs];
 if (opt.mapfrom) {

--- a/tools/less.js
+++ b/tools/less.js
@@ -12,4 +12,15 @@
 	script.src = "enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js";
 	script.charset = "utf-8";
 	document.getElementsByTagName('head')[0].appendChild(script);
+
+	script = document.createElement('script');
+	script.src = "enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js";
+	script.charset = "utf-8";
+	script.onload = function () {
+		var less = window.less || {};
+		var ri = new enyoLessRiPlugin();
+		less.plugins = [ri];
+		window.less = less;
+	}
+	document.getElementsByTagName('head')[0].appendChild(script);
 })();

--- a/tools/minifier/lessc.js
+++ b/tools/minifier/lessc.js
@@ -26,6 +26,9 @@ ResolutionIndependence.prototype = {
 	run: function (root) {
 		return this._visitor.visit(root);
 	},
+	generateRootRule: function () {
+		return "html { font-size: " + this._baseSize + "px; }";
+	},
 	visitRule: function (node) {
 		var values = node && node.value && node.value.value && node.value.value.length && node.value.value[0],
 			i;
@@ -77,6 +80,7 @@ function finish(loader, objs, doneCB) {
 				}
 			} else {
 				try {
+					var ri = new ResolutionIndependence();
 					var css =
 						"/* WARNING: This is a generated file for backward-compatibility.  Most      */\n" +
 						"/* users should instead modify LESS files.  If you choose to edit this CSS  */\n" +
@@ -85,7 +89,7 @@ function finish(loader, objs, doneCB) {
 						"/* '-c' flag to disable LESS compilation.  This will force the loader and   */\n" +
 						"/* minifier to fall back to using CSS files in place of the same-name       */\n" +
 						"/* LESS file.                                                               */\n" +
-						"\n" + tree.toCSS({plugins: [new ResolutionIndependence()]});
+						"\n" + ri.generateRootRule() + "\n" + tree.toCSS({plugins: [ri]});
 					fs.writeFileSync(cssFile, css, "utf8");
 					nextSheet();
 				} catch(e)  {

--- a/tools/minifier/lessc.js
+++ b/tools/minifier/lessc.js
@@ -4,56 +4,13 @@ var
 	path = require("path"),
 	walker = require("walker"),
 	nopt = require("nopt"),
-	less = require("less");
+	less = require("less"),
+	RezInd = require('less-plugin-resolution-independence');
 
 // Shimming path.relative with 0.8.8's version if it doesn't exist
 if(!path.relative){
 	path.relative = require('./path-relative-shim').relative;
 }
-
-// Adding a "plugin" that works with LESS 1.7, for converting pixel measurements to resolution
-// independent units i.e. rems.
-ResolutionIndependence = function(opts) {
-	this._baseSize = opts && opts.baseSize || this._baseSize;
-	this._riUnit = opts && opts.riUnit || this._riUnit;
-	this._unit = opts && opts.unit || this._unit;
-	this._visitor = new less.tree.visitor(this);
-};
-ResolutionIndependence.prototype = {
-	_baseSize: 12,
-	_riUnit: 'rem',
-	_unit: 'px',
-	_ignoreUnit: 'apx', // "absolute" px
-	run: function (root) {
-		return this._visitor.visit(root);
-	},
-	visitRule: function (node) {
-		var values = node && node.value && node.value.value && node.value.value.length && node.value.value[0],
-			i;
-
-		if (values) {
-			if (Array.isArray(values.value)) {
-				for (i = 0 ; i < values.value.length; i++) {
-					this.parseValue(values.value[i]);
-				}
-			} else {
-				this.parseValue(values);
-			}
-		}
-		return node;
-	},
-	parseValue: function (valueNode) {
-		if (valueNode.value && valueNode.value.toString().indexOf(this._ignoreUnit) != -1) {
-			valueNode.value = parseInt(valueNode.value, 10) + this._unit;
-		} else if (valueNode.value && valueNode.value.toString().indexOf(this._unit) != -1) {
-			valueNode.value = parseInt(valueNode.value, 10) / this._baseSize + this._riUnit;
-		} else if (valueNode.unit && valueNode.unit.numerator && valueNode.unit.numerator.length &&
-			valueNode.unit.numerator[0] == this._unit) {
-			valueNode.value = valueNode.value / this._baseSize;
-			valueNode.unit.numerator[0] = this._riUnit;
-		}
-	}
-};
 
 var w = console.log;
 
@@ -83,7 +40,8 @@ function finish(loader, objs, doneCB) {
 				try {
 					var generatedCss, ri;
 					if (opt.ri) {
-						ri = new ResolutionIndependence();
+						ri = new RezInd();
+						// console.log("ri:", RezInd, ri);
 						generatedCss = tree.toCSS({plugins: [ri]});
 					} else {
 						generatedCss = tree.toCSS();

--- a/tools/minifier/node_modules/less-plugin-resolution-independence/README.md
+++ b/tools/minifier/node_modules/less-plugin-resolution-independence/README.md
@@ -1,0 +1,4 @@
+less-plugin-resolution-independence
+========================
+
+Adds a means of conversion from pixels to rem, a resolution independant scalable mechanism.

--- a/tools/minifier/node_modules/less-plugin-resolution-independence/lib/index.js
+++ b/tools/minifier/node_modules/less-plugin-resolution-independence/lib/index.js
@@ -1,0 +1,8 @@
+var RezInd = require("./resolution-independence");
+
+module.exports = {
+    install: function(less, pluginManager) {
+        var ri = new RezInd(less);
+        pluginManager.addVisitor(ri);
+    }
+};

--- a/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
+++ b/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
@@ -21,6 +21,11 @@
 	*	resolution-independent units.
 	* @property {String} absoluteUnit - The unit of measurement to ignore for
 	*	resolution-independence conversion, and instead should be 1:1 converted to our `_unit` unit.
+	* @property {Number} minUnitSize The minimum unit size (as an absolute value) that any
+	*	measurement should be valued at the lowest device resolution we wish to support. This allows
+	*	for meaningful measurements that are not unnecessarily scaled down excessively.
+	* @property {Number} minSize The root font-size corresponding to the lowest device resolution we
+	*	wish to support. This is utilized in conjunction with the `minUnitSize` property.
 	*/
 
 	var ResolutionIndependence = function (opts) {
@@ -28,6 +33,8 @@
 		this._riUnit = opts && opts.riUnit || this._riUnit;
 		this._unit = opts && opts.unit || this._unit;
 		this._absoluteUnit = opts && opts.absoluteUnit || this._absoluteUnit;
+		this._minUnitSize = opts && opts.minUnitSize || this._minUnitSize;
+		this._minSize = opts && opts.minSize || this._minSize;
 	};
 
 	ResolutionIndependence.prototype = {
@@ -68,6 +75,28 @@
 		* @private
 		*/
 		_absoluteUnit: 'apx', // "absolute" px
+
+		/**
+		* The minimum unit size (as an absolute value), in our base unit `_unit`, that any
+		* measurement should be set to in the resolution corresponding to our minimum root font-size
+		* `_minSize`.
+		*
+		* @type {Number}
+		* @default 1
+		* @private
+		*/
+		_minUnitSize: 1,
+
+		/**
+		* The root font-size corresponding to the lowest device resolution we wish to support. The
+		* determination for adjusting our measurements based on the minimum unit `_minUnitSize` are
+		* dependent on this value.
+		*
+		* @type {String}
+		* @default 8
+		* @private
+		*/
+		_minSize: 8,
 
 		/*
 		* Entry point
@@ -148,22 +177,33 @@
 		* @private
 		*/
 		parseValue: function (value, unit) {
+			var minScaleFactor = this._minSize / this._baseSize,
+				scaledValue;
 			// String value in our absolute unit
 			if (value && value.toString().slice(-1*this._absoluteUnit.length) == this._absoluteUnit) {
 				return parseFloat(value) + this._unit;
 			}
 			// String value in our to-be-converted unit
 			else if (value && value.toString().slice(-1*this._unit.length) == this._unit) {
-				return parseFloat(value) / this._baseSize + this._riUnit;
+				value = parseFloat(value);
+				scaledValue = Math.abs(value * minScaleFactor);
+				return (scaledValue && scaledValue <= this._minUnitSize) ?
+					this._minUnitSize * (value < 0 ? -1 : 1) + this._unit : value / this._baseSize + this._riUnit;
 			}
 			// LESS object with separate value and unit properties
 			else if (unit) {
 				// The standard unit to convert
 				if (unit == this._unit) {
-					return {
-						value: value / this._baseSize,
-						unit: this._riUnit
-					};
+					scaledValue = Math.abs(value * minScaleFactor);
+					return (scaledValue && scaledValue <= this._minUnitSize) ? 
+						{
+							value: this._minUnitSize * (value < 0 ? -1 : 1),
+							unit: this._unit
+						} :
+						{
+							value: value / this._baseSize,
+							unit: this._riUnit
+						};
 				}
 				// The absolute unit to convert to our standard unit
 				else if (unit == this._absoluteUnit) {

--- a/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
+++ b/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
@@ -28,7 +28,11 @@
                 i;
 
             if (values) {
-                if (Array.isArray(values.value)) {
+                if (Array.isArray(values.args)) {
+                    for (i = 0; i < values.args.length; i++) {
+                        this.parseValue(values.args[i]);
+                    }
+                } else if (Array.isArray(values.value)) {
                     for (i = 0 ; i < values.value.length; i++) {
                         this.parseValue(values.value[i]);
                     }

--- a/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
+++ b/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
@@ -46,7 +46,7 @@
 		* @default 12
 		* @private
 		*/
-		_baseSize: 12,
+		_baseSize: 24,
 
 		/**
 		* The unit of measurement to we wish to use for resolution-independent units.

--- a/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
+++ b/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
@@ -43,7 +43,7 @@
 		* The root font-size we wish to use to base all of our conversions upon.
 		*
 		* @type {Number}
-		* @default 12
+		* @default 24
 		* @private
 		*/
 		_baseSize: 24,
@@ -93,7 +93,7 @@
 		* dependent on this value.
 		*
 		* @type {String}
-		* @default 8
+		* @default 16
 		* @private
 		*/
 		_minSize: 8,

--- a/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
+++ b/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
@@ -24,34 +24,47 @@
             return this._visitor.visit(root);
         },
         visitRule: function (node) {
-            var values = node && !node.inline && node.value && node.value.value && node.value.value.length && node.value.value[0],
+            var valueNode = node && !node.inline && node.value && node.value.value && node.value.value.length && node.value.value[0],
+                stringValues,
+                convertedStringValues,
                 i;
 
-            if (values) {
-                if (Array.isArray(values.args)) {
-                    for (i = 0; i < values.args.length; i++) {
-                        this.parseValue(values.args[i]);
-                    }
-                } else if (Array.isArray(values.value)) {
-                    for (i = 0 ; i < values.value.length; i++) {
-                        this.parseValue(values.value[i]);
-                    }
-                } else {
-                    this.parseValue(values);
+            if (Array.isArray(valueNode.args)) {
+                for (i = 0; i < valueNode.args.length; i++) {
+                    this.parseValue(valueNode.args[i]);
                 }
+            } else if (Array.isArray(valueNode.value)) {
+                for (i = 0; i < valueNode.value.length; i++) {
+                    this.parseValue(valueNode.value[i]);
+                }
+            } else if (typeof valueNode.value == 'string') {
+                stringValues = valueNode.value.split(/(\s+)/);
+                stringValues = stringValues.map(function (val) {
+                    return {value: val};
+                });
+                convertedStringValues = stringValues.map(this.parseValue.bind(this));
+                valueNode.value = convertedStringValues.join('');
+            } else {
+                this.parseValue(valueNode);
             }
+
             return node;
         },
         parseValue: function (valueNode) {
             if (valueNode.value && valueNode.value.toString().indexOf(this._ignoreUnit) != -1) {
-                valueNode.value = parseInt(valueNode.value, 10) + this._unit;
+                /*jshint -W093 */
+                return (valueNode.value = parseInt(valueNode.value, 10) + this._unit);
             } else if (valueNode.value && valueNode.value.toString().indexOf(this._unit) != -1) {
-                valueNode.value = parseInt(valueNode.value, 10) / this._baseSize + this._riUnit;
+                /*jshint -W093 */
+                return (valueNode.value = parseInt(valueNode.value, 10) / this._baseSize + this._riUnit);
             } else if (valueNode.unit && valueNode.unit.numerator && valueNode.unit.numerator.length &&
                 valueNode.unit.numerator[0] == this._unit) {
                 valueNode.value = valueNode.value / this._baseSize;
                 valueNode.unit.numerator[0] = this._riUnit;
+                return valueNode.value + valueNode.unit.numerator[0];
             }
+
+            return valueNode.value;
         }
     };
 

--- a/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
+++ b/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
@@ -103,7 +103,7 @@
 		* @default 16
 		* @private
 		*/
-		_minSize: 8,
+		_minSize: 16,
 
 		/**
 		* This number is a representation of how precise our measurements should be. More

--- a/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
+++ b/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
@@ -39,7 +39,7 @@
 		* @default 12
 		* @private
 		*/
-		_baseSize: 12,
+		_baseSize: 24,
 
 		/**
 		* The unit of measurement to we wish to use for resolution-independent units.

--- a/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
+++ b/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
@@ -20,9 +20,6 @@
         _unit: 'px',
         _ignoreUnit: 'apx', // "absolute" px
         run: function (root) {
-
-			console.log('hey');
-
 			this._visitor = this._visitor || new less.tree.visitor(this);
             return this._visitor.visit(root);
         },

--- a/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
+++ b/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
@@ -13,7 +13,6 @@
         this._baseSize = opts && opts.baseSize || this._baseSize;
         this._riUnit = opts && opts.riUnit || this._riUnit;
         this._unit = opts && opts.unit || this._unit;
-        this._visitor = new less.tree.visitor(this);
     };
     ResolutionIndependence.prototype = {
         _baseSize: 12,
@@ -21,6 +20,7 @@
         _unit: 'px',
         _ignoreUnit: 'apx', // "absolute" px
         run: function (root) {
+			this._visitor = this._visitor || new less.tree.visitor(this);
             return this._visitor.visit(root);
         },
         visitRule: function (node) {
@@ -52,19 +52,10 @@
     };
 
     if (typeof window != 'undefined') {
-
             var less = window.less || {};
-
-            window.enyoLessRiPlugin = new ResolutionIndependence();
+            window.enyoLessRiPlugin = ResolutionIndependence;
             less.plugins = [window.enyoLessRiPlugin];
             window.less = less;
-
-            //this is here right now in lieu of a better way of loading less, after the plugin.
-            var script = document.createElement('script');
-            script.src = "enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js";
-            script.charset = "utf-8";
-            document.getElementsByTagName('head')[0].appendChild(script);
-
     } else {
         module.exports = ResolutionIndependence;
     }

--- a/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
+++ b/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
@@ -21,11 +21,11 @@
 	*	resolution-independent units.
 	* @property {String} absoluteUnit - The unit of measurement to ignore for
 	*	resolution-independence conversion, and instead should be 1:1 converted to our `_unit` unit.
-	* @property {Number} minUnitSize The minimum unit size (as an absolute value) that any
+	* @property {Number} minUnitSize - The minimum unit size (as an absolute value) that any
 	*	measurement should be valued at the lowest device resolution we wish to support. This allows
 	*	for meaningful measurements that are not unnecessarily scaled down excessively.
-	* @property {Number} minSize The root font-size corresponding to the lowest device resolution we
-	*	wish to support. This is utilized in conjunction with the `minUnitSize` property.
+	* @property {Number} minSize - The root font-size corresponding to the lowest device resolution
+	*	we wish to support. This is utilized in conjunction with the `minUnitSize` property.
 	* @property {Number} precision - How precise our measurements will be, namely the maximum amount
 	*	of fractional digits that will appear in our converted measurements.
 	*/
@@ -38,6 +38,10 @@
 		this._minUnitSize = opts && opts.minUnitSize || this._minUnitSize;
 		this._minSize = opts && opts.minSize || this._minSize;
 		this._precision = opts && opts.precision || this._precision;
+
+		// One-time computation of the minimum scale factor that will be used for determining
+		// whether or not to clamp measurement values to the minimum unit size `_minUnitSize`.
+		this._minScaleFactor = this._minSize / this._baseSize;
 	};
 
 	ResolutionIndependence.prototype = {
@@ -129,73 +133,105 @@
 		* @private
 		*/
 		visitRule: function (node) {
-			var valueNode = node && !node.inline && node.value && node.value.value && node.value.value.length && node.value.value[0],
+			var ruleNode = node && !node.inline && node.value && node.value.value && node.value.value.length && node.value.value[0],
 				stringValues;
 
 			// The value(s) of a CSS function call
-			if (Array.isArray(valueNode.args)) {
-				valueNode.args.forEach(this.updateNode.bind(this));
+			if (Array.isArray(ruleNode.args)) {
+				ruleNode.args.forEach(this.updateNode.bind(this));
 			}
 			// Multiple property values where at least one value is a LESS variable (LESS
 			// automatically converts all of the values into array items)
-			else if (Array.isArray(valueNode.value)) {
-				valueNode.value.forEach(this.updateNode.bind(this));
+			else if (Array.isArray(ruleNode.value)) {
+				ruleNode.value.forEach(this.updateNode.bind(this));
 			}
 			// Directly set string values that have a number
-			else if (typeof valueNode.value == 'string' && valueNode.value.match(/\d+/g)) {
-				stringValues = valueNode.value.match(/\S+/g) || [];
-				valueNode.value = stringValues.map(this.parseValue.bind(this)).join(' ');
+			else if (typeof ruleNode.value == 'string' && ruleNode.value.match(/\d+/g)) {
+				stringValues = ruleNode.value.match(/\S+/g) || [];
+				ruleNode.value = stringValues.map(this.parseValueString.bind(this)).join(' ');
 			}
 			// A single value
 			else {
-				this.updateNode(valueNode);
+				this.updateNode(ruleNode);
 			}
-
-			return node;
 		},
 
 		/**
-		* Takes a LESS rule node and converts the value to a resolution-independent measurement. If
+		* Takes a LESS rule node and updates the value to a resolution-independent measurement. If
 		* the rule node's value is a string value, the value and unit will be set as the updated
 		* value of this node. If the rule node consists of a value object and unit object, both of
 		* these objects will be updated with the appropriate values.
 		*
-		* @param {Object} valueNode - The rule node we are currently examining and will convert.
+		* @param {Object} ruleNode - The rule node we are currently examining and will convert.
 		* @private
 		*/
-		updateNode: function (valueNode) {
-			var value = valueNode.value,
-				unitNode = valueNode.unit,
-				unit = unitNode && unitNode.numerator && unitNode.numerator.length && unitNode.numerator[0],
-				result;
+		updateNode: function (ruleNode) {
+			if (ruleNode) {
+				var value = ruleNode.value,
+					unitNode = ruleNode.unit,
+					result;
 
-			result = this.parseValue(value, unit);
-
-			if (unit && result && result.unit) {
-				valueNode.value = result.value;
-				unitNode.numerator[0] = result.unit;
-			} else if (result) {
-				valueNode.value = result;
+				if (unitNode) {
+					result = this.parseValueObject(value, unitNode);
+					ruleNode.value = result.value;
+					unitNode.numerator[0] = result.unit;
+				} else {
+					ruleNode.value = this.parseValueString(value);
+				}
 			}
 		},
 
 		/**
-		* Examines a value and optional unit, and converts to a resolution-independent measurement.
-		*
-		* @param {String} value - The value, usually a number, to be converted.
-		* @param {String} [unit] - The current unit of our value measurement. If this is provided,
-		*	we assume that we are dealing with a value object and a unit object and will return an
-		*	object instead of a string.
-		* @returns {String | Object} If we are converting a string value, we return a concatenated
-		*	string value consisting of the converted value and unit. If we are converting an object,
-		*	such as when we have separate value and unit values, we return an object consisting of
-		*	the converted value and unit as separate properties. If no conversion occurs, we return
-		*	the original value that was provided.
+		* Parses measurement values that have a separate unit object.
+		* 
+		* @param {Number} value - The measurement value we wish to convert.
+		* @param {Object} unitNode - An object representing the unit associated with the measurement
+		*	value.
+		* @returns {Object} An object with `value` and `unit` properties that represent the
+		*	measurement in resolution-independent units.
 		* @private
 		*/
-		parseValue: function (value, unit) {
-			var minScaleFactor = this._minSize / this._baseSize,
+		parseValueObject: function (value, unitNode) {
+			var unit = (unitNode && unitNode.numerator && unitNode.numerator.length && unitNode.numerator[0]) || unitNode.backupUnit,
 				scaledValue;
+
+			// The standard unit to convert (if no unit, we assume the base unit)
+			if (unit == this._unit) {
+				scaledValue = Math.abs(value * this._minScaleFactor);
+				return (scaledValue && scaledValue <= this._minUnitSize) ? 
+					{
+						value: Math.abs(value) < this._minUnitSize ? value : this._minUnitSize * (value < 0 ? -1 : 1),
+						unit: this._unit
+					} :
+					{
+						value: this.convertValue(value),
+						unit: this._riUnit
+					};
+			}
+			// The absolute unit to convert to our standard unit
+			else if (unit == this._absoluteUnit) {
+				return {
+					value: value,
+					unit: this._unit
+				};
+			}
+
+			return {
+				value: value,
+				unit: unit
+			};
+		},
+
+		/**
+		* Parses measurements that contain both the value and unit as a single string.
+		* 
+		* @param {String} value - The measurement in the base unit which we wish to convert.
+		* @returns {String} The measurement, in resolution-independent units.
+		* @private
+		*/
+		parseValueString: function (value) {
+			var scaledValue;
+
 			// String value in our absolute unit
 			if (value && value.toString().slice(-1*this._absoluteUnit.length) == this._absoluteUnit) {
 				return parseFloat(value) + this._unit;
@@ -203,34 +239,11 @@
 			// String value in our to-be-converted unit
 			else if (value && value.toString().slice(-1*this._unit.length) == this._unit) {
 				value = parseFloat(value);
-				scaledValue = Math.abs(value * minScaleFactor);
+				scaledValue = Math.abs(value * this._minScaleFactor);
 				return (scaledValue && scaledValue <= this._minUnitSize) ?
 					(Math.abs(value) < this._minUnitSize ?
 						value + this._unit : this._minUnitSize * (value < 0 ? -1 : 1) + this._unit) :
 					this.convertValue(value) + this._riUnit;
-			}
-			// LESS object with separate value and unit properties
-			else if (unit) {
-				// The standard unit to convert
-				if (unit == this._unit) {
-					scaledValue = Math.abs(value * minScaleFactor);
-					return (scaledValue && scaledValue <= this._minUnitSize) ? 
-						{
-							value: Math.abs(value) < this._minUnitSize ? value : this._minUnitSize * (value < 0 ? -1 : 1),
-							unit: this._unit
-						} :
-						{
-							value: this.convertValue(value),
-							unit: this._riUnit
-						};
-				}
-				// The absolute unit to convert to our standard unit
-				else if (unit == this._absoluteUnit) {
-					return {
-						value: value,
-						unit: this._unit
-					};
-				}
 			}
 
 			return value;

--- a/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
+++ b/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
@@ -24,7 +24,7 @@
             return this._visitor.visit(root);
         },
         visitRule: function (node) {
-            var values = node && node.value && node.value.value && node.value.value.length && node.value.value[0],
+            var values = node && !node.inline && node.value && node.value.value && node.value.value.length && node.value.value[0],
                 i;
 
             if (values) {

--- a/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
+++ b/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
@@ -31,40 +31,49 @@
 
             if (Array.isArray(valueNode.args)) {
                 for (i = 0; i < valueNode.args.length; i++) {
-                    this.parseValue(valueNode.args[i]);
+                    this.convertValue(valueNode.args[i]);
                 }
             } else if (Array.isArray(valueNode.value)) {
                 for (i = 0; i < valueNode.value.length; i++) {
-                    this.parseValue(valueNode.value[i]);
+                    this.convertValue(valueNode.value[i]);
                 }
-            } else if (typeof valueNode.value == 'string') {
-                stringValues = valueNode.value.split(/(\s+)/);
-                stringValues = stringValues.map(function (val) {
-                    return {value: val};
-                });
+            } else if (typeof valueNode.value == 'string' && valueNode.value.match(/\d+/g)) {
+                stringValues = valueNode.value.match(/\S+/g) || [];
                 convertedStringValues = stringValues.map(this.parseValue.bind(this));
-                valueNode.value = convertedStringValues.join('');
+                valueNode.value = convertedStringValues.join(' ');
             } else {
-                this.parseValue(valueNode);
+                this.convertValue(valueNode);
             }
 
             return node;
         },
-        parseValue: function (valueNode) {
-            if (valueNode.value && valueNode.value.toString().indexOf(this._ignoreUnit) != -1) {
-                /*jshint -W093 */
-                return (valueNode.value = parseInt(valueNode.value, 10) + this._unit);
-            } else if (valueNode.value && valueNode.value.toString().indexOf(this._unit) != -1) {
-                /*jshint -W093 */
-                return (valueNode.value = parseInt(valueNode.value, 10) / this._baseSize + this._riUnit);
-            } else if (valueNode.unit && valueNode.unit.numerator && valueNode.unit.numerator.length &&
-                valueNode.unit.numerator[0] == this._unit) {
-                valueNode.value = valueNode.value / this._baseSize;
-                valueNode.unit.numerator[0] = this._riUnit;
-                return valueNode.value + valueNode.unit.numerator[0];
+        convertValue: function (valueNode) {
+            var value = valueNode.value,
+                unit = valueNode.unit,
+                result;
+
+            result = this.parseValue(value, unit);
+
+            if (unit && result && typeof result == 'object') {
+                valueNode.value = result.value;
+                valueNode.unit.numerator[0] = result.unit;
+            } else if (result) {
+                valueNode.value = result;
+            }
+        },
+        parseValue: function (value, unit) {
+            if (value && value.toString().slice(-1*this._ignoreUnit.length) == this._ignoreUnit) {
+                return parseInt(value, 10) + this._unit;
+            } else if (value && value.toString().slice(-1*this._unit.length) == this._unit) {
+                return parseInt(value, 10) / this._baseSize + this._riUnit;
+            } else if (unit && unit.numerator && unit.numerator.length && unit.numerator[0] == this._unit) {
+                return {
+                    value: value / this._baseSize,
+                    unit: this._riUnit
+                };
             }
 
-            return valueNode.value;
+            return value;
         }
     };
 

--- a/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
+++ b/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
@@ -19,15 +19,15 @@
 	*	resolution-independent units.
 	* @property {String} unit - The unit of measurement to that we wish to convert to
 	*	resolution-independent units.
-	* @property {String} unit - The unit of measurement to ignore for resolution-independence
-	*	conversion, and instead should be 1:1 converted to our `_unit` unit.
+	* @property {String} absoluteUnit - The unit of measurement to ignore for
+	*	resolution-independence conversion, and instead should be 1:1 converted to our `_unit` unit.
 	*/
 
 	var ResolutionIndependence = function (opts) {
 		this._baseSize = opts && opts.baseSize || this._baseSize;
 		this._riUnit = opts && opts.riUnit || this._riUnit;
 		this._unit = opts && opts.unit || this._unit;
-		this._ignoreUnit = opts && opts.ignoreUnit || this._ignoreUnit;
+		this._absoluteUnit = opts && opts.absoluteUnit || this._absoluteUnit;
 	};
 
 	ResolutionIndependence.prototype = {
@@ -67,7 +67,7 @@
 		* @default 'apx'
 		* @private
 		*/
-		_ignoreUnit: 'apx', // "absolute" px
+		_absoluteUnit: 'apx', // "absolute" px
 
 		/*
 		* Entry point
@@ -148,15 +148,30 @@
 		* @private
 		*/
 		parseValue: function (value, unit) {
-			if (value && value.toString().slice(-1*this._ignoreUnit.length) == this._ignoreUnit) {
+			// String value in our absolute unit
+			if (value && value.toString().slice(-1*this._absoluteUnit.length) == this._absoluteUnit) {
 				return parseInt(value, 10) + this._unit;
-			} else if (value && value.toString().slice(-1*this._unit.length) == this._unit) {
+			}
+			// String value in our to-be-converted unit
+			else if (value && value.toString().slice(-1*this._unit.length) == this._unit) {
 				return parseInt(value, 10) / this._baseSize + this._riUnit;
-			} else if (unit && unit == this._unit) {
-				return {
-					value: value / this._baseSize,
-					unit: this._riUnit
-				};
+			}
+			// LESS object with separate value and unit properties
+			else if (unit) {
+				// The standard unit to convert
+				if (unit == this._unit) {
+					return {
+						value: value / this._baseSize,
+						unit: this._riUnit
+					};
+				}
+				// The absolute unit to convert to our standard unit
+				else if (unit == this._absoluteUnit) {
+					return {
+						value: value,
+						unit: this._unit
+					};
+				}
 			}
 
 			return value;

--- a/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
+++ b/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
@@ -150,11 +150,11 @@
 		parseValue: function (value, unit) {
 			// String value in our absolute unit
 			if (value && value.toString().slice(-1*this._absoluteUnit.length) == this._absoluteUnit) {
-				return parseInt(value, 10) + this._unit;
+				return parseFloat(value) + this._unit;
 			}
 			// String value in our to-be-converted unit
 			else if (value && value.toString().slice(-1*this._unit.length) == this._unit) {
-				return parseInt(value, 10) / this._baseSize + this._riUnit;
+				return parseFloat(value) / this._baseSize + this._riUnit;
 			}
 			// LESS object with separate value and unit properties
 			else if (unit) {

--- a/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
+++ b/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
@@ -188,7 +188,9 @@
 				value = parseFloat(value);
 				scaledValue = Math.abs(value * minScaleFactor);
 				return (scaledValue && scaledValue <= this._minUnitSize) ?
-					this._minUnitSize * (value < 0 ? -1 : 1) + this._unit : value / this._baseSize + this._riUnit;
+					(Math.abs(value) < this._minUnitSize ?
+						value + this._unit : this._minUnitSize * (value < 0 ? -1 : 1) + this._unit) :
+					value / this._baseSize + this._riUnit;
 			}
 			// LESS object with separate value and unit properties
 			else if (unit) {
@@ -197,7 +199,7 @@
 					scaledValue = Math.abs(value * minScaleFactor);
 					return (scaledValue && scaledValue <= this._minUnitSize) ? 
 						{
-							value: this._minUnitSize * (value < 0 ? -1 : 1),
+							value: Math.abs(value) < this._minUnitSize ? value : this._minUnitSize * (value < 0 ? -1 : 1),
 							unit: this._unit
 						} :
 						{

--- a/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
+++ b/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
@@ -2,85 +2,171 @@
 // independent units i.e. rems.
 ;(function(){
 
-    var less;
-    if (typeof window != 'undefined') {
-        less = window.less || {};
-    } else {
-        less = require("less");
-    }
+	var less;
+	if (typeof window != 'undefined') {
+		less = window.less || {};
+	} else {
+		less = require("less");
+	}
 
-    var ResolutionIndependence = function(opts) {
-        this._baseSize = opts && opts.baseSize || this._baseSize;
-        this._riUnit = opts && opts.riUnit || this._riUnit;
-        this._unit = opts && opts.unit || this._unit;
-    };
-    ResolutionIndependence.prototype = {
-        _baseSize: 12,
-        _riUnit: 'rem',
-        _unit: 'px',
-        _ignoreUnit: 'apx', // "absolute" px
-        run: function (root) {
+	/**
+	* The configurable options that can be passed into `ResolutionIndependence`.
+	*
+	* @typedef {Object} ResolutionIndependence~Options
+	* @property {Number} baseSize - The root font-size we wish to use to base all of our conversions
+	*	upon.
+	* @property {String} riUnit - The unit of measurement to we wish to use for
+	*	resolution-independent units.
+	* @property {String} unit - The unit of measurement to that we wish to convert to
+	*	resolution-independent units.
+	* @property {String} unit - The unit of measurement to ignore for resolution-independence
+	*	conversion, and instead should be 1:1 converted to our `_unit` unit.
+	*/
+
+	var ResolutionIndependence = function (opts) {
+		this._baseSize = opts && opts.baseSize || this._baseSize;
+		this._riUnit = opts && opts.riUnit || this._riUnit;
+		this._unit = opts && opts.unit || this._unit;
+		this._ignoreUnit = opts && opts.ignoreUnit || this._ignoreUnit;
+	};
+
+	ResolutionIndependence.prototype = {
+
+		/**
+		* The root font-size we wish to use to base all of our conversions upon.
+		*
+		* @type {Number}
+		* @default 12
+		* @private
+		*/
+		_baseSize: 12,
+
+		/**
+		* The unit of measurement to we wish to use for resolution-independent units.
+		*
+		* @type {String}
+		* @default 'rem'
+		* @private
+		*/
+		_riUnit: 'rem',
+
+		/**
+		* The unit of measurement to that we wish to convert to resolution-independent units.
+		*
+		* @type {String}
+		* @default 'px'
+		* @private
+		*/
+		_unit: 'px',
+
+		/**
+		* The unit of measurement to ignore for resolution-independence conversion, and instead
+		* should be 1:1 converted to our `_unit` unit.
+		*
+		* @type {String}
+		* @default 'apx'
+		* @private
+		*/
+		_ignoreUnit: 'apx', // "absolute" px
+
+		/*
+		* Entry point
+		*/
+		run: function (root) {
 			this._visitor = this._visitor || new less.tree.visitor(this);
-            return this._visitor.visit(root);
-        },
-        visitRule: function (node) {
-            var valueNode = node && !node.inline && node.value && node.value.value && node.value.value.length && node.value.value[0],
-                stringValues,
-                convertedStringValues,
-                i;
+			return this._visitor.visit(root);
+		},
 
-            if (Array.isArray(valueNode.args)) {
-                for (i = 0; i < valueNode.args.length; i++) {
-                    this.convertValue(valueNode.args[i]);
-                }
-            } else if (Array.isArray(valueNode.value)) {
-                for (i = 0; i < valueNode.value.length; i++) {
-                    this.convertValue(valueNode.value[i]);
-                }
-            } else if (typeof valueNode.value == 'string' && valueNode.value.match(/\d+/g)) {
-                stringValues = valueNode.value.match(/\S+/g) || [];
-                convertedStringValues = stringValues.map(this.parseValue.bind(this));
-                valueNode.value = convertedStringValues.join(' ');
-            } else {
-                this.convertValue(valueNode);
-            }
+		/*
+		* Hook into each rule node
+		*
+		* @private
+		*/
+		visitRule: function (node) {
+			var valueNode = node && !node.inline && node.value && node.value.value && node.value.value.length && node.value.value[0],
+				stringValues;
 
-            return node;
-        },
-        convertValue: function (valueNode) {
-            var value = valueNode.value,
-                unit = valueNode.unit,
-                result;
+			// The value(s) of a CSS function call
+			if (Array.isArray(valueNode.args)) {
+				valueNode.args.forEach(this.convertValue.bind(this));
+			}
+			// Multiple property values where at least one value is a LESS variable (LESS
+			// automatically converts all of the values into array items)
+			else if (Array.isArray(valueNode.value)) {
+				valueNode.value.forEach(this.convertValue.bind(this));
+			}
+			// Directly set string values that have a number
+			else if (typeof valueNode.value == 'string' && valueNode.value.match(/\d+/g)) {
+				stringValues = valueNode.value.match(/\S+/g) || [];
+				valueNode.value = stringValues.map(this.parseValue.bind(this)).join(' ');
+			}
+			// A single value
+			else {
+				this.convertValue(valueNode);
+			}
 
-            result = this.parseValue(value, unit);
+			return node;
+		},
 
-            if (unit && result && typeof result == 'object') {
-                valueNode.value = result.value;
-                valueNode.unit.numerator[0] = result.unit;
-            } else if (result) {
-                valueNode.value = result;
-            }
-        },
-        parseValue: function (value, unit) {
-            if (value && value.toString().slice(-1*this._ignoreUnit.length) == this._ignoreUnit) {
-                return parseInt(value, 10) + this._unit;
-            } else if (value && value.toString().slice(-1*this._unit.length) == this._unit) {
-                return parseInt(value, 10) / this._baseSize + this._riUnit;
-            } else if (unit && unit.numerator && unit.numerator.length && unit.numerator[0] == this._unit) {
-                return {
-                    value: value / this._baseSize,
-                    unit: this._riUnit
-                };
-            }
+		/**
+		* Takes a LESS rule node and converts the value to a resolution-independent measurement. If
+		* the rule node's value is a string value, the value and unit will be set as the updated
+		* value of this node. If the rule node consists of a value object and unit object, both of
+		* these objects will be updated with the appropriate values.
+		*
+		* @param {Object} valueNode - The rule node we are currently examining and will convert.
+		* @private
+		*/
+		convertValue: function (valueNode) {
+			var value = valueNode.value,
+				unitNode = valueNode.unit,
+				unit = unitNode && unitNode.numerator && unitNode.numerator.length && unitNode.numerator[0],
+				result;
 
-            return value;
-        }
-    };
+			result = this.parseValue(value, unit);
 
-    if (typeof window != 'undefined') {
+			if (unit && result && result.unit) {
+				valueNode.value = result.value;
+				unitNode.numerator[0] = result.unit;
+			} else if (result) {
+				valueNode.value = result;
+			}
+		},
+
+		/**
+		* Examines a value and optional unit, and converts to a resolution-independent measurement.
+		*
+		* @param {String} value - The value, usually a number, to be converted.
+		* @param {String} [unit] - The current unit of our value measurement. If this is provided,
+		*	we assume that we are dealing with a value object and a unit object and will return an
+		*	object instead of a string.
+		* @returns {String | Object} If we are converting a string value, we return a concatenated
+		*	string value consisting of the converted value and unit. If we are converting an object,
+		*	such as when we have separate value and unit values, we return an object consisting of
+		*	the converted value and unit as separate properties. If no conversion occurs, we return
+		*	the original value that was provided.
+		* @private
+		*/
+		parseValue: function (value, unit) {
+			if (value && value.toString().slice(-1*this._ignoreUnit.length) == this._ignoreUnit) {
+				return parseInt(value, 10) + this._unit;
+			} else if (value && value.toString().slice(-1*this._unit.length) == this._unit) {
+				return parseInt(value, 10) / this._baseSize + this._riUnit;
+			} else if (unit && unit == this._unit) {
+				return {
+					value: value / this._baseSize,
+					unit: this._riUnit
+				};
+			}
+
+			return value;
+		}
+	};
+
+	if (typeof window != 'undefined') {
 		window.enyoLessRiPlugin = ResolutionIndependence;
-    } else {
-        module.exports = ResolutionIndependence;
-    }
+	} else {
+		module.exports = ResolutionIndependence;
+	}
 
 }());

--- a/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
+++ b/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
@@ -26,6 +26,8 @@
 	*	for meaningful measurements that are not unnecessarily scaled down excessively.
 	* @property {Number} minSize The root font-size corresponding to the lowest device resolution we
 	*	wish to support. This is utilized in conjunction with the `minUnitSize` property.
+	* @property {Number} precision - How precise our measurements will be, namely the maximum amount
+	*	of fractional digits that will appear in our converted measurements.
 	*/
 
 	var ResolutionIndependence = function (opts) {
@@ -35,6 +37,7 @@
 		this._absoluteUnit = opts && opts.absoluteUnit || this._absoluteUnit;
 		this._minUnitSize = opts && opts.minUnitSize || this._minUnitSize;
 		this._minSize = opts && opts.minSize || this._minSize;
+		this._precision = opts && opts.precision || this._precision;
 	};
 
 	ResolutionIndependence.prototype = {
@@ -98,6 +101,20 @@
 		*/
 		_minSize: 8,
 
+		/**
+		* This number is a representation of how precise our measurements should be. More
+		* specifically, this number corresponds to the maximum number of fractional digits in our
+		* computed measurements. This will not affect measurements that utilize the `_absoluteUnit`
+		* unit, or measurements that are adjusted to the minimum unit size, in the event that
+		* `_minUnitSize` has more precision than what is specified here, as `_minUnitSize` would be
+		* user-overridden and assumed intentional.
+		* 
+		* @type {Number}
+		* @default 5
+		* @private
+		*/
+		_precision: 5,
+
 		/*
 		* Entry point
 		*/
@@ -117,12 +134,12 @@
 
 			// The value(s) of a CSS function call
 			if (Array.isArray(valueNode.args)) {
-				valueNode.args.forEach(this.convertValue.bind(this));
+				valueNode.args.forEach(this.updateNode.bind(this));
 			}
 			// Multiple property values where at least one value is a LESS variable (LESS
 			// automatically converts all of the values into array items)
 			else if (Array.isArray(valueNode.value)) {
-				valueNode.value.forEach(this.convertValue.bind(this));
+				valueNode.value.forEach(this.updateNode.bind(this));
 			}
 			// Directly set string values that have a number
 			else if (typeof valueNode.value == 'string' && valueNode.value.match(/\d+/g)) {
@@ -131,7 +148,7 @@
 			}
 			// A single value
 			else {
-				this.convertValue(valueNode);
+				this.updateNode(valueNode);
 			}
 
 			return node;
@@ -146,7 +163,7 @@
 		* @param {Object} valueNode - The rule node we are currently examining and will convert.
 		* @private
 		*/
-		convertValue: function (valueNode) {
+		updateNode: function (valueNode) {
 			var value = valueNode.value,
 				unitNode = valueNode.unit,
 				unit = unitNode && unitNode.numerator && unitNode.numerator.length && unitNode.numerator[0],
@@ -190,7 +207,7 @@
 				return (scaledValue && scaledValue <= this._minUnitSize) ?
 					(Math.abs(value) < this._minUnitSize ?
 						value + this._unit : this._minUnitSize * (value < 0 ? -1 : 1) + this._unit) :
-					value / this._baseSize + this._riUnit;
+					this.convertValue(value) + this._riUnit;
 			}
 			// LESS object with separate value and unit properties
 			else if (unit) {
@@ -203,7 +220,7 @@
 							unit: this._unit
 						} :
 						{
-							value: value / this._baseSize,
+							value: this.convertValue(value),
 							unit: this._riUnit
 						};
 				}
@@ -217,6 +234,18 @@
 			}
 
 			return value;
+		},
+
+		/**
+		* Converts a value from our base unit to a value in resolution-independent units.
+		* 
+		* @param {Number} value - The value, in base units, to be converted to a value that is in
+		*	resolution-independent units.
+		* @returns {Number} - The converted value in resolution-independent units.
+		* @private
+		*/
+		convertValue: function (value) {
+			return parseFloat((value / this._baseSize).toFixed(this._precision));
 		}
 	};
 

--- a/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
+++ b/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
@@ -39,7 +39,7 @@
 		* @default 12
 		* @private
 		*/
-		_baseSize: 24,
+		_baseSize: 12,
 
 		/**
 		* The unit of measurement to we wish to use for resolution-independent units.

--- a/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
+++ b/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
@@ -1,0 +1,72 @@
+// Adding a "plugin" that works with LESS 1.7, for converting pixel measurements to resolution
+// independent units i.e. rems.
+;(function(){
+
+    var less;
+    if (typeof window != 'undefined') {
+        less = window.less || {};
+    } else {
+        less = require("less");
+    }
+
+    var ResolutionIndependence = function(opts) {
+        this._baseSize = opts && opts.baseSize || this._baseSize;
+        this._riUnit = opts && opts.riUnit || this._riUnit;
+        this._unit = opts && opts.unit || this._unit;
+        this._visitor = new less.tree.visitor(this);
+    };
+    ResolutionIndependence.prototype = {
+        _baseSize: 12,
+        _riUnit: 'rem',
+        _unit: 'px',
+        _ignoreUnit: 'apx', // "absolute" px
+        run: function (root) {
+            return this._visitor.visit(root);
+        },
+        visitRule: function (node) {
+            var values = node && node.value && node.value.value && node.value.value.length && node.value.value[0],
+                i;
+
+            if (values) {
+                if (Array.isArray(values.value)) {
+                    for (i = 0 ; i < values.value.length; i++) {
+                        this.parseValue(values.value[i]);
+                    }
+                } else {
+                    this.parseValue(values);
+                }
+            }
+            return node;
+        },
+        parseValue: function (valueNode) {
+            if (valueNode.value && valueNode.value.toString().indexOf(this._ignoreUnit) != -1) {
+                valueNode.value = parseInt(valueNode.value, 10) + this._unit;
+            } else if (valueNode.value && valueNode.value.toString().indexOf(this._unit) != -1) {
+                valueNode.value = parseInt(valueNode.value, 10) / this._baseSize + this._riUnit;
+            } else if (valueNode.unit && valueNode.unit.numerator && valueNode.unit.numerator.length &&
+                valueNode.unit.numerator[0] == this._unit) {
+                valueNode.value = valueNode.value / this._baseSize;
+                valueNode.unit.numerator[0] = this._riUnit;
+            }
+        }
+    };
+
+    if (typeof window != 'undefined') {
+
+            var less = window.less || {};
+
+            window.enyoLessRiPlugin = new ResolutionIndependence();
+            less.plugins = [window.enyoLessRiPlugin];
+            window.less = less;
+
+            //this is here right now in lieu of a better way of loading less, after the plugin.
+            var script = document.createElement('script');
+            script.src = "enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js";
+            script.charset = "utf-8";
+            document.getElementsByTagName('head')[0].appendChild(script);
+
+    } else {
+        module.exports = ResolutionIndependence;
+    }
+
+}());

--- a/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
+++ b/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
@@ -20,6 +20,9 @@
         _unit: 'px',
         _ignoreUnit: 'apx', // "absolute" px
         run: function (root) {
+
+			console.log('hey');
+
 			this._visitor = this._visitor || new less.tree.visitor(this);
             return this._visitor.visit(root);
         },
@@ -52,10 +55,7 @@
     };
 
     if (typeof window != 'undefined') {
-            var less = window.less || {};
-            window.enyoLessRiPlugin = ResolutionIndependence;
-            less.plugins = [window.enyoLessRiPlugin];
-            window.less = less;
+		window.enyoLessRiPlugin = ResolutionIndependence;
     } else {
         module.exports = ResolutionIndependence;
     }

--- a/tools/minifier/node_modules/less-plugin-resolution-independence/lib/usage.js
+++ b/tools/minifier/node_modules/less-plugin-resolution-independence/lib/usage.js
@@ -1,0 +1,10 @@
+module.exports = {
+    printUsage: function() {
+        console.log("");
+        console.log("NPM Resolution Independence Conversion");
+        console.log("specify plugin with --resolution-independence");
+        console.log("No options. import with npm://packagename/path..");
+        console.log("css/less extensions not necessary");
+        console.log("");
+    }
+};

--- a/tools/minifier/node_modules/less-plugin-resolution-independence/package.json
+++ b/tools/minifier/node_modules/less-plugin-resolution-independence/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "less-plugin-resolution-independence",
+  "version": "1.0.0",
+  "description": "resolution independence conversion plugin for less.js",
+  "homepage": "http://www.enyojs.com",
+  "contributors": [
+    {
+      "name": "Blake Stephens"
+    },
+    {
+      "name": "Aaron Tam"
+    },
+    {
+      "name": "Derek Anderson"
+    }
+  ],
+  "main": "lib/resolution-independence.js",
+  "engines": {
+    "node": ">=0.4.2"
+  },
+  "devDependencies": {
+    "less": "^1.7"
+  },
+  "keywords": [
+    "less plugins",
+    "resolution independence"
+  ],
+  "directories": {}
+}

--- a/tools/minifier/node_modules/walker.js
+++ b/tools/minifier/node_modules/walker.js
@@ -39,7 +39,7 @@ module.exports = {
 				var mapIdx = inMapFrom.indexOf(dir);
 				if (mapIdx >= 0) {
 					var to = inMapTo[mapIdx];
-					var chunk = inIsPackage ? to : path.join(to, base);
+					var chunk = path.join(to, base);
 					chunks.push(chunk);
 					if (inIsPackage) {
 						loader.more.apply(loader);


### PR DESCRIPTION
### Issue
It's time to bring the band back together and merge `2.5-gordon` into `2.5-upkeep`.

### Fix
We rebase `2.5-gordon` on `2.5-upkeep` to prevent merging in any duplicate commits (some had been previously cherry-picked already).

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>