### PR TITLE
Clean-up post-transition logic.

### DIFF
--- a/source/ui/LightPanels.js
+++ b/source/ui/LightPanels.js
@@ -505,8 +505,7 @@
 					(this._indexDirection > 0 && this.popOnForward && this.index > 0)) {
 					this.popPanels(this.index - this._indexDirection, this._indexDirection);
 				}
-				if (this._currentPanel.shouldSkipPostTransition && !this._currentPanel.shouldSkipPostTransition()
-					&& this._currentPanel.postTransition) {
+				if (this._currentPanel.postTransition) {
 					enyo.asyncMethod(this, function () {
 						this._currentPanel.postTransition();
 					});


### PR DESCRIPTION
### Issue
We no longer need to use `shouldSkipPostTransition`.

### Fix
The call to `shouldSkipPostTransition` has been removed.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>