### PR TITLE
ENYO-952: Add resolution-independent version of less.js

### DIFF
--- a/tools/less-ri.js
+++ b/tools/less-ri.js
@@ -1,0 +1,26 @@
+// Client-side less.js configurator / loader
+(function() {
+	var less = window.less || {};
+	if (less.relativeUrls === undefined) {
+		less.relativeUrls = true;
+	}
+	if (less.environment === undefined) {
+		less.environment = "production";
+	}
+	window.less = less;
+	var script = document.createElement('script');
+	script.src = "enyo/tools/minifier/node_modules/less/dist/less-1.7.0.ri.min.js";
+	script.charset = "utf-8";
+	document.getElementsByTagName('head')[0].appendChild(script);
+
+	script = document.createElement('script');
+	script.src = "enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js";
+	script.charset = "utf-8";
+	script.onload = function () {
+		var less = window.less || {};
+		var ri = new enyoLessRiPlugin();
+		less.plugins = [ri];
+		window.less = less;
+	}
+	document.getElementsByTagName('head')[0].appendChild(script);
+})();

--- a/tools/less.js
+++ b/tools/less.js
@@ -9,18 +9,7 @@
 	}
 	window.less = less;
 	var script = document.createElement('script');
-	script.src = "enyo/tools/minifier/node_modules/less/dist/less-1.7.0.ri.min.js";
+	script.src = "enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js";
 	script.charset = "utf-8";
-	document.getElementsByTagName('head')[0].appendChild(script);
-
-	script = document.createElement('script');
-	script.src = "enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js";
-	script.charset = "utf-8";
-	script.onload = function () {
-		var less = window.less || {};
-		var ri = new enyoLessRiPlugin();
-		less.plugins = [ri];
-		window.less = less;
-	}
 	document.getElementsByTagName('head')[0].appendChild(script);
 })();


### PR DESCRIPTION
### Issue
When developing in the browser using resolution-independent versions of the framework, there is no way to disable this feature and test standard measurement versions (i.e. only pixels).

### Fix
We add a new script `less-ri.js`, which is a resolution-independent version of `less.js`, that can be referenced by developers wanting to utilize resolution-independent features when developing locally. We are able to remove some of the resolution-independent-specific tweaks we made in `less.js` as those can now be encapsulated in `less-ri.js`.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>