### PR TITLE
Prevent forcing an index change.

### DIFF
--- a/source/ui/LightPanels.js
+++ b/source/ui/LightPanels.js
@@ -54,10 +54,10 @@
 			* The index of the active panel.
 			*
 			* @type {Number}
-			* @default 0
+			* @default -1
 			* @public
 			*/
-			index: 0,
+			index: -1,
 
 			/**
 			* Indicates whether the panels animate when transitioning.
@@ -297,7 +297,7 @@
 				this.index = newIndex;
 				this.setupTransitions(currentIndex, false);
 			} else {
-				this.set('index', newIndex, true);
+				this.set('index', newIndex);
 			}
 
 			// TODO: When pushing panels after we have gone back (but have not popped), we need to
@@ -350,7 +350,7 @@
 				this.index = targetIdx;
 				this.setupTransitions(currentIndex, false);
 			} else {
-				this.set('index', targetIdx, true);
+				this.set('index', targetIdx);
 			}
 
 			return newPanels;


### PR DESCRIPTION
### Issue
We had originally been forcing an index change when pushing a panel(s).

### Fix
This was some crufty logic because the initial index value is `0`. This has been changed to default to `-1`, which corresponds to not inaccurately having an index value of `0` when there are no panels.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>