### PR TITLE
ENYO-1124: Add "accessibilityAlert" to enyo control

### DIFF
--- a/source/dom/Control.js
+++ b/source/dom/Control.js
@@ -215,6 +215,21 @@
 		accessibilityLabel : '',
 
 		/**
+		* AccessibilityAlert is for alert message or page description.
+		* If accessibilityAlert is true, screen reader will automatically reads
+		* content or accessibilityLabel regardless focus.
+		*
+		* Range: [`true`, `false`]
+		* - true: screen reader automatically reads label regardless focus.
+		* - false: screen reader reads label with focus.
+		*
+		* @type {Boolean}
+		* @default false
+		* @public
+		*/
+		accessibilityAlert : false,
+
+		/**
 		* @todo Find out how to document "handlers".
 		* @public
 		*/
@@ -485,6 +500,10 @@
 				this.accessibilityLabelChanged();
 			}
 
+			if (this.accessibilityAlert) {
+				this.accessibilityAlertChanged();
+			}
+
 			//TODO: adding accessibility code such as accessibilityDisabled.
 		},
 
@@ -526,6 +545,46 @@
 			} else {
 				this.setAttribute('tabindex', 0);
 				this.setAttribute('aria-label', this.accessibilityLabel);
+			}
+		},
+
+		/**
+		* Get the accessibilityAlert value true or false.
+		*
+		* @returns {Boolean} return accessibilityAlert status.
+		* @public
+		*/
+		getAccessibilityAlert: function () {
+			return this.accessibilityAlert;
+		},
+
+		/**
+		* Set the accessibilityAlert to true or false.
+		* If accessibilityAlert is true, screen reader will automatically reads
+		* content or accessibilityLabel regardless focus.
+		*
+		* @param {Boolean} accessibilityAlert - if true, screen reader reads content automatically.
+		* @returns {this} callee for chaining.
+		* @public
+		*/
+		setAccessibilityAlert: function (accessibilityAlert) {
+			var was = this.accessibilityAlert;
+			this.accessibilityAlert = accessibilityAlert;
+
+			if (was != accessibilityAlert) {
+				this.notify('accessibilityAlert', was, accessibilityAlert);
+			}
+			return this;
+		},
+
+		/**
+		* @private
+		*/
+		accessibilityAlertChanged: function () {
+			if (this.accessibilityAlert) {
+				this.setAttribute('role', 'alert');
+			} else {
+				this.setAttribute('role', null);
 			}
 		},
 

--- a/source/dom/Control.js
+++ b/source/dom/Control.js
@@ -212,7 +212,7 @@
 		* @default ''
 		* @public
 		*/
-		accessibilityLabel : '',
+		accessibilityLabel: '',
 
 		/**
 		* AccessibilityAlert is for alert message or page description.
@@ -227,7 +227,7 @@
 		* @default false
 		* @public
 		*/
-		accessibilityAlert : false,
+		accessibilityAlert: false,
 
 		/**
 		* @todo Find out how to document "handlers".


### PR DESCRIPTION
The accessibilityAlert property is to cover alert role of aria
attribute.
Basically screen reader reads content or accessibilityLabel out when the
control is focused, but there are some cases that it should be read
something regardless focus. For example, popup, notifications, page
description and so on. If accessibilityAlert is set true, screen reader
will automatically reads content or accessibilityLabe when the control
is rendered or visible.
Refer
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role.

https://jira2.lgsvl.com/browse/ENYO-1124
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>