### PR TITLE
ENYO-910: Throw errors when using the LESS parser during deploy.

### DIFF
--- a/tools/deploy.js
+++ b/tools/deploy.js
@@ -106,6 +106,7 @@ var node = process.argv[0],
 	deploy = process.argv[1],
 	less = true, // LESS compilation, turned on by default
 	ri = false, // LESS resolution-independence conversion, turned off by default
+	ignore = false, // Run LESS in ignore mode, where parsing errors are ignored and not thrown
 	verbose = false,
 	beautify = false,
 	noexec = false,
@@ -121,6 +122,7 @@ function printUsage() {
 		'  -b  build directory sub-folder                [default: "./build"]\n' +
 		'  -c  do not run the LESS compiler              [boolean]  [default: ' + less + ']\n' +
 		'  -r  perform LESS resolution-independence      [boolean]  [default: ' + ri + ']\n' +
+		'  -i  ignore LESS parsing errors                [boolean]  [default: ' + ignore + ']\n' +
 		'  -e  enyo framework sub-folder                 [default: "./enyo"]\n' +
 		'  -l  libs sub-folder                           [default: "./lib"]\n' +
 		'  -o  alternate output directory                [default: "PWD/deploy/APPNAME"]\n' +
@@ -139,6 +141,7 @@ var opt = nopt(/*knownOpts*/ {
 	"build": String,	// relative path
 	"less": Boolean,
 	"ri": Boolean,
+	"ignore": Boolean,
 	"enyo": String,		// relative path
 	"lib": String,		// relative path
 	"out": path,		// absolute path
@@ -156,6 +159,7 @@ var opt = nopt(/*knownOpts*/ {
 	"b": "--build",
 	"c": "--no-less",
 	"r": "--ri",
+	"i": "--ignore",
 	"e": "--enyo",
 	"l": "--lib",
 	"o": "--out",
@@ -224,6 +228,7 @@ log("opt:", opt);
 
 less = (opt.less !== false) && less;
 ri = opt.ri;
+ignore = opt.ignore;
 gather = (opt.gather !== false) && gather;
 beautify = opt.beautify;
 noexec = opt.noexec;
@@ -248,6 +253,7 @@ log("Using: ri=" + ri);
 log("Using: beautify=" + beautify);
 log("Using: noexec=" + noexec);
 log("Using: gather=" + gather);
+log("Using: ignore=" + ignore);
 
 // utils
 
@@ -282,6 +288,7 @@ if (!opt.mapfrom || opt.mapfrom.indexOf("enyo") < 0) {
 		'-destdir', opt.out,
 		'-output', path.join(opt.build, 'enyo'),
 		(ri ? '-ri' : '-no-ri'),
+		(ignore ? '-ignore' : '-no-ignore'),
 		(beautify ? '-beautify' : '-no-beautify'),
 		path.join(opt.enyo, 'minify', 'package.js')];
 	if (opt.mapfrom) {
@@ -302,6 +309,7 @@ args = [node, minifier,
 	'-output', path.join(opt.build, 'app'),
 	(less ? '-less' : '-no-less'),
 	(ri ? '-ri' : '-no-ri'),
+	(ignore ? '-ignore' : '-no-ignore'),
 	(beautify ? '-beautify' : '-no-beautify'),
 	opt.packagejs];
 if (opt.mapfrom) {

--- a/tools/minifier/minify.js
+++ b/tools/minifier/minify.js
@@ -37,6 +37,7 @@
 		w("-f", "Remote source mapping: from local path");
 		w("-t", "Remote source mapping: to remote path");
 		w("-gathering:", "Gathering libs to default location, so rewrite urls accordingly");
+		w("-ignore:", "Ignores LESS parsing errors and does not halt the minification; otherwise any errors are thrown");
 		w("-h, -?, -help:", "Show this message");
 	}
 
@@ -106,7 +107,11 @@
 					var parser = new(less.Parser)({filename:sheet, paths:[path.dirname(sheet)], relativeUrls:true});
 					parser.parse(code, function (err, tree) {
 						if (err) {
-							throw new Error("LESS parsing: " + err);
+							if (opt.ignore) {
+								console.error(err);
+							} else {
+								throw new Error("LESS parsing: " + err);
+							}
 						} else {
 							var generatedCss;
 							if (opt.ri) {
@@ -238,7 +243,8 @@
 		"mapfrom": [String, Array],
 		"mapto": [String, Array],
 		"gathering": Boolean,
-		"ri": Boolean
+		"ri": Boolean,
+		"ignore": Boolean
 	};
 
 	var shortHands = {
@@ -254,7 +260,8 @@
 		"beautify": ['--beautify'],
 		"f": ['--mapfrom'],
 		"t": ['--mapto'],
-		"ri": ['--ri']
+		"ri": ['--ri'],
+		"ignore": ['--ignore']
 	};
 
 	opt = nopt(knownOpts, shortHands, process.argv, 2);

--- a/tools/minifier/minify.js
+++ b/tools/minifier/minify.js
@@ -106,7 +106,7 @@
 					var parser = new(less.Parser)({filename:sheet, paths:[path.dirname(sheet)], relativeUrls:true});
 					parser.parse(code, function (err, tree) {
 						if (err) {
-							console.error(err);
+							throw new Error("LESS parsing: " + err);
 						} else {
 							var generatedCss;
 							if (opt.ri) {


### PR DESCRIPTION
### Issue
We want any errors upon parsing CSS files to be fatal and thrown, to identify any CSS issues regardless of target system.

### Fix
Instead of logging the errors, we now throw them.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>