### PR TITLE
Enyo 966 ChildSize changing does not affect on controlsPerPage.

### DIFF
--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -48,6 +48,8 @@
 		* After size of viewport is decided, get pageSize using pageSizeMutiplier.
 		* We should update this.pageSize when we update viewport or pageSizeMutiplier.
 		*
+		* @param {enyo.DataList} list - The [list]{@link enyo.DataList} to perform this action on.
+		* @return {Number} this.pageSize - height or width of each page.
 		* @private
 		*/
 		calculatePageSize: function(list) {
@@ -55,6 +57,7 @@
 				multi = list.pageSizeMultiplier || this.pageSizeMultiplier;
 			// using height/width of the available viewport times our multiplier value
 			this.pageSize = fn.call(this, list) * multi;
+			return this.pageSize;
 		},
 		/**
 		* @private

--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -169,7 +169,7 @@
 				// the metrics for the entire list
 				metrics = list.metrics,
 				// controls per page
-				perPage = this.controlsPerPage(list),
+				perPage = this.controlsPerPage(list, list.isChildSizeUpdated, page.index),
 				// placeholder for the control we're going to update
 				view,
 				// basically we assume that every page has same childSize, but just in case
@@ -264,10 +264,7 @@
 				}
 				if (index) {
 					list.metrics.pages[index].childSize = childSize;
-				} else {
-					list.childSize = childSize;
 				}
-
 			}
 			return list.fixedChildSize || childSize || 100; // we have to start somewhere
 		},
@@ -277,11 +274,14 @@
 		* out of [controlsPerPage]{@link DataList.delegates.vertical#controlsPerPage} so that it
 		* can be overridden by delegates that inherit from this one.
 		*
+		* @param {enyo.DataList} list - The [list]{@link enyo.DataList} to perform this action on.
+		* @param {Number} index - The index of given page. If it is, we can assume that only this page
+		*						has individual childSize and controlsPerPage.
 		* @private
 		*/
-		calculateControlsPerPage: function (list) {
+		calculateControlsPerPage: function (list, pageIndex) {
 			var pageSize        = this.pageSize,
-				childSize       = this.childSize(list);
+				childSize       = this.childSize(list, pageIndex);
 
 			return Math.ceil((pageSize / childSize) + 1);
 		},
@@ -308,9 +308,15 @@
 				// if we've never updated the value or it was done longer ago than the most
 				// recent updated sizing/bounds we need to update
 				if (forceUpdate || !updatedControls || (updatedControls < updatedBounds)) {
-					perPage = list.controlsPerPage = this.calculateControlsPerPage(list);
-					// update our time for future comparison
-					list._updatedControlsPerPage = enyo.perfNow();
+					perPage = this.calculateControlsPerPage(list, pageIndex);
+
+					if (list.controlsPerPage && typeof pageIndex !== 'undefined') {
+						list.metrics.pages[pageIndex].controlsPerPage = perPage;
+					} else {
+						list.controlsPerPage = perPage;
+						// update our time for future comparison
+						list._updatedControlsPerPage = enyo.perfNow();
+					}
 				}
 				return perPage;
 			}

--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -254,7 +254,8 @@
 			if (!list.fixedChildSize) {
 				var pageIndex = (typeof index !== 'undefined') ? index : list.$.page1.index,
 					sizeProp  = list.psizeProp,
-					n         = list.$.page1.node || list.$.page1.hasNode(),
+					page      = (pageIndex == list.$.page1.index) ? list.$.page1 : list.$.page2,
+					n         = page.node || page.hasNode(),
 					size, props;
 				if (pageIndex >= 0 && n) {
 					props = list.metrics.pages[pageIndex];

--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -45,9 +45,22 @@
 		},
 
 		/**
+		* After size of viewport is decided, get pageSize using pageSizeMutiplier.
+		* We should update this.pageSize when we update viewport or pageSizeMutiplier.
+		*
+		* @private
+		*/
+		calculatePageSize: function(list) {
+			var fn = this[list.psizeProp],
+				multi = list.pageSizeMultiplier || this.pageSizeMultiplier;
+			// using height/width of the available viewport times our multiplier value
+			this.pageSize = fn.call(this, list) * multi;
+		},
+		/**
 		* @private
 		*/
 		generate: function (list) {
+			this.pageSize = this.pageSize | this.calculatePageSize(list);
 			for (var i=0, p; (p=list.pages[i]); ++i) {
 				this.generatePage(list, p, p.index);
 			}
@@ -236,12 +249,10 @@
 		* @private
 		*/
 		calculateControlsPerPage: function (list) {
-			var fn              = this[list.psizeProp],
-				multi           = list.pageSizeMultiplier || this.pageSizeMultiplier,
+			var pageSize        = this.pageSize | this.calculatePageSize(list),
 				childSize       = this.childSize(list);
 
-			// using height/width of the available viewport times our multiplier value
-			return Math.ceil(((fn.call(this, list) * multi) / childSize) + 1);
+			return Math.ceil((pageSize / childSize) + 1);
 		},
 
 		/**

--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -169,7 +169,7 @@
 				// the metrics for the entire list
 				metrics = list.metrics,
 				// controls per page
-				perPage = this.controlsPerPage(list),
+				perPage = this.controlsPerPage(list, list.updatedChildSize),
 				// placeholder for the control we're going to update
 				view;
 
@@ -207,7 +207,8 @@
 			metrics.height = this.pageHeight(list, page);
 			metrics.width  = this.pageWidth(list, page);
 			// update the childSize value now that we have measurements
-			this.childSize(list);
+			var oldChildSize = list.childSize;
+			list.updatedChildSize = (oldChildSize == this.childSize(list)) ? false : true;
 		},
 
 		/**

--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -253,7 +253,7 @@
 		* @private
 		*/
 		calculateControlsPerPage: function (list) {
-			var pageSize        = this.pageSize || this.calculatePageSize(list),
+			var pageSize        = this.pageSize,
 				childSize       = this.childSize(list);
 
 			return Math.ceil((pageSize / childSize) + 1);
@@ -758,8 +758,9 @@
 
 			list._updateBounds = true;
 			this.updateBounds(list);
-			// Need to update our controlsPerPage value immediately,
+			// Need to update our controlsPerPage and pageSize value immediately,
 			// before any cached metrics are used
+			this.calculatePageSize(list);
 			this.controlsPerPage(list);
 			if (prevCPP !== list.controlsPerPage) {
 				// since we are now using a different number of controls per page,

--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -169,7 +169,7 @@
 				// the metrics for the entire list
 				metrics = list.metrics,
 				// controls per page
-				perPage = this.controlsPerPage(list, list.updatedChildSize),
+				perPage = this.controlsPerPage(list, list.isChildSizeUpdated),
 				// placeholder for the control we're going to update
 				view;
 
@@ -208,7 +208,7 @@
 			metrics.width  = this.pageWidth(list, page);
 			// update the childSize value now that we have measurements
 			var oldChildSize = list.childSize;
-			list.updatedChildSize = (oldChildSize == this.childSize(list)) ? false : true;
+			list.isChildSizeUpdated = (oldChildSize == this.childSize(list)) ? false : true;
 		},
 
 		/**

--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -227,6 +227,7 @@
 
 		/**
 		* Generates a child size for the given [list]{@link enyo.DataList}.
+		* if fixedChildSize is not assigned, we assume that each page could have different childSize
 		*
 		* @private
 		*/
@@ -269,8 +270,10 @@
 		*
 		* @private
 		*/
-		controlsPerPage: function (list, forceUpdate) {
-			if (list._staticControlsPerPage) {
+		controlsPerPage: function (list, forceUpdate, pageIndex) {
+			// if controlsPerPage is given from dataList instantiation, we will use it
+			// unless fixedChildSize is not assigned.
+			if (!list.fixedChildSize && list._staticControlsPerPage) {
 				return list.controlsPerPage;
 			} else {
 				var updatedControls = list._updatedControlsPerPage,

--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -63,7 +63,7 @@
 		* @private
 		*/
 		generate: function (list) {
-			this.pageSize = this.pageSize | this.calculatePageSize(list);
+			this.pageSize = this.pageSize || this.calculatePageSize(list);
 			for (var i=0, p; (p=list.pages[i]); ++i) {
 				this.generatePage(list, p, p.index);
 			}
@@ -253,7 +253,7 @@
 		* @private
 		*/
 		calculateControlsPerPage: function (list) {
-			var pageSize        = this.pageSize | this.calculatePageSize(list),
+			var pageSize        = this.pageSize || this.calculatePageSize(list),
 				childSize       = this.childSize(list);
 
 			return Math.ceil((pageSize / childSize) + 1);


### PR DESCRIPTION
Issue
-------
In Notification app, dynamical changing of a control's height and refresh() call make blank.

Cause
--------
Updated childSize does not affect on controlsPerPage. When childSize is increased, controlsPerPage should be reduced because page size was not changed.
However, we still have same controlsPerPage and it reduce number of pages.
So, target page index could be reduced and it affect on wrong page adjustment.

Fix
----
Use static page size and update controlsPerPage when childSize is changed.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com