### PR TITLE
ENYO-923: Stop marquee when window throw blur event

### DIFF
--- a/source/dom/dispatcher.js
+++ b/source/dom/dispatcher.js
@@ -42,7 +42,7 @@
 		*
 		* @private
 		*/
-		windowEvents: ["resize", "load", "unload", "message", "hashchange", "popstate", "focus", "blur"],
+		windowEvents: ["resize", "load", "unload", "message", "hashchange", "popstate"],
 
 		/**
 		* Feature plugins (aka filters)
@@ -54,8 +54,20 @@
 		/**
 		* @private
 		*/
+		platformSpecific: function() {
+			var d = enyo.dispatcher,
+				webosWindowEvents = ["focus", "blur"];
+			if (enyo.platform.webos >= 4) {
+				d.windowEvents.concat(webosWindowEvents);
+			}
+		},
+
+		/**
+		* @private
+		*/
 		connect: function() {
 			var d = enyo.dispatcher, i, n;
+			d.platformSpecific();
 			for (i=0; (n=d.events[i]); i++) {
 				d.listen(document, n);
 			}

--- a/source/dom/dispatcher.js
+++ b/source/dom/dispatcher.js
@@ -42,7 +42,7 @@
 		*
 		* @private
 		*/
-		windowEvents: ["resize", "load", "unload", "message", "hashchange", "popstate"],
+		windowEvents: ["resize", "load", "unload", "message", "hashchange", "popstate", "blur"],
 
 		/**
 		* Feature plugins (aka filters)

--- a/source/dom/dispatcher.js
+++ b/source/dom/dispatcher.js
@@ -42,7 +42,7 @@
 		*
 		* @private
 		*/
-		windowEvents: ["resize", "load", "unload", "message", "hashchange", "popstate", "blur"],
+		windowEvents: ["resize", "load", "unload", "message", "hashchange", "popstate", "focus", "blur"],
 
 		/**
 		* Feature plugins (aka filters)

--- a/source/dom/dispatcher.js
+++ b/source/dom/dispatcher.js
@@ -42,7 +42,7 @@
 		*
 		* @private
 		*/
-		windowEvents: ["resize", "load", "unload", "message", "hashchange", "popstate"],
+		windowEvents: ["resize", "load", "unload", "message", "hashchange", "popstate", "focus", "blur"],
 
 		/**
 		* Feature plugins (aka filters)
@@ -54,21 +54,8 @@
 		/**
 		* @private
 		*/
-		platformSpecific: function() {
-			var d = enyo.dispatcher,
-				webosWindowEvents = ["focus", "blur"];
-			if (enyo.platform.webos >= 4) {
-				// webos send focus/blue event for window but doesn't send for input field
-				d.windowEvents = d.windowEvents.concat(webosWindowEvents);
-			}
-		},
-
-		/**
-		* @private
-		*/
 		connect: function() {
 			var d = enyo.dispatcher, i, n;
-			d.platformSpecific();
 			for (i=0; (n=d.events[i]); i++) {
 				d.listen(document, n);
 			}

--- a/source/dom/dispatcher.js
+++ b/source/dom/dispatcher.js
@@ -58,7 +58,8 @@
 			var d = enyo.dispatcher,
 				webosWindowEvents = ["focus", "blur"];
 			if (enyo.platform.webos >= 4) {
-				d.windowEvents.concat(webosWindowEvents);
+				// webos send focus/blue event for window but doesn't send for input field
+				d.windowEvents = d.windowEvents.concat(webosWindowEvents);
 			}
 		},
 


### PR DESCRIPTION
### Issue:
On app change state between BG and FG, div which is under cursor is not getting onleave event.
While marquee is flow on hover, it is not stop because it is not getting onleave event when app  goes to BG.

### Fix:
- Add blur on windowEvents array to handle on dispatcher feature. (Core)
- Remember last hovered marqueeSupport control on global variable. (Marquee)
- Call onleave event handler of last hovered marqueeSupport control when app is getting onblur event. (Marquee)

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com