### PR TITLE
ENYO-909: Only process CSS as LESS for resolution independent builds.

### DIFF
--- a/tools/minifier/minify.js
+++ b/tools/minifier/minify.js
@@ -102,11 +102,11 @@
 					w(" (Substituting CSS: " + sheet + ")");
 				}
 				var code = fs.readFileSync(sheet, "utf8");
-				if (isLess || isCss) {
+				if (isLess || (opt.ri && isCss)) {
 					var parser = new(less.Parser)({filename:sheet, paths:[path.dirname(sheet)], relativeUrls:true});
 					parser.parse(code, function (err, tree) {
 						if (err) {
-							console.error(err);
+							throw new Error("LESS parsing: " + err);
 						} else {
 							var generatedCss;
 							if (opt.ri) {


### PR DESCRIPTION
### Issue
We had made a change via https://github.com/enyojs/enyo/commit/b4d0f6 to process CSS files as LESS to support resolution-independence, but had failed to make this conditional on the resolution-independence option being set. As a result, standard builds would also try to process CSS files as LESS. This was problematic when there were errors in the CSS files (as a side-note, this effectively identified errors in the CSS files), and would cause the contents of that CSS file to not be included at all, while failing silently.

### Fix
We modify the conditional so that we only process CSS files if the resolution independence option has been set. Additionally, we throw an error if there is an issue processing our LESS files.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>