### PR TITLE
ENYO-1161: Specify "less" option when minifying Enyo lib.

### DIFF
--- a/tools/deploy.js
+++ b/tools/deploy.js
@@ -281,6 +281,7 @@ if (!opt.mapfrom || opt.mapfrom.indexOf("enyo") < 0) {
 		'-enyo', opt.enyo,
 		'-destdir', opt.out,
 		'-output', path.join(opt.build, 'enyo'),
+		(less ? '-less' : '-no-less'),
 		(ri ? '-ri' : '-no-ri'),
 		(beautify ? '-beautify' : '-no-beautify'),
 		path.join(opt.enyo, 'minify', 'package.js')];


### PR DESCRIPTION
### Issue
When deploying an Enyo application, if there are LESS files in Enyo core that are part of the manifest, an error will be thrown. This is due to the fact that by default, LESS processing is disabled just for Enyo core, which tries to access the equivalent file with the `css` instead of `less` extension; because this file does not exist in most cases, an error is thrown.

### Fix
We explicitly pass in the `less` flag when invoking the minifier for Enyo core, to match what is occurring when minifying the rest of the application. We could also update the minifier to default to LESS parsing being enabled, but this seems to be tightly-interleaved with the deploy script, so I wanted to make this change first and then potentially revisit cleaning up both the deploy script and the minifier.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>