### PR TITLE
Fixes ENYO-988 and ENYO-1032

### DIFF
--- a/samples/SelectSample.js
+++ b/samples/SelectSample.js
@@ -1,6 +1,18 @@
 enyo.kind({
 	name: "enyo.sample.SelectSample",
 	classes: "select-sample",
+	bindings: [
+		{from: '$.selectTransitionTiming.selected', to: 'timingIndex'},
+		{from: '$.selectTransitionTiming.value', to: 'timingValue'},
+		{from: '$.selectTransitionDuration.selected', to: 'durationIndex'},
+		{from: '$.selectTransitionDuration.value', to: 'durationValue'},
+		{from: '$.selectColor.selected', to: 'colorIndex'},
+		{from: '$.selectColor.value', to: 'colorValue'},
+	],
+	observers: {
+		'logSelectChanged': ['timingIndex', 'timingValue', 'durationIndex', 'durationValue',
+							'colorIndex', 'colorValue']
+	},
 	components: [
 		{content: "Transition Timing Function", classes: "section"},
 		{kind: "enyo.Select", name: "selectTransitionTiming", onchange: "selectChanged", components: [
@@ -67,5 +79,8 @@ enyo.kind({
 	},
 	selectChanged: function(inSender, inEvent) {
 		this.$.results.setContent("The \"" + inSender.getName() + "\" value is \"" + inSender.getValue() + "\".");
+	},
+	logSelectChanged: function (was, is, prop) {
+		this.log(prop, 'was', was, 'and is now', is);
 	}
 });

--- a/source/ui/Select.js
+++ b/source/ui/Select.js
@@ -135,6 +135,9 @@
 			if (this.hasNode()) {
 				return Number(this.node.selectedIndex);
 			}
+			else {
+				return this.selected;
+			}
 		},
 
 		/**
@@ -149,12 +152,9 @@
 		* @private
 		*/
 		valueChanged: function() {
-			if (this.hasNode() && !this.updating) {
-				//Needs delay otherwise it won't update value (at least on chrome 42 canary)
-				this.startJob('updateValue', function() {
-					this.node.value = this.value;
-					this.set('selected', this.getSelected());
-				}, 100);
+			if (this.hasNode() && !this.updating && this.value) {
+				this.node.value = this.value;
+				this.set('selected', this.getSelected());
 			}
 		},
 		/**

--- a/source/ui/Select.js
+++ b/source/ui/Select.js
@@ -68,10 +68,10 @@
 			* The size of the select box in rows.
 			* 
 			* @type {Number}
-			* @default 1
+			* @default 0
 			* @public
 			*/
-			size: 1,
+			size: 0,
 
 			/**
 			* Sets whether the enyo.Select can select multiple options

--- a/source/ui/Select.js
+++ b/source/ui/Select.js
@@ -132,77 +132,46 @@
 		* @private
 		*/
 		getSelected: function () {
-			if (this.hasNode()) {
-				return Number(this.node.selectedIndex);
-			}
-			else {
-				return this.selected;
-			}
+			return Number(this.getNodeProperty('selectedIndex', this.selected));
 		},
 
 		/**
 		* @private
 		*/
 		selectedChanged: function () {
-			if (this.hasNode() && !this.updating) {
-				this.node.selectedIndex = this.selected;
-				this.updateValue();
-			}
+			this.setNodeProperty('selectedIndex', this.selected);
+			this.set('value', this.getNodeProperty('value', this.value));
 		},
 		/**
 		* @private
 		*/
 		valueChanged: function() {
-			if (this.hasNode() && !this.updating && this.value) {
-				this.node.value = this.value;
-				this.set('selected', this.getSelected());
-			}
+			this.setNodeProperty('value', this.value);
+			this.set('selected', this.getSelected());
 		},
 		/**
 		* @private
 		*/
 		sizeChanged: function() {
-			if (this.hasNode()) {
-				this.node.size = this.size;
-			}
+			this.setNodeProperty('size', this.size);
 		},
 		/**
 		* @private
 		*/
 		multipleChanged: function() {
-			if (this.hasNode()) {
-				this.node.multiple = this.multiple;
-			}
+			this.setNodeProperty('multiple', this.multiple);
 		},
 		/**
 		* @private
 		*/
 		disabledChanged: function() {
-			if (this.hasNode()) {
-				this.node.disabled = this.disabled;
-			}
-		},
-		/**
-		* @private
-		*/
-		updateValue: function() {
-			if (this.hasNode()) {
-				this.set('value', this.node.value);
-			}
+			this.setNodeProperty('disabled', this.disabled);
 		},
 		/**
 		* @private
 		*/
 		change: function () {
-			//Need to know internally if we are changing values,
-			//to prevent value and selected observers from firing
-			//until maximum_call_stack error is received
-			//But we still want this control's owner to be able to bind
-			//to changes of either or both of the selected and value properties
-			this.updating = true;
 			this.set('selected', this.getSelected());
-			this.updateValue();
-			this.updating = false;
 		},
 
 		/**

--- a/source/ui/Select.js
+++ b/source/ui/Select.js
@@ -80,7 +80,16 @@
 			* @default false
 			* @public
 			*/
-			multiple: false
+			multiple: false,
+
+			/**
+			* Sets whether the enyo.Select is disabled, or not
+			* 
+			* @type {Boolean}
+			* @default false
+			* @public
+			*/
+			disabled: false
 		},
 		
 		/**
@@ -112,9 +121,10 @@
 					this.setAttribute('onchange', enyo.bubbler);
 				}
 				this.selectedChanged();
-				this.updateValue();
+				this.valueChanged();
 				this.sizeChanged();
 				this.multipleChanged();
+				this.disabledChanged();
 			};
 		}),
 
@@ -161,6 +171,14 @@
 		multipleChanged: function() {
 			if (this.hasNode()) {
 				this.node.multiple = this.multiple;
+			}
+		},
+		/**
+		* @private
+		*/
+		disabledChanged: function() {
+			if (this.hasNode()) {
+				this.node.disabled = this.disabled;
 			}
 		},
 		/**

--- a/source/ui/Select.js
+++ b/source/ui/Select.js
@@ -146,6 +146,7 @@
 		selectedChanged: function () {
 			if (this.hasNode() && !this.updating) {
 				this.node.selectedIndex = this.selected;
+				this.updateValue();
 			}
 		},
 		/**


### PR DESCRIPTION
## Issue
enyo.Select.selected isn't a bindable property (as it should be) and setting the value of selected at create time is not respected.

## Fix
Some refactoring was needed to ensure the property changes were being applied in the right order and in the correct way (e.g. by using `set()` instead of modifying the member directly).

## Notes
This PR supercedes #1024. Thanks @appsbychris for much of the work to resolve this!

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)