### PR TITLE
ENYO-1025 (2.5.3-pre.13.t)

### DIFF
--- a/source/data/Collection.js
+++ b/source/data/Collection.js
@@ -422,6 +422,7 @@
 				, options = this.options
 				, pkey = ctor.prototype.primaryKey
 				, idx = len
+				, removedBeforeIdx = 0
 				, added, keep, removed, model, attrs, found, id;
 				
 			// for backwards compatibility with earlier api standards we allow the
@@ -537,9 +538,15 @@
 			if (purge && (keep && keep.length)) {
 				removed || (removed = []);
 				keep || (keep = {});
-				for (i=0; i<len; ++i) !keep[(model = loc[i]).euid] && removed.push(model);
+				for (i=0; i<len; ++i) {
+					if (!keep[(model = loc[i]).euid]) {
+						removed.push(model);
+						if (i < idx) removedBeforeIdx++;
+					}
+				} 
 				// if we removed any we process that now
 				removed.length && this.remove(removed, opts);
+				idx = idx - removedBeforeIdx;
 			}
 			
 			// added && loc.stopNotifications().add(added, idx).startNotifications();


### PR DESCRIPTION
Cherry-picking the changes from https://github.com/enyojs/enyo/pull/1038 into `release-2.5.3-pre.13.t`, creating a PR for tracking purposes.