### PR TITLE
ENYO-966 Refresh() after dynamic control size changing makes blank

### DIFF
--- a/source/ui/data/DataList.js
+++ b/source/ui/data/DataList.js
@@ -190,12 +190,14 @@
 		* the current dataset. This is much cheaper to call than `reset()`, but is primarily used
 		* internally.
 		*
+		* @param {Boolean} skipPageIndicesUpdate - Basically refreshing DataList requires to update
+		* page indices. but if it is true, we can skip this process.
 		* @public
 		*/
-		refresh: function (c, e) {
+		refresh: function (skipPageIndicesUpdate) {
 			if (this.get('absoluteShowing')) {
 				if (this.hasRendered) {
-					this.delegate.refresh(this);
+					this.delegate.refresh(this, skipPageIndicesUpdate);
 				}
 			} else {
 				this._addToShowingQueue('refresh', this.refresh);

--- a/source/ui/data/DataList.js
+++ b/source/ui/data/DataList.js
@@ -190,14 +190,12 @@
 		* the current dataset. This is much cheaper to call than `reset()`, but is primarily used
 		* internally.
 		*
-		* @param {Boolean} skipPageIndicesUpdate - Basically refreshing DataList requires to update
-		* page indices. but if it is true, we can skip this process.
 		* @public
 		*/
-		refresh: function (skipPageIndicesUpdate) {
+		refresh: function (c, e) {
 			if (this.get('absoluteShowing')) {
 				if (this.hasRendered) {
-					this.delegate.refresh(this, skipPageIndicesUpdate);
+					this.delegate.refresh(this);
 				}
 			} else {
 				this._addToShowingQueue('refresh', this.refresh);

--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -190,8 +190,9 @@
 			metrics        = metrics.pages[index] || (metrics.pages[index] = {});
 			metrics.height = this.pageHeight(list, page);
 			metrics.width  = this.pageWidth(list, page);
+
 			// update the childSize value now that we have measurements
-			this.childSize(list);
+			metrics.childSize = this.childSize(list);
 		},
 
 		/**
@@ -214,6 +215,7 @@
 		* @private
 		*/
 		childSize: function (list) {
+			var childSize;
 			if (!list.fixedChildSize) {
 				var pageIndex = list.$.page1.index,
 					sizeProp  = list.psizeProp,
@@ -222,10 +224,11 @@
 				if (pageIndex >= 0 && n) {
 					props = list.metrics.pages[pageIndex];
 					size  = props? props[sizeProp]: 0;
-					list.childSize = Math.floor(size / (n.children.length || 1));
+					childSize = Math.floor(size / (n.children.length || 1));
+					list.childSize = list.childSize? Math.max(list.childSize, childSize) : childSize;
 				}
 			}
-			return list.fixedChildSize || list.childSize || (list.childSize = 100); // we have to start somewhere
+			return list.fixedChildSize || childSize || (childSize = 100); // we have to start somewhere
 		},
 
 		/**

--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -524,6 +524,26 @@
 		},
 
 		/**
+		* Retrieves the assumed page index for the requested position.
+		*
+		* @param {enyo.DataList} list - The [list]{@link enyo.DataList} to perform this action on.
+		* @param {Number} targetPos - How long does target control in scroller.
+		* @private
+		*/
+		pageIndexByPosition: function (list, targetPos) {
+			var mx = list.metrics.pages,
+				ds = this.defaultPageSize(list),
+				tt = 0, sp = list.psizeProp, cp, i = 0;
+			while (tt < targetPos) {
+				cp = mx[i++];
+				tt += cp && cp.childSize ? cp.childSize * list.controlsPerPage
+					: cp && cp[sp] ? cp[sp]
+					: ds;
+			}
+			return (i > 0) ? i - 1 : 0;
+		},
+
+		/**
 		* Retrieves the default page size.
 		*
 		* @private
@@ -646,7 +666,8 @@
 			targetPos = Math.max(0, Math.min(targetPos, list.bufferSize));
 
 			// First, we find the target page (the one that covers the target position)
-			index1 = Math.floor(targetPos / this.defaultPageSize(list));
+			index1 = list.fixedChildSize ? Math.floor(targetPos / this.defaultPageSize(list))
+					: this.pageIndexByPosition(list, targetPos);
 			index1 = Math.min(index1, last);
 
 			// Our list always generates two pages worth of content, so -- now that we have

--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -102,13 +102,11 @@
 		* and adjusting the buffer accordingly.
 		*
 		* @param {enyo.DataList} list - The [list]{@link enyo.DataList} to perform this action on.
-		* @param {Boolean} skipPageIndicesUpdate - Basically refreshing DataList requires to update
-		* page indices. but if it is true, we can skip this process.
 		* @private
 		*/
-		refresh: function (list, skipPageIndicesUpdate) {
+		refresh: function (list) {
 			if (!list.hasReset) { return this.reset(list); }
-			if (!skipPageIndicesUpdate) { this.assignPageIndices(list); }
+			this.assignPageIndices(list);
 			this.generate(list);
 		},
 

--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -102,11 +102,13 @@
 		* and adjusting the buffer accordingly.
 		*
 		* @param {enyo.DataList} list - The [list]{@link enyo.DataList} to perform this action on.
+		* @param {Boolean} skipPageIndicesUpdate - Basically refreshing DataList requires to update
+		* page indices. but if it is true, we can skip this process.
 		* @private
 		*/
-		refresh: function (list) {
+		refresh: function (list, skipPageIndicesUpdate) {
 			if (!list.hasReset) { return this.reset(list); }
-			this.assignPageIndices(list);
+			if (!skipPageIndicesUpdate) { this.assignPageIndices(list); }
 			this.generate(list);
 		},
 


### PR DESCRIPTION
Issue
-------
If we dynamically change controls size then call refresh() to render it, dataList shows blank.

Cause
--------
Even though a single control's size is changed, calling generatePage() will update childSize.
And it affects on calculation of defaultPageSize and makes wrong page indices.

For example, when we expand a control size and call refresh(), childeSIze became bigger after generatePage().
Next refresh() call will execute assignPageIndices() but defaultPageSize() returns bigger value
due to incresed childSize.
That means, index of pages could have wrong value.

Fix
----
Each page could have individual childSize. 
Based on this assume, changed related method to get accurate page indices.


Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com