### PR TITLE
ENYO-1441 : modify resolution update routine for removing old resolution...

### DIFF
--- a/lib/resolution.js
+++ b/lib/resolution.js
@@ -7,11 +7,12 @@ var _baseScreenType = 'standard',
 	_riRatio,
 	_screenType,
 	_screenTypes = [ {name: 'standard', pxPerRem: 16, width: global.innerWidth,  height: global.innerHeight, aspectRatioName: 'standard'} ],	// Assign one sane value in case defineScreenTypes is never run.
-	_screenTypeObject;
+	_screenTypeObject,
+	_oldScreenType;
 
 var getScreenTypeObject = function (type) {
 	type = type || _screenType;
-	if (type == _screenType && _screenTypeObject) {
+	if (_screenTypeObject && _screenTypeObject.name == type) {
 		return _screenTypeObject;
 	}
 	return _screenTypes.filter(function (elem) {
@@ -88,6 +89,13 @@ var ri = module.exports = {
 	*/
 	updateScreenBodyClasses: function (type) {
 		type = type || _screenType;
+		if (_oldScreenType) {
+			Dom.removeClass(document.body, 'enyo-res-' + _oldScreenType.toLowerCase());
+			var oldScrObj = getScreenTypeObject(_oldScreenType);
+			if (oldScrObj.aspectRatioName) {
+				Dom.removeClass(document.body, 'enyo-aspect-ratio-' + oldScrObj.aspectRatioName.toLowerCase());
+			}
+		}
 		if (type) {
 			Dom.addBodyClass('enyo-res-' + type.toLowerCase());
 			var scrObj = getScreenTypeObject(type);
@@ -231,6 +239,7 @@ var ri = module.exports = {
 	*/
 	// Later we can wire this up to a screen resize event so it doesn't need to be called manually.
 	init: function () {
+		_oldScreenType = _screenType;
 		_screenType = this.getScreenType();
 		_screenTypeObject = getScreenTypeObject();
 		this.updateScreenBodyClasses();


### PR DESCRIPTION
## issue
moon.ri.init() function needs a line for removing ScreenTypeOnBody
moon.ri.getScreenTypeObject always return old screenTypeObject if there is no parameter

## fix
added oldScreenType variable for for checking and removing old resolution classes.
and removed caching routine in getScreenTypeObject function.
(this is a copy of https://github.com/enyojs/moonstone/pull/2074 for master branch)

Enyo-DCO-1.1-Signed-off-by: Sungbae Cho sb.cho@lge.com