### PR TITLE
ENYO-1098: Adding simulated flag on generated tap event

### DIFF
--- a/source/dom/dispatcher.js
+++ b/source/dom/dispatcher.js
@@ -288,7 +288,6 @@
 					// but note the tap event will fire first
 					var cp = enyo.clone(e);
 					cp.type = "tap";
-					cp.simulated = true;
 					cp.preventDefault = enyo.nop;
 					enyo.dispatch(cp);
 				}

--- a/source/dom/dispatcher.js
+++ b/source/dom/dispatcher.js
@@ -283,7 +283,7 @@
 	enyo.dispatcher.features.push(
 		function (e) {
 			if ("click" === e.type) {
-				if (e.clientX === 0 && e.clientY === 0) {
+				if (e.clientX === 0 && e.clientY === 0 && e.detail === 0) {
 					// this allows the click to dispatch as well
 					// but note the tap event will fire first
 					var cp = enyo.clone(e);
@@ -347,5 +347,5 @@
 		}
 		return p;
 	};
-	
+
 })(enyo, this);

--- a/source/dom/dispatcher.js
+++ b/source/dom/dispatcher.js
@@ -283,7 +283,7 @@
 	enyo.dispatcher.features.push(
 		function (e) {
 			if ("click" === e.type) {
-				if (e.clientX === 0 && e.clientY === 0 && e.detail === 0) {
+				if (e.clientX === 0 && e.clientY === 0 && !e.detail) {
 					// this allows the click to dispatch as well
 					// but note the tap event will fire first
 					var cp = enyo.clone(e);

--- a/source/dom/dispatcher.js
+++ b/source/dom/dispatcher.js
@@ -288,6 +288,7 @@
 					// but note the tap event will fire first
 					var cp = enyo.clone(e);
 					cp.type = "tap";
+					cp.simulated = true;
 					cp.preventDefault = enyo.nop;
 					enyo.dispatch(cp);
 				}


### PR DESCRIPTION
### Issue:
When (0, 0) is tapped on drawers, drawers do not open/close.
We have a code to filter out simulated click event in Spotlight onClick handler.
And, it is checking clientX/clientY == 0 to know is that a simulated event.
That is eventually filter out normal click event also.

### Fix:
Add a flag to indicate the event is generated from click event.
This can be used in Spotlight to exactly distinguish simulated event.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com