### PR TITLE
Fixes ENYO-1519

### DIFF
--- a/lib/RelationalModel/RelationalCollection.js
+++ b/lib/RelationalModel/RelationalCollection.js
@@ -1,10 +1,8 @@
-require('enyo');
+var
+	kind = require('../kind'),
+	Collection = require('../Collection');
 
 var
-	kind = require('./kind');
-
-var
-	Collection = require('./Collection'),
 	RelationalModel = require('./RelationalModel');
 
 /**

--- a/lib/RelationalModel/RelationalModel.js
+++ b/lib/RelationalModel/RelationalModel.js
@@ -1,17 +1,14 @@
-require('enyo');
+var
+	kind = require('../kind'),
+	utils = require('../utils');
 
 var
-	kind = require('./kind'),
-	utils = require('./utils');
+	Model = require('../Model'),
+	Store = require('../Store'),
+	Relation = require('../Relation');
 
 var
-	Model = require('./Model'),
-	Store = require('./Store'),
-	Relation = require('./Relation'),
-	toOne = require('./toOne'),
-	toMany = require('./toMany'),
-	manyToMany = require('./manyToMany');
-
+	defaultRelationType;
 
 /**
 * A type of {@link enyo.Model} extended to automatically understand relationships with
@@ -303,6 +300,20 @@ var RelationalModel = module.exports = kind(
 });
 
 /**
+* Defines a named relation type
+*
+* @param  {String}  name      Name of relation type
+* @param  {Relation}  type    Relation kind constructor
+* @param  {Boolean} isDefault `true` if this type should be the default for type-less relations
+*
+* @private
+*/
+RelationalModel.defineRelationType = function (name, type, isDefault) {
+	RelationalModel[name] = type;
+	if (isDefault) defaultRelationType = type;
+};
+
+/**
 * Ensures that we concatenate (sanely) the relations for any subkinds.
 * 
 * @name enyo.RelationalModel.concat
@@ -321,12 +332,8 @@ RelationalModel.concat = function (ctor, props) {
 	// have to look it up later, only need to do this for the incoming props as
 	// it will have already been done for any existing relations from a base kind
 	props.relations && props.relations.forEach(function (relation) {
-		var type = relation.type;
-		/*jshint -W018 */
-		if (!(type === toMany) && !(type === toOne) && !(type === manyToMany)) {
-			relation.type = typeof type == 'string'? kind.constructorForKind((type.indexOf('enyo') === -1 ? ('enyo.' + relation.type) : relation.type)): toOne;
-		}
-		/*jshint +W018 */
+		var type = /^enyo\./.test(relation.type) ? relation.type.substring(5) : relation.type;
+		relation.type = RelationalModel[type] || type || defaultRelationType;
 	});
 	
 	// remove this property so it will not be slammed on top of the root property

--- a/lib/RelationalModel/index.js
+++ b/lib/RelationalModel/index.js
@@ -1,0 +1,13 @@
+require('enyo');
+
+var
+	RelationalModel = require('./RelationalModel'),
+	toOne = require('./toOne'),
+	toMany = require('./toMany'),
+	manyToMany = require('./manyToMany');
+
+RelationalModel.defineRelationType('toOne', toOne, true);
+RelationalModel.defineRelationType('toMany', toMany);
+RelationalModel.defineRelationType('manyToMany', manyToMany);
+
+module.exports = RelationalModel;

--- a/lib/RelationalModel/manyToMany.js
+++ b/lib/RelationalModel/manyToMany.js
@@ -1,7 +1,5 @@
-require('enyo');
-
 var
-	kind = require('./kind');
+	kind = require('../kind');
 
 var
 	toMany = require('./toMany');

--- a/lib/RelationalModel/package.json
+++ b/lib/RelationalModel/package.json
@@ -1,0 +1,3 @@
+{
+	"main": "index.js"
+}

--- a/lib/RelationalModel/toMany.js
+++ b/lib/RelationalModel/toMany.js
@@ -1,14 +1,12 @@
-require('enyo');
+var
+	kind = require('../kind'),
+	utils = require('../utils'),
+	Collection = require('../Collection'),
+	Relation = require('../Relation'),
+	Store = require('../Store');
 
 var
-	kind = require('./kind'),
-	utils = require('./utils');
-
-var
-	Relation = require('./Relation'),
 	RelationalCollection = require('./RelationalCollection'),
-	Collection = require('./Collection'),
-	Store = require('./Store'),
 	toOne = require('./toOne');
 
 /**

--- a/lib/RelationalModel/toOne.js
+++ b/lib/RelationalModel/toOne.js
@@ -1,13 +1,9 @@
-require('enyo');
-
 var
-	kind = require('./kind'),
-	utils = require('./utils');
-
-var
-	Relation = require('./Relation'),
-	Store = require('./Store'),
-	Model = require('./Model');
+	kind = require('../kind'),
+	utils = require('../utils'),
+	Model = require('../Model'),
+	Relation = require('../Relation'),
+	Store = require('../Store');
 
 /**
 * Represents a relationship of data from one [model]{@link enyo.Model} to another

--- a/test/tests/RelationalModel.js
+++ b/test/tests/RelationalModel.js
@@ -4,9 +4,9 @@ var
 	RelationalModel = require('../../lib/RelationalModel'),
 	Collection = require('../../lib/Collection'),
 	CoreObject = require('../../lib/CoreObject'),
-	toOne = require('../../lib/toOne'),
-	toMany = require('../../lib/toMany'),
-	manyToMany = require('../../lib/manyToMany');
+	toOne = RelationalModel.toOne,
+	toMany = RelationalModel.toMany,
+	manyToMany = RelationalModel.manyToMany;
 
 describe('RelationalModel', function () {
 	


### PR DESCRIPTION
## Issue
There is a circular module dependency between RelationalModel, toMany, and RelationalCollection.

## Fix
* Remove the dependency on the relation types from RelationalModel and refactor RelationalModel.concat to support the change.
* Add RelationalModel.defineRelationType to register named types on RelationalModel to support string-based relation type definition (as currently supported).
* Move the RelationalModel-related code into a submodule

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)