### PR TITLE
ENYO-510-Auto show a placeholder in image grid as images load

### DIFF
--- a/samples/ImageSample.css
+++ b/samples/ImageSample.css
@@ -10,15 +10,6 @@
 	font-weight: bold;
 	margin-bottom: 8px;
 }
-.image-sample .enyo-input[type=text] {
-	margin: 10px 0;
-	width: 400px;
-	display: block;
-	background: none;
-	border: 1px solid #CCC;
-	color: #555;
-	font-size: 16px;
-}
 .image-sample .placeholder {
 	width: 200px;
 	height: 200px;

--- a/samples/ImageSample.js
+++ b/samples/ImageSample.js
@@ -2,10 +2,14 @@ enyo.kind({
 	name: "enyo.sample.ImageSample",
 	classes: "image-sample",
 	components: [
-		{content: "Image", classes: "section"},
+		{content: "Image - No Sizing", classes: "section"},
 		{kind: "enyo.Image", src: "http://enyojs.com/img/enyo-logo.png", alt: "Enyo Logo"},
-		{content: "Background Image", classes: "section"},
-		{kind: "enyo.Image", style: "width:200px;height:75px;background-color:gray", sizing: "constrain", position: "left top", src: "http://enyojs.com/img/enyo-logo.png", alt: "Enyo Logo"},
+		{content: "Sizing - Contain", classes: "section"},
+		{kind: "enyo.Image", style: "width:200px; height:100px; background-color:rgba(200,100,0,0.3); border: 1px dashed orange; margin-right: 1em;", sizing: "contain", src: "http://enyojs.com/img/enyo-logo.png", alt: "Enyo Logo"},
+		{kind: "enyo.Image", style: "width:200px; height:100px; background-color:rgba(0,200,0,0.3); border: 1px dashed green;", sizing: "contain", position: "left top", src: "http://enyojs.com/img/enyo-logo.png", alt: "Enyo Logo"},
+		{content: "Sizing - Cover", classes: "section"},
+		{kind: "enyo.Image", style: "width:200px; height:100px; background-color:rgba(0,0,200,0.3); border: 1px dashed blue; margin-right: 1em;", sizing: "cover", src: "http://enyojs.com/img/enyo-logo.png", alt: "Enyo Logo"},
+		{kind: "enyo.Image", style: "width:200px; height:100px; background-color:rgba(200,200,0,0.3); border: 1px dashed yellow;", sizing: "cover", position: "left top", src: "http://enyojs.com/img/enyo-logo.png", alt: "Enyo Logo"},
 		{content: "Placeholder Image", classes: "section"},
 		{kind: "enyo.Image", src: enyo.Image.placeholder, alt: "Placeholder Image", classes: "placeholder"}
 	]

--- a/source/ui/Image.js
+++ b/source/ui/Image.js
@@ -231,10 +231,10 @@
 			this.tag = this.sizing ? 'div' : 'img';
 			this.addRemoveClass('sized', !!this.sizing);
 			if (was) {
-				this.removeClass('enyo-'+was);
+				this.removeClass(was);
 			}
 			if (this.sizing) {
-				this.addClass('enyo-'+this.sizing);
+				this.addClass(this.sizing);
 			}
 			if (this.generated) {
 				this.srcChanged();

--- a/source/ui/Image.js
+++ b/source/ui/Image.js
@@ -157,6 +157,10 @@
 			draggable: 'false'
 		},
 
+		handlers: {
+			onload: 'handleLoad'
+		},
+
 		/**
 		* @method
 		* @private
@@ -181,14 +185,17 @@
 		srcChanged: function () {
 			var src = enyo.ri.selectSrc(this.src);
 			if (this.sizing) {
-				var placeholder =  enyo.path.rewrite(this.placeholder);
-				var multiple= "url('"+ enyo.path.rewrite(src) +"'), url('"+ (placeholder ? placeholder : enyo.Image.placeholder) + "');";
-				this.applyStyle('background-image',  multiple);
+				var placeholder = this.placeholder ? ', url(\'' + enyo.path.rewrite(this.placeholder) + '\')' : '';
+				var url = 'url(\'' + enyo.path.rewrite(src) + '\')' + placeholder + ';';
+				this.applyStyle('background-image', url);
 			} else {
 				if (!src) {
 					// allow us to clear the src property
 					this.setAttribute('src', '');
 				} else {
+					if (this.placeholder) {
+						this.applyStyle('background-image', 'url(\'' + enyo.path.rewrite(this.placeholder) + '\')');
+					}
 					this.setAttribute('src', enyo.path.rewrite(src));
 				}
 			}
@@ -225,6 +232,15 @@
 		positionChanged: function () {
 			if (this.sizing) {
 				this.applyStyle('background-position', this.position);
+			}
+		},
+
+		/**
+		* @private
+		*/
+		handleLoad: function () {
+			if (!this.sizing && this.placeholder) {
+				this.applyStyle('background-image', null);
 			}
 		},
 

--- a/source/ui/Image.js
+++ b/source/ui/Image.js
@@ -187,8 +187,8 @@
 			var src = enyo.ri.selectSrc(this.src);
 			if (this.sizing) {
 				var placeholder = this.placeholder ? 'url(\'' + enyo.path.rewrite(this.placeholder) + '\')' : '';
-				var url= (src? 'url(\'' + enyo.path.rewrite(src) + '\'),' : '') + placeholder;
-				this.applyStyle('background-image', url);
+				var url= (src ? ( placeholder ? 'url(\'' + enyo.path.rewrite(src) + '\'),' : 'url(\'' + enyo.path.rewrite(src) + '\')') : '');
+				this.applyStyle('background-image', url+placeholder);
 			} else {
 				if (!src) {
 					// allow us to clear the src property
@@ -199,6 +199,15 @@
 					}
 					this.setAttribute('src', enyo.path.rewrite(src));
 				}
+			}
+		},
+
+		/**
+		* @private
+		*/
+		placeholderChanged: function(){
+			if (this.placeholder) {
+				this.applyStyle('background-image', 'url(\'' + enyo.path.rewrite(this.placeholder) + '\')');
 			}
 		},
 

--- a/source/ui/Image.js
+++ b/source/ui/Image.js
@@ -126,7 +126,14 @@
 			* @default 'center'
 			* @public
 			*/
-			position: 'center'
+			position: 'center',
+
+			/**
+			* @type {String}
+			* @default ''
+			* @public
+			*/
+			placeholder: ''
 		},
 
 		/**
@@ -173,14 +180,15 @@
 		*/
 		srcChanged: function () {
 			var src = enyo.ri.selectSrc(this.src);
+			var multiple= "url('"+ enyo.path.rewrite(src) +"'), url('"+ this.placeholder + "');";
 			if (this.sizing) {
-				this.applyStyle('background-image', src ? 'url(' + enyo.path.rewrite(src) + ')' : 'none');
+				this.applyStyle('background-image', src ? multiple : 'none');
 			} else {
 				if (!src) {
 					// allow us to clear the src property
 					this.setAttribute('src', '');
 				} else {
-					this.setAttribute('src', enyo.path.rewrite(src));
+					this.applyStyle('background-image', multiple );
 				}
 			}
 		},

--- a/source/ui/Image.js
+++ b/source/ui/Image.js
@@ -158,7 +158,8 @@
 		},
 
 		handlers: {
-			onload: 'handleLoad'
+			onload: 'handleLoad',
+			onerror: 'handleError'
 		},
 
 		/**
@@ -243,6 +244,16 @@
 				this.applyStyle('background-image', null);
 			}
 		},
+
+		/**
+		* @private
+		*/
+		handleError: function() {
+			if (this.placeholder) {
+				this.setSrc(null);
+			}
+		},
+
 
 		/**
 		* @fires enyo.Image#onload

--- a/source/ui/Image.js
+++ b/source/ui/Image.js
@@ -186,8 +186,8 @@
 		srcChanged: function () {
 			var src = enyo.ri.selectSrc(this.src);
 			if (this.sizing) {
-				var placeholder = this.placeholder ? ', url(\'' + enyo.path.rewrite(this.placeholder) + '\')' : '';
-				var url = 'url(\'' + enyo.path.rewrite(src) + '\')' + placeholder + ';';
+				var placeholder = this.placeholder ? 'url(\'' + enyo.path.rewrite(this.placeholder) + '\')' : '';
+				var url= (src? 'url(\'' + enyo.path.rewrite(src) + '\'),' : '') + placeholder;
 				this.applyStyle('background-image', url);
 			} else {
 				if (!src) {

--- a/source/ui/Image.js
+++ b/source/ui/Image.js
@@ -103,10 +103,10 @@
 
 			/**
 			* By default, the [image]{@link enyo.Image} is rendered using an `<img>` tag.
-			* When this property is set to `'cover'` or `'constrain'`, the image will be
+			* When this property is set to `'cover'` or `'contain'`, the image will be
 			* rendered using a `<div>`, utilizing `background-image` and `background-size`.
 			*
-			* Set this property to `'constrain'` to letterbox the image in the available
+			* Set this property to `'contain'` to letterbox the image in the available
 			* space, or `'cover'` to cover the available space with the image (cropping the
 			* larger dimension).  Note that when `sizing` is set, the control must be
 			* explicitly sized.
@@ -179,25 +179,29 @@
 		* @private
 		*/
 		srcChanged: function () {
-			var src = enyo.ri.selectSrc(this.src);
+			var url = 'none',
+				src = enyo.ri.selectSrc(this.src);
+
+			src = src ? enyo.path.rewrite(src) : '';	// Only run rewrite if src is truthy.
+
 			if (this.sizing) {
-				var placeholder = this.placeholder ? 'url(\'' + enyo.path.rewrite(this.placeholder) + '\')' : '';
-				var murl= src ? ( 'url(\'' + enyo.path.rewrite(src) + '\')' + ( placeholder ? ','+ placeholder : '' ) ): ''; 
-				this.applyStyle('background-image', murl ? murl : 'none');
-			} else{
-				if (!src) {
-					// allow us to clear the src property
-					this.setAttribute('src', '');
-				} else{
-					//If placeholder property exists
-					if(this.placeholder){
-						this.img = document.createElement('img');
-						this.img.onload = this.bindSafely('handleLoad');
-						this.img.onerror = this.bindSafely('handleError');
-						this.img.src = src;
-					} else{
-						this.setAttribute('src', enyo.path.rewrite(src));
+				if (src) {
+					url = 'url(\'' + src + '\')';
+
+					if (this.placeholder) {
+						url += ', url(\'' + enyo.path.rewrite(this.placeholder) + '\')';
 					}
+				}
+				this.applyStyle('background-image', url);
+			} else {
+				//If placeholder property exists
+				if (src && this.placeholder) {
+					this.img = document.createElement('img');
+					this.img.onload = this.bindSafely('handleLoad');
+					this.img.onerror = this.bindSafely('handleError');
+					this.img.src = src;
+				} else {
+					this.setAttribute('src', src);
 				}
 			}
 		},
@@ -208,10 +212,10 @@
 		placeholderChanged: function(){
 			var placeholder = this.placeholder ? enyo.path.rewrite(this.placeholder) : '';
 			//Change placeholder when the src is empty
-			if(!this.src){
-				if(this.sizing){
+			if (!this.src) {
+				if (this.sizing) {
 					this.applyStyle('background-image', placeholder ? 'url(\'' + placeholder + '\')' : 'none');
-				} else{
+				} else {
 					this.setAttribute('src', placeholder);
 				}
 			}

--- a/source/ui/Image.js
+++ b/source/ui/Image.js
@@ -157,11 +157,6 @@
 			draggable: 'false'
 		},
 
-		handlers: {
-			onload: 'handleLoad',
-			onerror: 'handleError'
-		},
-
 		/**
 		* @method
 		* @private
@@ -187,17 +182,22 @@
 			var src = enyo.ri.selectSrc(this.src);
 			if (this.sizing) {
 				var placeholder = this.placeholder ? 'url(\'' + enyo.path.rewrite(this.placeholder) + '\')' : '';
-				var url= (src ? ( placeholder ? 'url(\'' + enyo.path.rewrite(src) + '\'),' : 'url(\'' + enyo.path.rewrite(src) + '\')') : '');
-				this.applyStyle('background-image', url+placeholder);
-			} else {
+				var murl= src ? ( 'url(\'' + enyo.path.rewrite(src) + '\')' + ( placeholder ? ','+ placeholder : '' ) ): ''; 
+				this.applyStyle('background-image', murl ? murl : 'none');
+			} else{
 				if (!src) {
 					// allow us to clear the src property
 					this.setAttribute('src', '');
-				} else {
-					if (this.placeholder) {
-						this.applyStyle('background-image', 'url(\'' + enyo.path.rewrite(this.placeholder) + '\')');
+				} else{
+					//If placeholder property exists
+					if(this.placeholder){
+						this.img = document.createElement('img');
+						this.img.onload = this.bindSafely('handleLoad');
+						this.img.onerror = this.bindSafely('handleError');
+						this.img.src = src;
+					} else{
+						this.setAttribute('src', enyo.path.rewrite(src));
 					}
-					this.setAttribute('src', enyo.path.rewrite(src));
 				}
 			}
 		},
@@ -206,8 +206,14 @@
 		* @private
 		*/
 		placeholderChanged: function(){
-			if (this.placeholder) {
-				this.applyStyle('background-image', 'url(\'' + enyo.path.rewrite(this.placeholder) + '\')');
+			var placeholder = this.placeholder ? enyo.path.rewrite(this.placeholder) : '';
+			//Change placeholder when the src is empty
+			if(!this.src){
+				if(this.sizing){
+					this.applyStyle('background-image', placeholder ? 'url(\'' + placeholder + '\')' : 'none');
+				} else{
+					this.setAttribute('src', placeholder);
+				}
 			}
 		},
 
@@ -225,10 +231,10 @@
 			this.tag = this.sizing ? 'div' : 'img';
 			this.addRemoveClass('sized', !!this.sizing);
 			if (was) {
-				this.removeClass(was);
+				this.removeClass('enyo-'+was);
 			}
 			if (this.sizing) {
-				this.addClass(this.sizing);
+				this.addClass('enyo-'+this.sizing);
 			}
 			if (this.generated) {
 				this.srcChanged();
@@ -249,20 +255,15 @@
 		* @private
 		*/
 		handleLoad: function () {
-			if (!this.sizing && this.placeholder) {
-				this.applyStyle('background-image', null);
-			}
+			this.setAttribute('src', enyo.path.rewrite(this.src));
 		},
 
 		/**
 		* @private
 		*/
 		handleError: function() {
-			if (this.placeholder) {
-				this.setSrc(null);
-			}
+			this.setAttribute('src', enyo.path.rewrite(this.placeholder));
 		},
-
 
 		/**
 		* @fires enyo.Image#onload

--- a/source/ui/Image.js
+++ b/source/ui/Image.js
@@ -180,15 +180,16 @@
 		*/
 		srcChanged: function () {
 			var src = enyo.ri.selectSrc(this.src);
-			var multiple= "url('"+ enyo.path.rewrite(src) +"'), url('"+ this.placeholder + "');";
 			if (this.sizing) {
-				this.applyStyle('background-image', src ? multiple : 'none');
+				var placeholder =  enyo.path.rewrite(this.placeholder);
+				var multiple= "url('"+ enyo.path.rewrite(src) +"'), url('"+ (placeholder ? placeholder : enyo.Image.placeholder) + "');";
+				this.applyStyle('background-image',  multiple);
 			} else {
 				if (!src) {
 					// allow us to clear the src property
 					this.setAttribute('src', '');
 				} else {
-					this.applyStyle('background-image', multiple );
+					this.setAttribute('src', enyo.path.rewrite(src));
 				}
 			}
 		},

--- a/source/ui/ui.css
+++ b/source/ui/ui.css
@@ -30,10 +30,10 @@
 	background-position: center;
 	background-repeat: no-repeat;
 }
-.enyo-image.contain {
+.enyo-image.enyo-contain {
 	background-size: contain;
 }
-.enyo-image.cover {
+.enyo-image.enyo-cover {
 	background-size: cover;
 }
 

--- a/source/ui/ui.css
+++ b/source/ui/ui.css
@@ -30,10 +30,10 @@
 	background-position: center;
 	background-repeat: no-repeat;
 }
-.enyo-image.enyo-contain {
+.enyo-image.contain {
 	background-size: contain;
 }
-.enyo-image.enyo-cover {
+.enyo-image.cover {
 	background-size: cover;
 }
 


### PR DESCRIPTION
Issue:

There was no placeholder in image grid, and image gets displayed once loaded. In between grid remains empty.

Fix:

Using multiple background images through css, we can set the placeholder, a static image, which will be seen until the image gets loaded and will be replaced.

Enyo-DCO-1.1-Signed-off-by: Rakesh kumar rakesh25.kumar@lge.com