### PR TITLE
ENYO-944: Refactoring and adding direct transition option support

### DIFF
--- a/source/ui/LightPanels.js
+++ b/source/ui/LightPanels.js
@@ -1,4 +1,17 @@
 (function (enyo, scope) {
+
+	/**
+	* The configurable options used by {@link enyo.LightPanels} when pushing panels.
+	*
+	* @typedef {Object} enyo.LightPanels~PushPanelOptions
+	* @property {Boolean} [preventAnimation] - If `true`, the transition to the panel whose index
+	*	we are changing to will not be animated.
+	* @property {Boolean} [forcePostTransition] - If `true`, forces post-transition work to be run
+	*	immediately after each panel is created.
+	* @property {Number} [targetIndex] - The index of the panel to display, otherwise the last panel
+	*	created will be displayed.
+	*/
+
 	/**
 	* A light-weight panels implementation that has basic support for CSS transitions between child
 	* components.
@@ -20,6 +33,11 @@
 		* @private
 		*/
 		kind: 'enyo.Control',
+
+		/**
+		* @private
+		*/
+		mixins: ['enyo.ViewPreloadSupport'],
 
 		/**
 		* @private
@@ -52,7 +70,6 @@
 
 			/**
 			* Indicates whether panels "wrap around" when moving past the end.
-			* The actual effect depends upon the arranger in use.
 			*
 			* @type {Boolean}
 			* @default false
@@ -116,15 +133,6 @@
 			direction: 'forwards',
 
 			/**
-			* When `true`, existing panels are cached for reuse, otherwise they are destroyed.
-			*
-			* @type {Boolean}
-			* @default true
-			* @public
-			*/
-			cachePanels: true,
-
-			/**
 			* The default priority for view caching jobs.
 			*
 			* @type {Number}
@@ -163,18 +171,17 @@
 
 				this.orientationChanged();
 				this.directionChanged();
-
-				if (this.cachePanels) {
-					this.createChrome([
-						{name: 'panelCache', kind: 'enyo.Control', canGenerate: false}
-					]);
-					this.removeChild(this.$.panelCache);
-					this._cachedPanels = {};
-				}
-
 				this.indexChanged();
 			};
 		}),
+
+
+
+		/*
+			===============
+			Change handlers
+			===============
+		*/
 
 		/**
 		* @private
@@ -193,13 +200,13 @@
 		/**
 		* @private
 		*/
-		indexChanged: function (previousIndex) {
+		indexChanged: function (was) {
 			var panels = this.getPanels(),
 				nextPanel = panels[this.index],
 				trans, wTrans;
 
 			this._shouldAnimate = null;
-			this._indexDirection = (this.index - previousIndex < 0 ? -1 : 1);
+			this._indexDirection = (this.index - was < 0 ? -1 : 1);
 
 			if (nextPanel) {
 				if (!nextPanel.generated) {
@@ -233,40 +240,13 @@
 			}
 		},
 
-		/**
-		* Sets up the transitions between the current and next panel.
-		*
-		* @param {Object} nextPanel - The panel we are transitioning to.
-		* @private
-		*/
-		setupTransitions: function (nextPanel) {
-			// setup the transition for the next panel
-			var nextTransition = {};
-			nextTransition['translate' + this._axis] = -100 * this._direction + '%';
-			enyo.dom.transform(nextPanel, nextTransition);
-			if (this._currentPanel) { // setup the transition for the current panel
-				var currentTransition = {};
-				currentTransition['translate' + this._axis] = this._indexDirection > 0 ? -200 * this._direction + '%' : '0%';
-				enyo.dom.transform(this._currentPanel, currentTransition);
-			}
 
-			this._previousPanel = this._currentPanel;
-			this._currentPanel = nextPanel;
-			if (!this.shouldAnimate()) { // ensure that `transitionFinished is called, regardless of animation
-				this.transitionFinished(this._currentPanel, {originator: this._currentPanel});
-			}
-		},
 
-		/**
-		* Determines whether or not we should animate the panel transition.
-		*
-		* @return {Boolean} If `true`, the panels should animate.
-		* @public
+		/*
+			=======================
+			Public accessor methods
+			=======================
 		*/
-		shouldAnimate: function () {
-			/*jshint -W093 */
-			return this.generated && (this._shouldAnimate = this._shouldAnimate || this.getPanels().length > 1 && this.animate);
-		},
 
 		/**
 		* Retrieves the currently displayed panel.
@@ -277,6 +257,25 @@
 		getActivePanel: function () {
 			return this._currentPanel;
 		},
+
+		/**
+		* Retrieves the panels currently part of this control.
+		*
+		* @return {Array} The set of panels.
+		* @public
+		*/
+		getPanels: function () {
+			/*jshint -W093 */
+			return (this._panels = this._panels || (this.controlParent || this).children);
+		},
+
+
+
+		/*
+			=====================
+			Public action methods
+			=====================
+		*/
 
 		/**
 		* Transitions to the previous panel--i.e., the panel whose index value is one
@@ -315,9 +314,8 @@
 		*
 		* @param {Object} info - The declarative {@glossary kind} definition.
 		* @param {Object} moreInfo - Additional properties to be applied (defaults).
-		* @param {Object} opts - Additional options to be used during panel pushing. If the
-		*	`forcePostTransition` option is truthy, post-transition work will be run immediately
-		*	after the creation of the panel.
+		* @param {enyo.LightPanels~PushPanelOptions} opts - Additional options to be used during
+		*	panel pushing.
 		* @return {Object} The instance of the panel that was created on top of the stack.
 		* @public
 		*/
@@ -327,8 +325,8 @@
 			}
 
 			var lastIndex = this.getPanels().length - 1,
-				nextPanel = (this.cachePanels && this.restorePanel(info.kind)) || this.createComponent(info, moreInfo);
-			if (this.cachePanels) {
+				nextPanel = (this.cacheViews && this.restoreView(info.kind)) || this.createComponent(info, moreInfo);
+			if (this.cacheViews) {
 				this.pruneQueue([info]);
 			}
 
@@ -351,10 +349,8 @@
 		*
 		* @param {Object[]} info - The declarative {@glossary kind} definitions.
 		* @param {Object} moreInfo - Additional properties to be applied (defaults).
-		* @param {Object} opts - Additional options for pushPanels. A `targetIndex` can be
-		*	specified as the index of the panel to display, otherwise the last panel created will
-		*	be displayed. Additionally, `forcePostTransition` can be specified to force
-		*	post-transition work to be run immediately after each panel is created.
+		* @param {enyo.LightPanels~PushPanelOptions} opts - Additional options to be used when
+		*	pushing multiple panels.
 		* @return {null|Object[]} Array of the panels that were created on top of the stack, or
 		*	`null` if panels could not be created.
 		* @public
@@ -369,8 +365,8 @@
 				newPanel, idx;
 
 			for (idx = 0; idx < info.length; idx++) {
-				if (!this.cachePanels || this.cachePanels && !this.panelExists(info[idx].kind)) {
-					newPanel = (this.cachePanels && this.restorePanel(info[idx].kind)) || this.createComponent(info[idx], moreInfo);
+				if (!this.cacheViews || this.cacheViews && !this.panelExists(info[idx].kind)) {
+					newPanel = (this.cacheViews && this.restoreView(info[idx].kind)) || this.createComponent(info[idx], moreInfo);
 					newPanels.push(newPanel);
 					if ((opts && opts.targetIndex != null && lastIndex + idx == opts.targetIndex) || idx == info.length - 1) {
 						newPanel.render();
@@ -380,34 +376,13 @@
 					}
 				}
 			}
-			if (this.cachePanels) {
+			if (this.cacheViews) {
 				this.pruneQueue(info);
 			}
 
 			this.set('index', (opts && opts.targetIndex != null) ? opts.targetIndex : lastIndex + newPanels.length - 1, true);
 
 			return newPanels;
-		},
-
-		/**
-		* @private
-		*/
-		getPanels: function () {
-			/*jshint -W093 */
-			return (this._panels = this._panels || (this.controlParent || this).children);
-		},
-
-		/**
-		* Determines whether or not the specified panel already exists as part of the current set of
-		* panels.
-		*
-		* @param {String} pid - The id of the panel to check.
-		* @private
-		*/
-		panelExists: function (pid) {
-			return !!(this.getPanels().filter( function (elem) {
-				return elem.kind == pid;
-			})).length;
 		},
 
 		/**
@@ -437,7 +412,7 @@
 		* Destroys the specified panel.
 		*
 		* @param {Number} index - The index of the panel to destroy.
-		* @param {Boolean} [preserve] - If {@link enyo.LightPanels#cachePanels} is `true`, this
+		* @param {Boolean} [preserve] - If {@link enyo.LightPanels#cacheViews} is `true`, this
 		*	value is used to determine whether or not to preserve the current panel's position in
 		*	the component hierarchy and on the screen, when caching.
 		* @public
@@ -447,165 +422,53 @@
 				panel = panels[index];
 
 			if (panel) {
-				if (this.cachePanels) {
-					this.cachePanel(panel, preserve);
+				if (this.cacheViews) {
+					this.cacheView(panel, preserve);
 				} else {
 					panel.destroy();
 				}
 			}
 		},
 
-		/**
-		* Destroys all panels. These will be queued for destruction after the next panel has loaded.
-		*
-		* @private
+
+
+		/*
+			============================================================
+			Public methods implementing the ViewPreloadSupport interface
+			============================================================
 		*/
-		purge: function () {
-			var panels = this.getPanels();
-			this._garbagePanels = panels.slice();
-			panels.length = 0;
-		},
 
 		/**
-		* Clean-up any panels queued for destruction.
+		* Determines the id of the given view.
 		*
-		* @private
+		* @param {Object} view - The view whose id we will determine.
+		* @return {String} The id of the given view.
+		* @public
 		*/
-		finalizePurge: function () {
-			var panels = this._garbagePanels,
-				panel;
-			while (panels.length) {
-				panel = panels.pop();
-				if (this.cachePanels) {
-					this.cachePanel(panel);
-				}
-				else {
-					panel.destroy();
-				}
-			}
+		getViewId: function (view) {
+			return view.kind || view.kindName;
 		},
 
 		/**
 		* Reset the state of the given panel. Currently resets the translated position of the panel.
 		*
-		* @param {Object} panel - The panel whose state we wish to reset.
+		* @param {Object} view - The panel whose state we wish to reset.
 		* @private
 		*/
-		resetPanel: function (panel) {
+		resetView: function (view) {
 			// reset position
 			var trans = {};
 			trans['translate' + this._axis] = '0%';
-			enyo.dom.transform(panel, trans);
+			enyo.dom.transform(view, trans);
 		},
 
-		/**
-		* Caches a given panel so that it can be quickly instantiated and utilized at a later point.
-		* This is typically performed on a panel which has already been rendered and which no longer
-		* needs to remain in view, but may be revisited at a later time.
-		*
-		* @param {Object} panel - The panel to cache for later use.
-		* @param {Boolean} preserve - If `true`, preserves the panel's position both on the screen
-		*	and within the component hierarchy.
-		* @public
+
+
+		/*
+			======================================
+			Public methods for queued task support
+			======================================
 		*/
-		cachePanel: function (panel, preserve) {
-			// TODO: This works for Settings use case,
-			// but we need to support an alternative
-			// identifier for panel-caching purposes
-			var pid = panel.kind;
-
-			// The panel could have already been removed from DOM and torn down if we popped when
-			// moving forward.
-			if (panel.node) {
-				panel.node.remove();
-				panel.teardownRender(true);
-			}
-
-			if (!preserve) {
-				this.resetPanel(panel);
-
-				this.removeControl(panel);
-				this.$.panelCache.addControl(panel);
-			}
-
-			this._cachedPanels[pid] = panel;
-		},
-
-		/**
-		* Restores the specified panel that was previously cached.
-		*
-		* @param {String} pid - The unique identifier for the cached panel that is being restored.
-		* @return {Object} The restored panel.
-		* @public
-		*/
-		restorePanel: function (pid) {
-			var cp = this._cachedPanels,
-				panel = cp[pid];
-
-			if (panel) {
-				this.$.panelCache.removeControl(panel);
-				this.addControl(panel);
-
-				this._cachedPanels[pid] = null;
-			}
-
-			return panel;
-		},
-
-		/**
-		* Pre-caches a set of panels by creating and caching them, even if they have not yet been
-		* rendered into view. This is helpful for reducing the instantiation time for panels which
-		* have yet to be shown, but can and eventually will be shown to the user.
-		*
-		* @param {Object} info - The declarative {@glossary kind} definition.
-		* @param {Object} commonInfo - Additional properties to be applied (defaults).
-		* @param {Boolean} runPostTransition - If `true`, the {@link enyo.LightPanel#postTransition}
-		*	method will be run.
-		* @public
-		*/
-		preCachePanels: function(info, commonInfo, runPostTransition) {
-			var pc, panels, i, panel;
-
-			if (this.cachePanels) {
-				pc = this.$.panelCache;
-				commonInfo = commonInfo || {};
-				commonInfo.owner = this;
-				panels = pc.createComponents(info, commonInfo);
-				for (i = 0; i < panels.length; i++) {
-					panel = panels[i];
-					this._cachedPanels[panel.kind] = panel;
-					if (runPostTransition && panel.postTransition) {
-						panel.postTransition();
-					}
-				}
-			}
-		},
-
-		/**
-		* Pre-caches a single panel by creating and caching the panel, even if it has not yet been
-		* rendered into view. This is helpful for reducing the instantiation time for panels which
-		* have yet to be shown, but can and eventually will be shown to the user.
-		*
-		* @param {Object} info - The declarative {@glossary kind} definition.
-		* @param {Object} commonInfo - Additional properties to be applied (defaults).
-		* @param {Boolean} runPostTransition - If `true`, the {@link enyo.LightPanel#postTransition}
-		*	method will be run.
-		* @public
-		*/
-		preCachePanel: function(info, commonInfo, runPostTransition) {
-			var pc, panel;
-
-			if (this.cachePanels && !this._cachedPanels[info.kind]) {
-				pc = this.$.panelCache;
-				commonInfo = commonInfo || {};
-				commonInfo.owner = this;
-				panel = pc.createComponent(info, commonInfo);
-				this._cachedPanels[panel.kind] = panel;
-				if (runPostTransition && panel.postTransition) {
-					panel.postTransition();
-				}
-			}
-		},
 
 		/**
 		* Enqueues a view that will eventually be pre-cached at an opportunistic time.
@@ -633,41 +496,32 @@
 			}
 		},
 
-		/**
-		*
+
+
+		/*
+			=================
+			Protected methods
+			=================
 		*/
-		isViewQueued: function (id) {
-			return this._cachedPanels[id];
-		},
 
 		/**
-		* Starts a job to cache a given view at an opportune time.
+		* Determines whether or not we should animate the panel transition.
 		*
-		* @param {String} viewProps - The properties of the view to be enqueued.
-		* @param {Number} [delay] - The delay in ms before starting the job to cache the view.
-		* @param {Number} [priority] - The priority of the job.
-		* @private
+		* @return {Boolean} If `true`, the panels should animate.
+		* @protected
 		*/
-		startViewCacheJob: function (viewProps, delay, priority) {
-			this.startJob(viewProps.kind, function () {
-				// TODO: once the data layer is hooked into the run loop, we should no longer need
-				// to forcibly trigger the post transition work.
-				this.preCachePanel(viewProps, {}, true);
-			}, delay || this.delay, priority || this.priority);
+		shouldAnimate: function () {
+			/*jshint -W093 */
+			return this.generated && (this._shouldAnimate = this._shouldAnimate || this.getPanels().length > 1 && this.animate);
 		},
 
-		/**
-		* Prunes the queue of to-be-cached panels in the event that any panels in the queue have
-		* already been instanced.
-		*
-		* @param {String} viewProps - The properties of the view to be enqueued.
-		* @private
+
+
+		/*
+			==============
+			Event handlers
+			==============
 		*/
-		pruneQueue: function (viewProps) {
-			for (var idx = 0; idx < viewProps.length; idx++) {
-				this.stopJob(viewProps[idx].kind);
-			}
-		},
 
 		/**
 		* @private
@@ -691,6 +545,114 @@
 				if (this._garbagePanels && this._garbagePanels.length) {
 					this.finalizePurge();
 				}
+			}
+		},
+
+
+
+		/*
+			=======================
+			Private support methods
+			=======================
+		*/
+
+		/**
+		* Sets up the transitions between the current and next panel.
+		*
+		* @param {Object} nextPanel - The panel we are transitioning to.
+		* @private
+		*/
+		setupTransitions: function (nextPanel) {
+			// setup the transition for the next panel
+			var nextTransition = {};
+			nextTransition['translate' + this._axis] = -100 * this._direction + '%';
+			enyo.dom.transform(nextPanel, nextTransition);
+			if (this._currentPanel) { // setup the transition for the current panel
+				var currentTransition = {};
+				currentTransition['translate' + this._axis] = this._indexDirection > 0 ? -200 * this._direction + '%' : '0%';
+				enyo.dom.transform(this._currentPanel, currentTransition);
+			}
+
+			this._previousPanel = this._currentPanel;
+			this._currentPanel = nextPanel;
+			if (!this.shouldAnimate()) { // ensure that `transitionFinished is called, regardless of animation
+				this.transitionFinished(this._currentPanel, {originator: this._currentPanel});
+			}
+		},
+
+		/**
+		* Determines whether or not the specified panel already exists as part of the current set of
+		* panels.
+		*
+		* @param {String} pid - The id of the panel to check.
+		* @private
+		*/
+		panelExists: function (pid) {
+			return !!(this.getPanels().filter( function (elem) {
+				return elem.kind == pid;
+			})).length;
+		},
+
+		/**
+		* Destroys all panels. These will be queued for destruction after the next panel has loaded.
+		*
+		* @private
+		*/
+		purge: function () {
+			var panels = this.getPanels();
+			this._garbagePanels = panels.slice();
+			panels.length = 0;
+		},
+
+		/**
+		* Clean-up any panels queued for destruction.
+		*
+		* @private
+		*/
+		finalizePurge: function () {
+			var panels = this._garbagePanels,
+				panel;
+			while (panels.length) {
+				panel = panels.pop();
+				if (this.cacheViews) {
+					this.cacheView(panel);
+				}
+				else {
+					panel.destroy();
+				}
+			}
+		},
+
+		/**
+		* Starts a job to cache a given view at an opportune time.
+		*
+		* @param {String} viewProps - The properties of the view to be enqueued.
+		* @param {Number} [delay] - The delay in ms before starting the job to cache the view.
+		* @param {Number} [priority] - The priority of the job.
+		* @private
+		*/
+		startViewCacheJob: function (viewProps, delay, priority) {
+			this.startJob(viewProps.kind, function () {
+				// TODO: once the data layer is hooked into the run loop, we should no longer need
+				// to forcibly trigger the post transition work.
+				this.preCacheView(viewProps, {}, function (view) {
+					if (view.postTransition) {
+						view.postTransition();
+					}
+				});
+			}, delay || this.delay, priority || this.priority);
+		},
+
+		/**
+		* Prunes the queue of to-be-cached panels in the event that any panels in the queue have
+		* already been instanced.
+		*
+		* @param {String} viewProps - The properties of the view to be enqueued.
+		* @private
+		*/
+		pruneQueue: function (viewProps) {
+			for (var idx = 0; idx < viewProps.length; idx++) {
+				this.stopJob(viewProps[idx].kind);
 			}
 		}
 

--- a/source/ui/ViewPreloadSupport.js
+++ b/source/ui/ViewPreloadSupport.js
@@ -95,10 +95,7 @@
 		* @public
 		*/
 		cacheView: function (view, preserve) {
-			// TODO: This works for Settings use case,
-			// but we need to support an alternative
-			// identifier for panel-caching purposes
-			var id = this.getViewId();
+			var id = this.getViewId(view);
 
 			// The panel could have already been removed from DOM and torn down if we popped when
 			// moving forward.
@@ -150,13 +147,13 @@
 		* @public
 		*/
 		preCacheViews: function(info, commonInfo, cbComplete) {
-			var pc, views, i, view;
+			var vc, views, i, view;
 
 			if (this.cacheViews) {
-				pc = this.$.viewCache;
+				vc = this.$.viewCache;
 				commonInfo = commonInfo || {};
 				commonInfo.owner = this;
-				views = pc.createComponents(info, commonInfo);
+				views = vc.createComponents(info, commonInfo);
 				for (i = 0; i < views.length; i++) {
 					view = views[i];
 					this._cachedViews[this.getViewId(view)] = view;
@@ -179,13 +176,13 @@
 		* @public
 		*/
 		preCacheView: function(info, commonInfo, cbComplete) {
-			var pc, view;
+			var vc, view;
 
 			if (this.cacheViews && !this._cachedViews[info.kind]) {
-				pc = this.$.viewCache;
+				vc = this.$.viewCache;
 				commonInfo = commonInfo || {};
 				commonInfo.owner = this;
-				view = pc.createComponent(info, commonInfo);
+				view = vc.createComponent(info, commonInfo);
 				this._cachedViews[this.getViewId(info)] = view;
 				if (cbComplete) {
 					cbComplete.call(this, view);

--- a/source/ui/ViewPreloadSupport.js
+++ b/source/ui/ViewPreloadSupport.js
@@ -1,0 +1,198 @@
+(function (enyo, scope) {
+
+	/** @lends enyo.ViewPreloadSupport.prototype */
+	enyo.ViewPreloadSupport = {
+
+		/**
+		* @method
+		* @private
+		*/
+		name: 'enyo.ViewPreloadSupport',
+
+		/**
+		* @private
+		*/
+		published: {
+
+			/**
+			* When `true`, existing views are cached for reuse, otherwise they are destroyed.
+			*
+			* @type {Boolean}
+			* @default true
+			* @public
+			*/
+			cacheViews: true
+		},
+
+		/**
+		* @method
+		* @private
+		*/
+		create: enyo.inherit(function (sup) {
+			return function () {
+				sup.apply(this, arguments);
+
+				if (this.cacheViews) {
+					this.createChrome([
+						{name: 'viewCache', kind: 'enyo.Control', canGenerate: false}
+					]);
+					this.removeChild(this.$.viewCache);
+					this._cachedViews = {};
+				}
+			};
+		}),
+
+
+		/*
+			===================================
+			Interface methods to be implemented
+			===================================
+		*/
+
+		/**
+		* Determines the id of the given view. This is something that should generally be
+		* implemented in the actual kind as this will vary from case to case.
+		*
+		* @param {Object} view - The view whose id we will determine.
+		* @return {String} The id of the given view.
+		* @public
+		*/
+		getViewId: enyo.inherit(function (sup) {
+			return function (view) {
+				return sup.apply(this, arguments);
+			};
+		}),
+
+		/**
+		* Reset the state of the given view. This is something that should generally be implemented
+		* in the actual kind.
+		*
+		* @param {Object} view - The view whose state we wish to reset.
+		* @private
+		*/
+		resetView: enyo.inherit(function (sup) {
+			return function (view) {
+				return sup.apply(this, arguments);
+			};
+		}),
+
+
+
+		/*
+			==============
+			Public methods
+			==============
+		*/
+
+		/**
+		* Caches a given view so that it can be quickly instantiated and utilized at a later point.
+		* This is typically performed on a view which has already been rendered and which no longer
+		* needs to remain in view, but may be revisited at a later time.
+		*
+		* @param {Object} view - The view to cache for later use.
+		* @param {Boolean} preserve - If `true`, preserves the view's position both on the screen
+		*	and within the component hierarchy.
+		* @public
+		*/
+		cacheView: function (view, preserve) {
+			// TODO: This works for Settings use case,
+			// but we need to support an alternative
+			// identifier for panel-caching purposes
+			var id = this.getViewId();
+
+			// The panel could have already been removed from DOM and torn down if we popped when
+			// moving forward.
+			if (view.node) {
+				view.node.remove();
+				view.teardownRender(true);
+			}
+
+			if (!preserve) {
+				this.resetView(view);
+
+				this.removeControl(view);
+				this.$.viewCache.addControl(view);
+			}
+
+			this._cachedViews[id] = view;
+		},
+
+		/**
+		* Restores the specified view that was previously cached.
+		*
+		* @param {String} id - The unique identifier for the cached view that is being restored.
+		* @return {Object} The restored view.
+		* @public
+		*/
+		restoreView: function (id) {
+			var cp = this._cachedViews,
+				view = cp[id];
+
+			if (view) {
+				this.$.viewCache.removeControl(view);
+				this.addControl(view);
+
+				this._cachedViews[id] = null;
+			}
+
+			return view;
+		},
+
+		/**
+		* Pre-caches a set of views by creating and caching them, even if they have not yet been
+		* rendered into view. This is helpful for reducing the instantiation time for views which
+		* have yet to be shown, but can and eventually will be shown to the user.
+		*
+		* @param {Object} info - The declarative {@glossary kind} definition.
+		* @param {Object} commonInfo - Additional properties to be applied (defaults).
+		* @param {Boolean} [cbComplete] - If specified, this callback will be executed, with the
+		*	created view being passed as a parameter.
+		* @public
+		*/
+		preCacheViews: function(info, commonInfo, cbComplete) {
+			var pc, views, i, view;
+
+			if (this.cacheViews) {
+				pc = this.$.viewCache;
+				commonInfo = commonInfo || {};
+				commonInfo.owner = this;
+				views = pc.createComponents(info, commonInfo);
+				for (i = 0; i < views.length; i++) {
+					view = views[i];
+					this._cachedViews[this.getViewId(view)] = view;
+					if (cbComplete) {
+						cbComplete.call(this, view);
+					}
+				}
+			}
+		},
+
+		/**
+		* Pre-caches a single view by creating and caching the view, even if it has not yet been
+		* rendered into view. This is helpful for reducing the instantiation time for panels which
+		* have yet to be shown, but can and eventually will be shown to the user.
+		*
+		* @param {Object} info - The declarative {@glossary kind} definition.
+		* @param {Object} commonInfo - Additional properties to be applied (defaults).
+		* @param {Function} [cbComplete] - If specified, this callback will be executed, with the
+		*	created view being passed as a parameter.
+		* @public
+		*/
+		preCacheView: function(info, commonInfo, cbComplete) {
+			var pc, view;
+
+			if (this.cacheViews && !this._cachedViews[info.kind]) {
+				pc = this.$.viewCache;
+				commonInfo = commonInfo || {};
+				commonInfo.owner = this;
+				view = pc.createComponent(info, commonInfo);
+				this._cachedViews[this.getViewId(info)] = view;
+				if (cbComplete) {
+					cbComplete.call(this, view);
+				}
+			}
+		}
+
+	};
+
+})(enyo, this);

--- a/source/ui/wip-package.js
+++ b/source/ui/wip-package.js
@@ -5,5 +5,6 @@
 * and are subject to future changes, so you may use these only "at your own risk".
 */
 enyo.depends(
+	'ViewPreloadSupport.js',
 	'LightPanels.js'
 );


### PR DESCRIPTION
- Factored out view-caching support into a mixin.
- Added support for specifying a direct transition option when pushing a panel or panels.
- General clean-up and code reorganization.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>