### PR TITLE
[2.6.0-pre.4-dev -> 2.6.0-dev] Add missing change from 243ff29 for FluxStore

### DIFF
--- a/lib/FluxStore.js
+++ b/lib/FluxStore.js
@@ -1,6 +1,7 @@
 var
 	kind = require('./kind'),
 	utils = require('enyo/utils'),
+	bindSafely = utils.bindSafely,
 	CoreObject = require('./CoreObject'),
 	EventEmitter = require('./EventEmitter'),
 	FluxDispatcher = require('./FluxDispatcher'),
@@ -82,7 +83,7 @@ module.exports = kind(
 	published: {
 
 		/**
-		* @name enyo.FluxStore.mergeRoot
+		* @name enyo.FluxStore.MergeRoot
 		*
 		* When a source sends data to the store,
 		* should the data root have the new data
@@ -93,7 +94,7 @@ module.exports = kind(
 		* @default true
 		*
 		*/
-		mergeRoot: true
+		MergeRoot: true
 	},
 
 	/**
@@ -102,8 +103,11 @@ module.exports = kind(
 	constructor: kind.inherit(function (sup) {
 		return function () {
 			sup.apply(this, arguments);
-			//subscribe the store to the dispatcher
+			//id the store with the dispatcher
 			this.id = FluxDispatcher.subscribe();
+
+			//if the store has an update method, subscribe to payload updates
+			if(this.update) this.updateID = FluxDispatcher.subscribe(this.id, bindSafely(this, this.update));
 		};
 	}),
 
@@ -117,7 +121,7 @@ module.exports = kind(
 	* @private
 	*/
 	add: function (data, opts) {
-		if (this.mergeRoot) {
+		if (this.MergeRoot) {
 			update(this.data, data);
 			return;
 		}


### PR DESCRIPTION
"Cherry-picking" the changes from https://github.com/enyojs/enyo/pull/1119 into `2.6.0-dev`.