### PR TITLE
ENYO-1188: Accessibility: Apply "aria-label" to all enyo control which h...

### DIFF
--- a/source/dom/Control.js
+++ b/source/dom/Control.js
@@ -796,6 +796,13 @@
 		contentChanged: function () {
 			var delegate = this.renderDelegate || Control.renderDelegate;
 			delegate.invalidate(this, 'content');
+
+			// Accessibility : If accessibilityLabel is not set, change
+			// aria-label to current content when content changed.
+			if (this.content && !this.accessibilityLabel) {
+				this.setAttribute('tabindex', 0);
+				this.setAttribute('aria-label', this.content);
+			}
 		},
 
 		/**

--- a/source/dom/dom.css
+++ b/source/dom/dom.css
@@ -139,4 +139,6 @@ body .enyo-fullscreen {
 *[tabindex] {
 	/* remove outline in case dom has tabindex attribute */
 	outline: none;
+	/* remove tap highlight in case dom has tabindex attribute */
+	-webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }

--- a/source/dom/dom.css
+++ b/source/dom/dom.css
@@ -134,3 +134,9 @@ body .enyo-fullscreen {
 	height: 100% !important;
 	box-sizing: border-box !important;
 }
+
+/* Accessibility CSS */
+*[tabindex] {
+	/* remove outline in case dom has tabindex attribute */
+	outline: none;
+}


### PR DESCRIPTION
...ave a content

When content of control is set or chagned, aria-label should be also set
and changed. So I added the code of setting aria-label in contentChanged
function.
In addition, it needs the tabindex attribute to be focusable because
screen reader can read aria-label when dom is focused. And if dom has
tabindex attribute default outline is shown when it focused, so remove
the outline in case dom has tabindex attribute.

https://jira2.lgsvl.com/browse/ENYO-1188
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>