### PR TITLE
ENYO-944: Update sample, further optimize pushPanels.

### DIFF
--- a/samples/LightPanelsSample.html
+++ b/samples/LightPanelsSample.html
@@ -10,6 +10,7 @@
 	<title>LightPanels Sample</title>
 	<!-- -->
 	<script src="../../enyo/enyo.js" type="text/javascript"></script>
+	<script src="../../enyo/source/kernel/wip-package.js" type="text/javascript"></script>
 	<script src="../../enyo/source/ui/wip-package.js" type="text/javascript"></script>
 	<script src="../../lib/layout/package.js" type="text/javascript"></script>
 	<!-- -->

--- a/source/ui/LightPanels.js
+++ b/source/ui/LightPanels.js
@@ -327,18 +327,16 @@
 				newPanel, targetIdx, compareIdx, idx;
 
 			for (idx = 0; idx < info.length; idx++) {
-				if (!this.cacheViews || this.cacheViews && !this.panelExists(info[idx].kind)) {
-					newPanel = (this.cacheViews && this.restoreView(info[idx].kind)) || this.createComponent(info[idx], moreInfo);
-					newPanels.push(newPanel);
-					if ((opts && opts.targetIndex != null && lastIndex + idx == opts.targetIndex) || idx == info.length - 1) {
-						newPanel.render();
-					} else {
-						compareIdx = opts && opts.targetIndex != null ? opts.targetIndex : lastIndex + info.length;
-						this.shiftPanel(newPanel, compareIdx - this.index);
-					}
-					if (opts && opts.forcePostTransition && newPanel.postTransition) {
-						newPanel.postTransition();
-					}
+				newPanel = (this.cacheViews && this.restoreView(info[idx].kind)) || this.createComponent(info[idx], moreInfo);
+				newPanels.push(newPanel);
+				if ((opts && opts.targetIndex != null && lastIndex + idx == opts.targetIndex) || idx == info.length - 1) {
+					newPanel.render();
+				} else {
+					compareIdx = opts && opts.targetIndex != null ? opts.targetIndex : lastIndex + info.length;
+					this.shiftPanel(newPanel, compareIdx - this.index);
+				}
+				if (opts && opts.forcePostTransition && newPanel.postTransition) {
+					newPanel.postTransition();
 				}
 			}
 			if (this.cacheViews) {
@@ -608,19 +606,6 @@
 			var trans = {};
 			trans['translate' + this._axis] = indexDirection > 0 ? -200 * this._direction + '%' : '0%';
 			enyo.dom.transform(panel, trans);
-		},
-
-		/**
-		* Determines whether or not the specified panel already exists as part of the current set of
-		* panels.
-		*
-		* @param {String} pid - The id of the panel to check.
-		* @private
-		*/
-		panelExists: function (pid) {
-			return !!(this.getPanels().filter( function (elem) {
-				return elem.kind == pid;
-			})).length;
 		},
 
 		/**


### PR DESCRIPTION
### Issue
Two issues addressed here. The first issue is that we moved some of the BTM-related kinds to a wip-package and the `LightPanelsSample` needed to reference this manifest. The second issue is that for each call to `pushPanels`, there are multiple calls to an expensive `panelExists` method. This is partially cruft and partially stop-gap for how we are dealing with routing in the app. This stop-gap should not be part of `enyo.LightPanels` anyways, and has been addressed in the app code.

### Fix
The sample has been updated to reference the manifest, and `enyo.LightPanels` has been cleaned-up with the removal of `panelExists` and the associated calls to this method.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>