### PR TITLE
ENYO-1126: Accessibility: Add "readAlert()" to enyo

### DIFF
--- a/source/dom/accessibility.js
+++ b/source/dom/accessibility.js
@@ -1,5 +1,18 @@
 (function (enyo, scope) {
 
+	/**
+	* _enyo.readAlert_ is the API to use TTS for accessibility VoiceReadout.
+	*
+	* @private
+	*/
+	enyo.readAlert = function(s) {
+
+		if (window.webOS !== undefined && window.webOS.voicereadout !== undefined) {
+			window.webOS.voicereadout.readAlert(s);
+		}
+
+	};
+
 	if (enyo.options.accessibility) {
 		enyo.Control.extend(
 			/** @lends enyo.Control.prototype */ {


### PR DESCRIPTION
The readAlert API is for calling tts api of system service. Most of
cases accessibility supports focus based readout, but ux scenario
sometimes wants application reads a message dynamically. We provides the
readAlert API to cover it.

https://jira2.lgsvl.com/browse/ENYO-1126
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>