### PR TITLE
ENYO-1454: Fix threshold stabilization in NewDataList

### DIFF
--- a/source/ui/data/NewDataList.js
+++ b/source/ui/data/NewDataList.js
@@ -128,8 +128,14 @@
 				this.set('first', this.first - (st * this.dim2extent));
 			}
 			if (tt.max > maxVal) {
-				tt.max = maxVal;
-				tt.min = maxMin;
+				if (maxVal < minMax) {
+					tt.max = minMax;
+					tt.min = -Infinity;
+				}
+				else {
+					tt.max = maxVal;
+					tt.min = maxMin;
+				}
 			}
 			this.positionChildren();
 		},


### PR DESCRIPTION
We recently added some code to stabilize (bring within range) the
scroll threshold values in cases where the list size has just
changed (a fix for ENYO-1349).

This fix wasn't working properly in the case where the list was
entirely or nearly emptied, so accounting for that case now.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)