### PR TITLE
Fix: Android browser detection for some phones

### DIFF
--- a/source/dom/platform.js
+++ b/source/dom/platform.js
@@ -45,6 +45,8 @@ enyo.platform = {
 		{platform: "androidChrome", regex: /Android .* Chrome\/(\d+)[.\d]+/},
 		// Android 2 - 4
 		{platform: "android", regex: /Android (\d+)/},
+		// Some android phones, e.g. ZTE and Lenovo
+		{platform: "android", regex: /Android\/(\d+)/},
 		// Kindle Fire
 		// Force version to 2, (desktop mode does not list android version)
 		{platform: "android", regex: /Silk\/1./, forceVersion: 2, extra: {silk: 1}},


### PR DESCRIPTION
ZTE and Lenovo phones have browser userAgent like `Android/4.x.x`

Signed-off-by: Linan Wang<wang.linan at gmail dot com>