### PR TITLE
ENYO-1279 Document containerOptions and containerName

### DIFF
--- a/source/ui/data/DataRepeater.js
+++ b/source/ui/data/DataRepeater.js
@@ -143,6 +143,37 @@
 		childBindingDefaults: null,
 
 		/**
+		* The name of the container specified in
+		* [containerOptions]{@link enyo.DataRepeater#containerOptions}. This may or may not have the
+		* same value as [controlParentName]{@link enyo.DataRepeater#controlParentName}.
+		*
+		* @type {String}
+		* @default 'container'
+		* @public
+		*/
+		containerName: 'container',
+
+		/**
+		* A [Kind]{@glossary Kind} definition that will be used as the chrome for the container
+		*  of the DataRepeater. When specifying a custom definition be sure to include a container
+		*  component that has the name specified in
+		*  [controlParentName]{@link enyo.DataRepeater#controlParentName}.
+		*
+		* @type {Object}
+		* @default {name: 'container', classes: 'enyo-fill enyo-data-repeater-container'}
+		* @public
+		*/
+		containerOptions: {name: 'container', classes: 'enyo-fill enyo-data-repeater-container'},
+
+		/**
+		* See {@link enyo.UiComponent#controlParentName}
+		* @type {String}
+		* @default 'container'
+		* @public
+		*/
+		controlParentName: 'container',
+
+		/**
 		* @private
 		*/
 		initComponents: function () {
@@ -665,21 +696,6 @@
 		* @private
 		*/
 		childMixins: [enyo.RepeaterChildSupport],
-
-		/**
-		* @private
-		*/
-		controlParentName: 'container',
-
-		/**
-		* @private
-		*/
-		containerName: 'container',
-
-		/**
-		* @private
-		*/
-		containerOptions: {name: 'container', classes: 'enyo-fill enyo-data-repeater-container'},
 
 		/**
 		* @private


### PR DESCRIPTION
**Issue**
`DataRepeater` has two members currently marked private: `containerName` and `containerOptions`. Document these two and make them public.

Enyo-DCO-1.1-Signed-off-by: Roy Sutton <roy.sutton@lge.com>