### PR TITLE
ENYO-944: Only return sibling controls that have been rendered. Addition...

### DIFF
--- a/source/dom/Control.js
+++ b/source/dom/Control.js
@@ -1098,20 +1098,23 @@
 		},
 
 		/**
+		* @param {Boolean} [cache] - Whether or not we are tearing down as part of a destroy
+		*	operation, or if we are just caching. If `true`, the `showing` and `canGenerate`
+		*	properties of the control will not be reset.
 		* @private
 		*/
-		teardownRender: function () {
+		teardownRender: function (cache) {
 			var delegate = this.renderDelegate || Control.renderDelegate;
 
 			if (this._retainedNode) {
 				storeRetainedNode(this);
 			}
 
-			delegate.teardownRender(this);
+			delegate.teardownRender(this, cache);
 
 			// if the original state was set with renderOnShow true then we need to reset these
 			// values as well to coordinate the original intent
-			if (this.renderOnShow) {
+			if (this.renderOnShow && !cache) {
 				this.set('showing', false);
 				this.set('canGenerate', false);
 			}

--- a/source/dom/delegates/HTMLStringDelegate.js
+++ b/source/dom/delegates/HTMLStringDelegate.js
@@ -1,8 +1,8 @@
 (function (enyo, scope) {
-	
+
 	var selfClosing = {img: 1, hr: 1, br: 1, area: 1, base: 1, basefont: 1, input: 1, link: 1,
 		meta: 1, command: 1, embed: 1, keygen: 1, wbr: 1, param: 1, source: 1, track: 1, col: 1};
-	
+
 	/**
 	* This is the default render delegate used by {@link enyo.Control}. It
 	* generates the HTML [string]{@glossary String} content and correctly inserts
@@ -14,7 +14,7 @@
 	* @public
 	*/
 	enyo.HTMLStringDelegate = {
-		
+
 		/**
 		* @private
 		*/
@@ -28,34 +28,34 @@
 				break;
 			}
 		},
-		
+
 		/**
 		* @private
 		*/
 		render: function (control) {
 			if (control.parent) {
 				control.parent.beforeChildRender(control);
-				
+
 				if (!control.parent.generated) return;
 				if (control.tag === null) return control.parent.render();
 			}
-			
+
 			if (!control.hasNode()) this.renderNode(control);
 			if (control.hasNode()) {
 				this.renderDom(control);
 				if (control.generated) control.rendered();
 			}
 		},
-		
+
 		/**
 		* @private
 		*/
 		renderInto: function (control, parentNode) {
 			parentNode.innerHTML = this.generateHtml(control);
-			
+
 			if (control.generated) control.rendered();
 		},
-		
+
 		/**
 		* @private
 		*/
@@ -65,7 +65,7 @@
 			control.addNodeToParent();
 			control.set('generated', true);
 		},
-		
+
 		/**
 		* @private
 		*/
@@ -74,13 +74,13 @@
 			this.renderStyles(control);
 			this.renderContent(control);
 		},
-		
+
 		/**
 		* @private
 		*/
 		renderStyles: function (control) {
 			var style = control.style;
-			
+
 			// we can safely do this knowing it will synchronize properly without a double
 			// set in the DOM because we're flagging the internal property
 			if (control.hasNode()) {
@@ -92,7 +92,7 @@
 				control.set('style', style);
 			}
 		},
-		
+
 		/**
 		* @private
 		*/
@@ -101,7 +101,7 @@
 				node = control.hasNode(),
 				key,
 				val;
-			
+
 			if (node) {
 				for (key in attrs) {
 					val = attrs[key];
@@ -113,7 +113,7 @@
 				}
 			}
 		},
-		
+
 		/**
 		* @private
 		*/
@@ -121,14 +121,14 @@
 			if (control.generated) this.teardownChildren(control);
 			if (control.hasNode()) control.node.innerHTML = this.generateInnerHtml(control);
 		},
-		
+
 		/**
 		* @private
 		*/
 		generateHtml: function (control) {
 			var content,
 				html;
-			
+
 			if (control.canGenerate === false) {
 				return '';
 			}
@@ -147,7 +147,7 @@
 			control.set('generated', true);
 			return html;
 		},
-		
+
 		/**
 		* @private
 		*/
@@ -156,14 +156,14 @@
 			if (!control.tagsValid) this.prepareTags(control);
 			return control._openTag + content + control._closeTag;
 		},
-		
+
 		/**
 		* @private
 		*/
 		generateInnerHtml: function (control) {
 			var allowHtml = control.allowHtml,
 				content;
-			
+
 			// flow can alter the way that html content is rendered inside
 			// the container regardless of whether there are children.
 			control.flow();
@@ -173,7 +173,7 @@
 				return allowHtml ? content : enyo.dom.escape(content);
 			}
 		},
-		
+
 		/**
 		* @private
 		*/
@@ -182,21 +182,21 @@
 				html = '',
 				i = 0,
 				delegate;
-			
+
 			for (; (child = control.children[i]); ++i) {
 				delegate = child.renderDelegate || this;
 				html += delegate.generateHtml(child);
 			}
-			
+
 			return html;
 		},
-		
+
 		/**
 		* @private
 		*/
 		prepareTags: function (control) {
 			var html = '';
-			
+
 			// open tag
 			html += '<' + control.tag + (control.style ? ' style="' + control.style + '"' : '');
 			html += this.attributesToHtml(control.attributes);
@@ -207,10 +207,10 @@
 				control._openTag = html + '>';
 				control._closeTag = '</' + control.tag + '>';
 			}
-			
+
 			control.tagsValid = true;
 		},
-		
+
 		/**
 		* @private
 		*/
@@ -218,46 +218,46 @@
 			var key,
 				val,
 				html = '';
-				
+
 			for (key in attrs) {
 				val = attrs[key];
 				if (val != null && val !== false && val !== '') {
 					html += ' ' + key + '="' + this.escapeAttribute(val) + '"';
 				}
 			}
-			
+
 			return html;
 		},
-		
+
 		/**
 		* @private
 		*/
 		escapeAttribute: function (text) {
 			if (typeof text != 'string') return text;
-		
+
 			return String(text).replace(/&/g, '&amp;').replace(/\"/g, '&quot;');
 		},
-		
+
 		/**
 		* @private
 		*/
-		teardownRender: function (control) {
-			if (control.generated) this.teardownChildren(control);
+		teardownRender: function (control, cache) {
+			if (control.generated) this.teardownChildren(control, cache);
 			control.node = null;
 			control.set('generated', false);
 		},
-		
+
 		/**
 		* @private
 		*/
-		teardownChildren: function (control) {
+		teardownChildren: function (control, cache) {
 			var child,
 				i = 0;
-				
+
 			for (; (child = control.children[i]); ++i) {
-				child.teardownRender();
+				child.teardownRender(cache);
 			}
 		}
 	};
-	
+
 })(enyo, this);

--- a/source/kernel/UiComponent.js
+++ b/source/kernel/UiComponent.js
@@ -368,7 +368,7 @@
 			for (i = comps.length - 1; i >= 0; i--) {
 				comp = comps[i];
 				if (comp === this) return sibling ? sibling : null;
-				sibling = comp;
+				if (comp.generated) sibling = comp;
 			}
 
 			return null;

--- a/source/ui/LightPanels.js
+++ b/source/ui/LightPanels.js
@@ -445,7 +445,7 @@
 			var pid = panel.kind;
 
 			panel.node.remove();
-			panel.teardownRender();
+			panel.teardownRender(true);
 
 			this.resetPanel(panel);
 


### PR DESCRIPTION
...ally, prevent the resetting of state for renderOnShow controls that will be cached.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>