### PR TITLE
Update enyo.Select so it is bindable, and syncs

### DIFF
--- a/source/ui/Select.js
+++ b/source/ui/Select.js
@@ -135,6 +135,9 @@
 			if (this.hasNode()) {
 				return Number(this.node.selectedIndex);
 			}
+			else {
+				return this.selected;
+			}
 		},
 
 		/**
@@ -149,12 +152,9 @@
 		* @private
 		*/
 		valueChanged: function() {
-			if (this.hasNode() && !this.updating) {
-				//Needs delay otherwise it won't update value (at least on chrome 42 canary)
-				this.startJob('updateValue', function() {
-					this.node.value = this.value;
-					this.set('selected', this.getSelected());
-				}, 100);
+			if (this.hasNode() && !this.updating && this.value) {
+				this.node.value = this.value;
+				this.set('selected', this.getSelected());
 			}
 		},
 		/**

--- a/source/ui/Select.js
+++ b/source/ui/Select.js
@@ -80,7 +80,16 @@
 			* @default false
 			* @public
 			*/
-			multiple: false
+			multiple: false,
+
+			/**
+			* Sets whether the enyo.Select is disabled, or not
+			* 
+			* @type {Boolean}
+			* @default false
+			* @public
+			*/
+			disabled: false
 		},
 		
 		/**
@@ -112,9 +121,10 @@
 					this.setAttribute('onchange', enyo.bubbler);
 				}
 				this.selectedChanged();
-				this.updateValue();
+				this.valueChanged();
 				this.sizeChanged();
 				this.multipleChanged();
+				this.disabledChanged();
 			};
 		}),
 
@@ -161,6 +171,14 @@
 		multipleChanged: function() {
 			if (this.hasNode()) {
 				this.node.multiple = this.multiple;
+			}
+		},
+		/**
+		* @private
+		*/
+		disabledChanged: function() {
+			if (this.hasNode()) {
+				this.node.disabled = this.disabled;
 			}
 		},
 		/**

--- a/source/ui/Select.js
+++ b/source/ui/Select.js
@@ -146,6 +146,7 @@
 		selectedChanged: function () {
 			if (this.hasNode() && !this.updating) {
 				this.node.selectedIndex = this.selected;
+				this.updateValue();
 			}
 		},
 		/**


### PR DESCRIPTION
Been using a lot of enyo.Select's in an app, i noticed the selected
property and value can get out of sync. Also, you could not bind to
selected. With these changes you can now bind to both selected and
value, and they stay in sync.

Also add properties for size and multiple

Enyo-DCO-1.1-Signed-off-by: Chris Van Hooser <chrisvanhooser@gmail.com>