### PR TITLE
[2.6.0-pre.4-dev -> 2.6.0-dev] LightPanels updates and refinement.

### DIFF
--- a/lib/LightPanels/LightPanels.js
+++ b/lib/LightPanels/LightPanels.js
@@ -73,10 +73,10 @@ module.exports = kind(
 		* The index of the active panel.
 		*
 		* @type {Number}
-		* @default 0
+		* @default -1
 		* @public
 		*/
-		index: 0,
+		index: -1,
 
 		/**
 		* Indicates whether the panels animate when transitioning.
@@ -316,7 +316,7 @@ module.exports = kind(
 			this.index = newIndex;
 			this.setupTransitions(currentIndex, false);
 		} else {
-			this.set('index', newIndex, true);
+			this.set('index', newIndex);
 		}
 
 		// TODO: When pushing panels after we have gone back (but have not popped), we need to
@@ -369,7 +369,7 @@ module.exports = kind(
 			this.index = targetIdx;
 			this.setupTransitions(currentIndex, false);
 		} else {
-			this.set('index', targetIdx, true);
+			this.set('index', targetIdx);
 		}
 
 		return newPanels;

--- a/lib/LightPanels/LightPanels.js
+++ b/lib/LightPanels/LightPanels.js
@@ -311,7 +311,7 @@ module.exports = kind(
 			nextPanel.postTransition();
 		}
 
-		if (!opts || opts.direct) {
+		if (opts && opts.direct) {
 			var currentIndex = this.index;
 			this.index = newIndex;
 			this.setupTransitions(currentIndex, false);
@@ -364,7 +364,7 @@ module.exports = kind(
 
 		targetIdx = (opts && opts.targetIndex != null) ? opts.targetIndex : lastIndex + newPanels.length - 1;
 
-		if (!opts || opts.direct) {
+		if (opts && opts.direct) {
 			var currentIndex = this.index;
 			this.index = targetIdx;
 			this.setupTransitions(currentIndex, false);

--- a/lib/LightPanels/LightPanels.js
+++ b/lib/LightPanels/LightPanels.js
@@ -639,6 +639,7 @@ module.exports = kind(
 		var panels = this.getPanels();
 		this._garbagePanels = panels.slice();
 		panels.length = 0;
+		this.index = -1;
 	},
 
 	/**

--- a/lib/LightPanels/LightPanels.js
+++ b/lib/LightPanels/LightPanels.js
@@ -522,8 +522,7 @@ module.exports = kind(
 				(this._indexDirection > 0 && this.popOnForward && this.index > 0)) {
 				this.popPanels(this.index - this._indexDirection, this._indexDirection);
 			}
-			if (this._currentPanel.shouldSkipPostTransition && !this._currentPanel.shouldSkipPostTransition()
-				&& this._currentPanel.postTransition) {
+			if (this._currentPanel.postTransition) {
 				asyncMethod(this, function () {
 					this._currentPanel.postTransition();
 				});

--- a/lib/LightPanels/LightPanels.js
+++ b/lib/LightPanels/LightPanels.js
@@ -467,25 +467,23 @@ module.exports = kind(
 	* Enqueues a view that will eventually be pre-cached at an opportunistic time.
 	*
 	* @param {String} viewProps - The properties of the view to be enqueued.
-	* @param {Number} [delay] - The delay in ms before starting the job to cache the view.
 	* @param {Number} [priority] - The priority of the job.
 	* @public
 	*/
-	enqueueView: function (viewProps, delay, priority) {
-		this.startViewCacheJob(viewProps, delay, priority);
+	enqueueView: function (viewProps, priority) {
+		this.startViewCacheJob(viewProps, priority);
 	},
 
 	/**
 	* Enqueues a set of views that will eventually be pre-cached at an opportunistic time.
 	*
 	* @param {Array} viewPropsArray - A set of views to be enqueued.
-	* @param {Number} [delay] - The delay in ms before starting the job to cache the view.
 	* @param {Number} [priority] - The priority of the job.
 	* @public
 	*/
-	enqueueViews: function (viewPropsArray, delay, priority) {
+	enqueueViews: function (viewPropsArray, priority) {
 		for (var idx = 0; idx < viewPropsArray.length; idx++) {
-			this.startViewCacheJob(viewPropsArray[idx], delay, priority);
+			this.startViewCacheJob(viewPropsArray[idx], priority);
 		}
 	},
 
@@ -679,7 +677,6 @@ module.exports = kind(
 	* Starts a job to cache a given view at an opportune time.
 	*
 	* @param {String} viewProps - The properties of the view to be enqueued.
-	* @param {Number} [delay] - The delay in ms before starting the job to cache the view.
 	* @param {Number} [priority] - The priority of the job.
 	* @private
 	*/

--- a/lib/LightPanels/LightPanels.js
+++ b/lib/LightPanels/LightPanels.js
@@ -692,7 +692,7 @@ module.exports = kind(
 					view.postTransition();
 				}
 			});
-		}, priority, 'PRE-CACHE:' + viewProps.kind);
+		}, priority || this.priority, 'PRE-CACHE:' + viewProps.kind);
 	},
 
 	/**

--- a/lib/LightPanels/LightPanels.js
+++ b/lib/LightPanels/LightPanels.js
@@ -14,8 +14,7 @@ var
 var
 	Control = require('../Control'),
 	ViewPreloadSupport = require('../ViewPreloadSupport'),
-	TaskManagerSupport = require('../TaskManagerSupport'),
-	Priorities = require('../PriorityQueue').Priorities;
+	TaskManagerSupport = require('../TaskManagerSupport');
 
 /**
 * The configurable options used by {@link enyo.LightPanels} when pushing panels.
@@ -149,16 +148,7 @@ module.exports = kind(
 		* @default 'forwards'
 		* @public
 		*/
-		direction: 'forwards',
-
-		/**
-		* The default priority for view caching jobs.
-		*
-		* @type {Number}
-		* @default enyo.Priorities.SOMETIME
-		* @public
-		*/
-		priority: Priorities.SOMETIME
+		direction: 'forwards'
 	},
 
 	/**
@@ -689,7 +679,7 @@ module.exports = kind(
 					view.postTransition();
 				}
 			});
-		}, priority || this.priority, 'PRE-CACHE:' + viewProps.kind);
+		}, priority || this.defaultPriority, 'PRE-CACHE:' + viewProps.kind);
 	},
 
 	/**

--- a/lib/TaskManagerSupport.js
+++ b/lib/TaskManagerSupport.js
@@ -6,6 +6,7 @@ var
 var
 	EventEmitter = require('./EventEmitter'),
 	PriorityQueue = require('./PriorityQueue'),
+	Priorities = PriorityQueue.Priorities,
 	BackgroundTaskManager = require('./BackgroundTaskManager');
 
 /** @lends TaskManagerSupport.prototype */
@@ -40,6 +41,15 @@ module.exports = {
 	* @public
 	*/
 	managed: false,
+
+	/**
+	* The default priority for added tasks.
+	*
+	* @type {Number}
+	* @default enyo.Priorities.SOMETIME
+	* @public
+	*/
+	defaultPriority: Priorities.SOMETIME,
 
 	/**
 	* @method


### PR DESCRIPTION
"Cherry-picking" changes to `enyo.LightPanels` from `2.6.0-pre.4-dev` to `2.6.0-dev`.