### PR TITLE
ENYO-1441 : modify resolution update routine for removing old resolution classes

### DIFF
--- a/source/dom/resolution.js
+++ b/source/dom/resolution.js
@@ -7,9 +7,9 @@
 		_screenTypeObject,
 		_oldScreenType;
 
-	var getScreenTypeObject = function (type, ignoreCache) {
+	var getScreenTypeObject = function (type) {
 		type = type || _screenType;
-		if (type == _screenType && !ignoreCache && _screenTypeObject) {
+		if (_screenTypeObject && _screenTypeObject.name == type) {
 			return _screenTypeObject;
 		}
 		return _screenTypes.filter(function (elem) {
@@ -238,7 +238,7 @@
 		init: function () {
 			_oldScreenType = _screenType;
 			_screenType = this.getScreenType();
-			_screenTypeObject = getScreenTypeObject(_screenType, true);
+			_screenTypeObject = getScreenTypeObject();
 			this.updateScreenBodyClasses();
 			enyo.dom.unitToPixelFactors.rem = this.getUnitToPixelFactors();
 			_riRatio = this.getRiRatio();

--- a/source/dom/resolution.js
+++ b/source/dom/resolution.js
@@ -7,8 +7,11 @@
 		_screenTypeObject,
 		_oldScreenType;
 
-	var getScreenTypeObject = function (type) {
+	var getScreenTypeObject = function (type, ignoreCache) {
 		type = type || _screenType;
+		if (type == _screenType && !ignoreCache && _screenTypeObject) {
+			return _screenTypeObject;
+		}
 		return _screenTypes.filter(function (elem) {
 			return (type == elem.name);
 		})[0];
@@ -235,7 +238,7 @@
 		init: function () {
 			_oldScreenType = _screenType;
 			_screenType = this.getScreenType();
-			_screenTypeObject = getScreenTypeObject();
+			_screenTypeObject = getScreenTypeObject(_screenType, true);
 			this.updateScreenBodyClasses();
 			enyo.dom.unitToPixelFactors.rem = this.getUnitToPixelFactors();
 			_riRatio = this.getRiRatio();

--- a/source/dom/resolution.js
+++ b/source/dom/resolution.js
@@ -4,13 +4,11 @@
 		_riRatio,
 		_screenType,
 		_screenTypes = [ {name: 'standard', pxPerRem: 16, width: scope.innerWidth,  height: scope.innerHeight, aspectRatioName: 'standard'} ],	// Assign one sane value in case defineScreenTypes is never run.
-		_screenTypeObject;
+		_screenTypeObject,
+		_oldScreenType;
 
 	var getScreenTypeObject = function (type) {
 		type = type || _screenType;
-		if (type == _screenType && _screenTypeObject) {
-			return _screenTypeObject;
-		}
 		return _screenTypes.filter(function (elem) {
 			return (type == elem.name);
 		})[0];
@@ -85,6 +83,13 @@
 		*/
 		updateScreenBodyClasses: function (type) {
 			type = type || _screenType;
+			if (_oldScreenType) {
+				enyo.dom.removeClass(document.body, 'enyo-res-' + _oldScreenType.toLowerCase());
+				var oldScrObj = getScreenTypeObject(_oldScreenType);
+				if (oldScrObj.aspectRatioName) {
+					enyo.dom.removeClass(document.body, 'enyo-aspect-ratio-' + oldScrObj.aspectRatioName.toLowerCase());
+				}
+			}
 			if (type) {
 				enyo.dom.addBodyClass('enyo-res-' + type.toLowerCase());
 				var scrObj = getScreenTypeObject(type);
@@ -228,6 +233,7 @@
 		*/
 		// Later we can wire this up to a screen resize event so it doesn't need to be called manually.
 		init: function () {
+			_oldScreenType = _screenType;
 			_screenType = this.getScreenType();
 			_screenTypeObject = getScreenTypeObject();
 			this.updateScreenBodyClasses();


### PR DESCRIPTION
## issue
moon.ri.init() function needs a line for removing ScreenTypeOnBody
moon.ri.getScreenTypeObject always return old screenTypeObject if there is no parameter

## fix
added oldScreenType variable for for checking and removing old resolution classes.
and removed caching routine in getScreenTypeObject function.
(this is a copy of https://github.com/enyojs/moonstone/pull/2074 for master branch)

Enyo-DCO-1.1-Signed-off-by: Sungbae Cho sb.cho@lge.com