### PR TITLE
Remove unnecessary call to shouldSkipPostTransition.

### DIFF
--- a/source/ui/LightPanels.js
+++ b/source/ui/LightPanels.js
@@ -503,8 +503,7 @@
 					(this._indexDirection > 0 && this.popOnForward && this.index > 0)) {
 					this.popPanels(this.index - this._indexDirection, this._indexDirection);
 				}
-				if (this._currentPanel.shouldSkipPostTransition && !this._currentPanel.shouldSkipPostTransition()
-					&& this._currentPanel.postTransition) {
+				if (this._currentPanel.postTransition) {
 					enyo.asyncMethod(this, function () {
 						this._currentPanel.postTransition();
 					});


### PR DESCRIPTION
### Issue
Based on some clean-up in https://github.com/enyojs/moonstone/pull/2066, we no longer need an explicit call to `shouldSkipPostTransition`.

### Fix
The call to `shouldSkipPostTransition` has been removed.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>