### PR TITLE
ENYO-1542: Scroller doesn't display last line when using p tag on conten...

### DIFF
--- a/source/touch/Scroller.css
+++ b/source/touch/Scroller.css
@@ -25,3 +25,10 @@
 	bottom: 0;
 	right: 0;
 }
+
+.enyo-scroller p {
+	-webkit-margin-before: 0;
+	-webkit-margin-after: 0;
+	margin-top: 1em;
+	margin-bottom: 1em;
+}


### PR DESCRIPTION
...t

### Issue:
Last line is not visible when scroll down to the bottom
This happens because p tag has default style of '-webkit-margin-before/after: 1em;' which our scroller doesn't respect.

### Fix:
We can fix this by reset -webkit-margin-before / after as 0 and set margin as 1em.
But, we change that only when p is used under enyo-scroller.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com