### PR TITLE
Update default priority to be part of mixin.

### DIFF
--- a/source/kernel/TaskManagerSupport.js
+++ b/source/kernel/TaskManagerSupport.js
@@ -34,6 +34,15 @@
 		managed: false,
 
 		/**
+		* The default priority for added tasks.
+		*
+		* @type {Number}
+		* @default enyo.Priorities.SOMETIME
+		* @public
+		*/
+		defaultPriority: enyo.Priorities.SOMETIME,
+
+		/**
 		* @method
 		* @private
 		*/

--- a/source/ui/LightPanels.js
+++ b/source/ui/LightPanels.js
@@ -130,16 +130,7 @@
 			* @default 'forwards'
 			* @public
 			*/
-			direction: 'forwards',
-
-			/**
-			* The default priority for view caching jobs.
-			*
-			* @type {Number}
-			* @default enyo.Priorities.SOMETIME
-			* @public
-			*/
-			priority: enyo.Priorities.SOMETIME
+			direction: 'forwards'
 		},
 
 		/**
@@ -670,7 +661,7 @@
 						view.postTransition();
 					}
 				});
-			}, priority || this.priority, 'PRE-CACHE:' + viewProps.kind);
+			}, priority || this.defaultPriority, 'PRE-CACHE:' + viewProps.kind);
 		},
 
 		/**


### PR DESCRIPTION
### Issue
Each task manager would have to set their own default priority.

### Fix
We include a standard default priority as part of the `TaskManagerSupport` mixin.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>