### PR TITLE
Enyo 1452 Use accurate childSize to prevent blank page

### DIFF
--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -226,18 +226,25 @@
 		* @private
 		*/
 		childSize: function (list) {
-			if (!list.fixedChildSize) {
-				var pageIndex = list.$.page1.index,
+			if (!list.fixedChildSize || !list.childSize) {
+				var page = list.$.page1,
 					sizeProp  = list.psizeProp,
 					n         = list.$.page1.node || list.$.page1.hasNode(),
 					size, props;
-				if (pageIndex >= 0 && n) {
-					props = list.metrics.pages[pageIndex];
-					size  = props? props[sizeProp]: 0;
-					list.childSize = Math.floor(size / (n.children.length || 1));
+				if (page.index >= 0 && n) {
+					// if indexed page was not generated ever, it will return 'undefined'
+					props = list.metrics.pages[page.index];
+					if (!props) {
+						page.start = page.end = 0;
+						this.updatePage(list, page);
+						list.childSize = page.getBounds()[sizeProp];
+					} else {
+						size  = props[sizeProp];
+						list.childSize = Math.floor(size / (n.children.length || 1));
+					}
 				}
 			}
-			return list.fixedChildSize || list.childSize || (list.childSize = 100); // we have to start somewhere
+			return list.fixedChildSize || list.childSize;
 		},
 
 		/**

--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -135,36 +135,19 @@
 			// want to do any more initialization
 			if (list.collection && list.collection.length) { this.reset(list); }
 		},
+
 		/**
-		* Generates the markup for the page content.
+		* Update page with model
 		*
 		* @private
 		*/
-		generatePage: function (list, page, index) {
-			// Temporarily add logging code to make it easier for
-			// QA and others to detect and report page-index issues
-			if (index < 0) {
-				enyo.warn('Invalid page index: ' + index);
-			}
-			// in case it hasn't been set we ensure it is marked correctly
-			page.index  = index;
-				// the collection of data with records to use
-			var data    = list.collection,
-				// the metrics for the entire list
-				metrics = list.metrics,
-				// controls per page
-				perPage = this.controlsPerPage(list),
-				// placeholder for the control we're going to update
+		updatePage: function(list, page) {
+			var data = list.collection,
+			// placeholder for the control we're going to update
 				view;
-
-			// the first index for this generated page
-			page.start  = perPage * index;
-			// the last index for this generated page
-			page.end    = Math.min((data.length - 1), (page.start + perPage) - 1);
-
 			// if generating a control we need to use the correct page as the control parent
 			list.controlParent = page;
-			for (var i=page.start; i <= page.end && i < data.length; ++i) {
+			for (var i = page.start; i <= page.end && i < data.length; ++i) {
 				view = (page.children[i - page.start] || list.createComponent({}));
 				// disable notifications until all properties to be updated
 				// have been
@@ -186,6 +169,35 @@
 			// update the entire page at once - this removes old nodes and updates
 			// to the correct ones
 			page.render();
+		},
+
+		/**
+		* Generates the markup for the page content.
+		*
+		* @private
+		*/
+		generatePage: function (list, page, index) {
+			// Temporarily add logging code to make it easier for
+			// QA and others to detect and report page-index issues
+			if (index < 0) {
+				enyo.warn('Invalid page index: ' + index);
+			}
+			// in case it hasn't been set we ensure it is marked correctly
+			page.index  = index;
+				// the collection of data with records to use
+			var data    = list.collection,
+				// the metrics for the entire list
+				metrics = list.metrics,
+				// controls per page
+				perPage = this.controlsPerPage(list);
+
+			// the first index for this generated page
+			page.start  = perPage * index;
+			// the last index for this generated page
+			page.end    = Math.min((data.length - 1), (page.start + perPage) - 1);
+
+			this.updatePage(list, page);
+
 			// now to update the metrics
 			metrics        = metrics.pages[index] || (metrics.pages[index] = {});
 			metrics.height = this.pageHeight(list, page);

--- a/source/ui/data/VerticalDelegate.js
+++ b/source/ui/data/VerticalDelegate.js
@@ -399,6 +399,10 @@
 		* @private
 		*/
 		modelsAdded: function (list, props) {
+			// new added models could have different childSize.
+			if (list.childSize) {
+				list.childSize = null;
+			}
 
 			// if the list has not already reset, reset
 			if (!list.hasReset) return this.reset(list);


### PR DESCRIPTION
Issue
------
DataList show blank page when actual childSize is less than 100px

Cause
-------
Without fixedChildSize, DataList could not know what is actual childSize. 
So, childSize() uses assumed childSize like 100px
A controlsPerPage is decided based on assumed childSize and PageSize is calculated with childSize and controlsPerPage.  
Here is clue of blank issue.

To guarantee proper page adjusting behavior, pageSize should be larger than viewport size.
Because of that, we have pageSizeMultiplier.
However, if actual childSize is smaller than assumed childSize, pageSize could be smaller than viewport size.

Fix
----
Rendering a single child on blank page is enough condition to check accurate childSize.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
