### PR TITLE
Reset panel index when purging.

### DIFF
--- a/source/ui/LightPanels.js
+++ b/source/ui/LightPanels.js
@@ -620,6 +620,7 @@
 			var panels = this.getPanels();
 			this._garbagePanels = panels.slice();
 			panels.length = 0;
+			this.index = -1;
 		},
 
 		/**


### PR DESCRIPTION
### Issue
We made a previous fix to prevent the unnecessary forcing of an index change when pushing a panel or panels, but this prevented switching of panels in the purge state, as the panel index remained at `0` in this case.

### Fix
When purging, we reset the panel index to the default value of `-1`.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>