### PR TITLE
ENYO-1124: Accessibility: Add "accessibilityAlert" to enyo control

### DIFF
--- a/source/dom/accessibility.js
+++ b/source/dom/accessibility.js
@@ -26,6 +26,21 @@
 			accessibilityHint: '',
 
 			/**
+			* AccessibilityAlert is for alert message or page description.
+			* If accessibilityAlert is true, screen reader will automatically reads
+			* content or accessibilityLabel regardless focus.
+			*
+			* Range: [`true`, `false`]
+			* - true: screen reader automatically reads label regardless focus.
+			* - false: screen reader reads label with focus.
+			*
+			* @type {Boolean}
+			* @default false
+			* @public
+			*/
+			accessibilityAlert: false,
+
+			/**
 			* @method
 			* @private
 			*/
@@ -46,6 +61,10 @@
 
 				if (this.accessibilityHint) {
 					this.accessibilityHintChanged();
+				}
+
+				if (this.accessibilityAlert) {
+					this.accessibilityAlertChanged();
 				}
 			},
 
@@ -151,6 +170,46 @@
 				} else {
 					this.setAttribute('tabindex', this.accessibilityHint? 0 : null);
 					this.setAttribute('aria-label', this.accessibilityHint? this.accessibilityHint : null);
+				}
+			},
+
+			/**
+			* Get the accessibilityAlert value true or false.
+			*
+			* @returns {Boolean} return accessibilityAlert status.
+			* @public
+			*/
+			getAccessibilityAlert: function () {
+				return this.accessibilityAlert;
+			},
+
+			/**
+			* Set the accessibilityAlert to true or false.
+			* If accessibilityAlert is true, screen reader will automatically reads
+			* content or accessibilityLabel regardless focus.
+			*
+			* @param {Boolean} accessibilityAlert - if true, screen reader reads content automatically.
+			* @returns {this} callee for chaining.
+			* @public
+			*/
+			setAccessibilityAlert: function (accessibilityAlert) {
+				var was = this.accessibilityAlert;
+				this.accessibilityAlert = accessibilityAlert;
+
+				if (was != accessibilityAlert) {
+					this.notify('accessibilityAlert', was, accessibilityAlert);
+				}
+				return this;
+			},
+
+			/**
+			* @private
+			*/
+			accessibilityAlertChanged: function () {
+				if (this.accessibilityAlert) {
+					this.setAttribute('role', 'alert');
+				} else {
+					this.setAttribute('role', null);
 				}
 			}
 		});

--- a/source/dom/accessibility.js
+++ b/source/dom/accessibility.js
@@ -27,8 +27,11 @@
 
 			/**
 			* AccessibilityAlert is for alert message or page description.
-			* If accessibilityAlert is true, screen reader will automatically reads
-			* content or accessibilityLabel regardless focus.
+			* If accessibilityAlert is true, aria role will be set to "alert" and 
+			* screen reader will automatically reads content or accessibilityLabel
+			* regardless focus.
+			* Note that if you use accessibilityAlert, previous role will be
+			* replaced with "alert" role.
 			*
 			* Range: [`true`, `false`]
 			* - true: screen reader automatically reads label regardless focus.


### PR DESCRIPTION
The accessibilityAlert property is to cover alert role of aria
attribute.
Basically screen reader reads content or accessibilityLabel out when the
control is focused, but there are some cases that it should be read
something regardless focus. For example, popup, notifications, page
description and so on. If accessibilityAlert is set true, screen reader
will automatically reads content or accessibilityLabel when the control
is rendered or visible.
Refer

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role.

https://jira2.lgsvl.com/browse/ENYO-1124
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang jaewon98.jang@lgepartner.com