### PR TITLE
Update LightPanels

### DIFF
--- a/samples/LightPanelsSample.html
+++ b/samples/LightPanelsSample.html
@@ -10,8 +10,7 @@
 	<title>LightPanels Sample</title>
 	<!-- -->
 	<script src="../../enyo/enyo.js" type="text/javascript"></script>
-	<script src="../../enyo/source/kernel/wip-package.js" type="text/javascript"></script>
-	<script src="../../enyo/source/ui/wip-package.js" type="text/javascript"></script>
+	<script src="../../enyo/source/2.6.0-pre.4-wip-package.js"></script>
 	<script src="../../lib/layout/package.js" type="text/javascript"></script>
 	<!-- -->
 	<link href="LightPanelsSample.css" rel="stylesheet">

--- a/source/ui/LightPanels.js
+++ b/source/ui/LightPanels.js
@@ -292,7 +292,7 @@
 				nextPanel.postTransition();
 			}
 
-			if (!opts || opts.direct) {
+			if (opts && opts.direct) {
 				var currentIndex = this.index;
 				this.index = newIndex;
 				this.setupTransitions(currentIndex, false);
@@ -345,7 +345,7 @@
 
 			targetIdx = (opts && opts.targetIndex != null) ? opts.targetIndex : lastIndex + newPanels.length - 1;
 
-			if (!opts || opts.direct) {
+			if (opts && opts.direct) {
 				var currentIndex = this.index;
 				this.index = targetIdx;
 				this.setupTransitions(currentIndex, false);


### PR DESCRIPTION
### Issue
The sample was referencing outdated manifests. Additionally, pushing a panel did not result in any animation occurring.

### Fix
The sample's manifest has been updated to point to the combined manifest for `2.6.0-pre.4`. Additionally, a fix has been made so that directly pushing panels (versus pre-caching them) results in a transition animation.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>