### PR TITLE
ENYO-1200 Update partially filled page when models are added.

### DIFF
--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -413,14 +413,20 @@
 			if (props.index <= end ) this.refresh(list);
 			else {
 				// we should confirm that the page which new models are added is need to update list.metrics
-				var targetPageIndex = this.pageForIndex(list, props.index),
-					page = list.metrics.pages[targetPageIndex],
+				var lastPageIndex = this.pageForIndex(list, props.index),
+					// the last page before model added
+					lastPage = list.metrics.pages[lastPageIndex],
 					sp = list.psizeProp,
+					// current page count after models added
 					pc = this.pageCount(list),
-					pageSize = this.defaultPageSize(list);
+					pageSize;
 
-				if (targetPageIndex < pc && page[sp] < pageSize) {
-					page[sp] = pageSize;
+				// if there is more pages after lastPage, the lastPage metric needs to be updated
+				if (lastPageIndex < pc) {
+					pageSize = this.defaultPageSize(list);
+					if (lastPage[sp] < pageSize) {
+						lastPage[sp] = pageSize;
+					}
 				}
 
 				// we still need to ensure that the metrics are updated so it knows it can scroll

--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -401,13 +401,28 @@
 			// the only time we don't refresh is if the first index of the contiguous set of added
 			// models is beyond our final rendered page (possible) indices
 
-			// in the case where it does not need to refresh the existing controls it will update its
-			// measurements and page positions within the buffer so scrolling can continue properly
+			// in the case where it does not need to refresh the existing controls except the last page
+			// if the last page is not fully filled, it will be filled with added models
+			// so we should generate the last page.
+
+			// it will update its measurements and page positions within the buffer
+			// so scrolling can continue properly
 
 			// if we need to refresh, do it now and ensure that we're properly setup to scroll
 			// if we were adding to a partially filled page
 			if (props.index <= end ) this.refresh(list);
 			else {
+				// we should confirm that the page which new models are added is need to update list.metrics
+				var targetPageIndex = this.pageForIndex(list, props.index),
+					page = list.metrics.pages[targetPageIndex],
+					sp = list.psizeProp,
+					pc = this.pageCount(list),
+					pageSize = this.defaultPageSize(list);
+
+				if (targetPageIndex < pc && page[sp] < pageSize) {
+					page[sp] = pageSize;
+				}
+
 				// we still need to ensure that the metrics are updated so it knows it can scroll
 				// past the boundaries of the current pages (potentially)
 				this.adjustBuffer(list);


### PR DESCRIPTION
Issue
------
A page generated once, and it is not fully filled page.
And some models are added without re-generate that page.
We we call scrollToIndex over that page, generatePage() is called infinitely.

Cause
--------
Model adding does not update partially filled page's bounds

FIx
-----
The last page of list can be partially filled if models are not equally distributed to every page.
However if new models are added and then list has more pages than before,
previous last page must be fully filled.

Currently that last page does not update its metric until it is generated again.
So, list.bufferSize could miss calculate it.
We can prevent this edge case with this commit.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com