### PR TITLE
ENYO-521: updated keeping key value between changes

### DIFF
--- a/source/data/Model.js
+++ b/source/data/Model.js
@@ -638,6 +638,9 @@
 						// note that we check inside this loop so we don't have to examine keys
 						// later only the local variable changed
 						changed = this.changed || (this.changed = {});
+						//store the previous attr value
+						this.previous[key] = attrs[key];
+						//set new value
 						changed[key] = attrs[key] = value;
 					}
 				}


### PR DESCRIPTION
Issue.

When changing the value of an attribute, the previous value is not maintained except during construction and committing. Expectation is that the previous value should be retained anytime the attribute is updated.

Fix.

Ensure that we copy the previous attributes value, into the previous object's keys.

Enyo-DCO-1.1-Signed-off-by: Derek Anderson derek.anderson@lge.com