### PR TITLE
[2.6.0-pre.4-dev -> 2.6.0-dev] Properly update location when initiating a "back" action.

### DIFF
--- a/lib/Router.js
+++ b/lib/Router.js
@@ -11,7 +11,7 @@ var
 
 /**
 * Any instance of a router will be referenced here for the global hash change handler.
-* 
+*
 * @private
 */
 var listeners = [];
@@ -19,7 +19,7 @@ var listeners = [];
 /**
 * This is the intended global `window.hashchange` event handler. If another handler is
 * arbitrarily registered for this event, then it will not fire.
-* 
+*
 * @private
 */
 var hashDidChange = function (hash) {
@@ -46,7 +46,7 @@ var prepare = function (str) {
 /**
 * All of our actively-supported browsers support this method of registering
 * for `hashchange` events.
-* 
+*
 * @private
 */
 ready(function () {
@@ -96,7 +96,7 @@ ready(function () {
 * be mapped to an object, if possible.
 *
 * Note that, currently, only letters and numbers are supported in dynamic routes.
-* 
+*
 * @class enyo.Router
 * @extends enyo.Controller
 * @public
@@ -112,7 +112,7 @@ module.exports = kind(
 	/**
 	* If `true`, the router will respond to hash changes or internal events. If this flag is set
 	* to `false`, it will stop responding. This may be changed at any time.
-	* 
+	*
 	* @type {Boolean}
 	* @default true
 	* @public
@@ -124,7 +124,7 @@ module.exports = kind(
 	* nor be able to trigger them. Instead, the router may be used internally to
 	* maintain or trigger state changes in an application without changing
 	* location.
-	* 
+	*
 	* @type {Boolean}
 	* @default false
 	* @public
@@ -135,7 +135,7 @@ module.exports = kind(
 	* Set this to `true` to force the current browser location to a particular
 	* path on startup. This flag will be ignored if
 	* [triggerOnStart]{@link enyo.Router#triggerOnStart} is `false`.
-	* 
+	*
 	* @type {Boolean}
 	* @default false
 	* @public
@@ -148,7 +148,7 @@ module.exports = kind(
 	* [routes]{@link enyo.Router#routes} array with a special `default: true` flag set. For
 	* any unmatched hash changes, this route will be executed and passed the path that was not
 	* matched.
-	* 
+	*
 	* @type {Object}
 	* @default null
 	* @public
@@ -158,7 +158,7 @@ module.exports = kind(
 	/**
 	* By default, when a router is created, it will attempt to trigger the correct route for the
 	* current browser location. Set this flag to `false` to prevent this behavior.
-	* 
+	*
 	* @type {Boolean}
 	* @default true
 	* @public
@@ -168,7 +168,7 @@ module.exports = kind(
 	/**
 	* The router will attempt to track history based on the events that have been generated
 	* through it. This allows the usage of the browser's 'Back' and 'Forward' buttons.
-	* 
+	*
 	* @type {Boolean}
 	* @default false
 	* @public
@@ -183,7 +183,7 @@ module.exports = kind(
 	* (for static and dynamic paths), an optional `context` (for the `handler`),
 	* or a `default` Boolean `true`|`false` value indicating whether the handler
 	* should be used when no other route can handle the `hashchange` event.
-	* 
+	*
 	* @example
 	* routes: [
 	*     {path: 'users/:userName', handler: 'loadUser'},
@@ -193,7 +193,7 @@ module.exports = kind(
 	*     {path: 'home', handler: 'homeScreen', default: true},
 	*     {path: '', handler: 'handleBlankRoute'}
 	* ]
-	* 
+	*
 	* @type {Array}
 	* @public
 	*/
@@ -229,7 +229,7 @@ module.exports = kind(
 
 	// ...........................
 	// COMPUTED PROPERTIES
-	
+
 	computed: [
 		{method: 'location', path: '_current', config: {cached: true}},
 		{method: 'defaultPath'}
@@ -350,7 +350,7 @@ module.exports = kind(
 				this._history.shift();
 				// we shift the requested location off the stack
 				// but reapply it
-				this.set('location', this._history.shift());
+				this.location(this._history.shift());
 			}
 		}
 	},


### PR DESCRIPTION
"Cherry-picking" the changes from https://github.com/enyojs/enyo/pull/1110 into `2.6.0-dev`.