### PR TITLE
ENYO-944: Only render when directly shown.

### DIFF
--- a/source/dom/Control.js
+++ b/source/dom/Control.js
@@ -862,11 +862,6 @@
 		* @private
 		*/
 		showingChangedHandler: function (sender, event) {
-
-			if (!this.showing && event.showing && this.renderOnShow && !this.generated) {
-				this.set('showing', true);
-			}
-
 			return sender === this ? false : !this.showing;
 		},
 


### PR DESCRIPTION
### Issue
When a control is shown, the `onShowingChanged` event is waterfalled. The original intent of `renderOnShow` was to allow a parent control to selectively render a child control by directly showing the control; this seems to be in conflict with rendering the control in response to a waterfalled `onShowingChanged` event, as is the current behavior.

### Fix
We remove the code that renders a `renderOnShow:true` control in response to an `onShowingChanged` event.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>