### PR TITLE
Fixes ENYO-1553

### DIFF
--- a/lib/Select.js
+++ b/lib/Select.js
@@ -20,7 +20,7 @@ var
 *	{content: 'Ascending', value: 'a'}
 * ]}
 * 
-* selectChanged: function(inSender, inEvent) {
+* selectChanged: function (inSender, inEvent) {
 *	var s = inSender.getValue();
 *	if (s == 'd') {
 *		this.sortListDescending();
@@ -125,14 +125,19 @@ module.exports = kind(
 	* @private
 	*/
 	rendered: kind.inherit(function (sup) {
-		return function() {
+		return function () {
 			sup.apply(this, arguments);
 			//Trick to force IE8 onchange event bubble
-			if(platform.ie == 8){
+			if (platform.ie == 8) {
 				this.setAttribute('onchange', dispatcher.bubbler);
 			}
-			this.selectedChanged();
-			this.valueChanged();
+			// This makes Select.selected a higher priority than Option.selected but ensures that
+			// the former works at create time
+			if (this.selected !== 0) {
+				this.selectedChanged();
+			} else {
+				this.updateSelectedFromNode();
+			}
 			this.sizeChanged();
 			this.multipleChanged();
 			this.disabledChanged();
@@ -142,8 +147,15 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	getSelected: function () {
-		return Number(this.getNodeProperty('selectedIndex', this.selected));
+	updateSelectedFromNode: function () {
+		this.set('selected', Number(this.getNodeProperty('selectedIndex', this.selected)));
+	},
+
+	/**
+	* @private
+	*/
+	updateValueFromNode: function () {
+		this.set('value', this.getNodeProperty('value', this.value));
 	},
 
 	/**
@@ -151,31 +163,35 @@ module.exports = kind(
 	*/
 	selectedChanged: function () {
 		this.setNodeProperty('selectedIndex', this.selected);
-		this.set('value', this.getNodeProperty('value', this.value));
+		this.updateValueFromNode();
 	},
+
 	/**
 	* @private
 	*/
-	valueChanged: function() {
+	valueChanged: function () {
 		this.setNodeProperty('value', this.value);
-		this.set('selected', this.getSelected());
+		this.updateSelectedFromNode();
 	},
+
 	/**
 	* @private
 	*/
-	sizeChanged: function() {
+	sizeChanged: function () {
 		this.setNodeProperty('size', this.size);
 	},
+
 	/**
 	* @private
 	*/
-	multipleChanged: function() {
+	multipleChanged: function () {
 		this.setNodeProperty('multiple', this.multiple);
 	},
+
 	/**
 	* @private
 	*/
-	disabledChanged: function() {
+	disabledChanged: function () {
 		this.setNodeProperty('disabled', this.disabled);
 	},
 
@@ -183,7 +199,7 @@ module.exports = kind(
 	* @private
 	*/
 	change: function () {
-		this.set('selected', this.getSelected());
+		this.updateSelectedFromNode();
 	},
 
 	/**
@@ -191,7 +207,7 @@ module.exports = kind(
 	* @private
 	*/
 	render: kind.inherit(function (sup) {
-		return function() {
+		return function () {
 			// work around IE bug with innerHTML setting of <select>, rerender parent instead
 			// http://support.microsoft.com/default.aspx?scid=kb;en-us;276228
 			if (platform.ie) {

--- a/lib/Select.js
+++ b/lib/Select.js
@@ -61,10 +61,10 @@ module.exports = kind(
 		* The index of the selected [option]{@link enyo.Option} in the list.
 		* 
 		* @type {Number}
-		* @default 0
+		* @default null
 		* @public
 		*/
-		selected: 0,
+		selected: null,
 
 		/**
 		* The value of the selected [option]{@link enyo.Option}.
@@ -133,10 +133,11 @@ module.exports = kind(
 			}
 			// This makes Select.selected a higher priority than Option.selected but ensures that
 			// the former works at create time
-			if (this.selected !== 0) {
+			if (this.selected !== null) {
 				this.selectedChanged();
 			} else {
 				this.updateSelectedFromNode();
+				this.updateValueFromNode();
 			}
 			this.sizeChanged();
 			this.multipleChanged();

--- a/test/tests/Option.js
+++ b/test/tests/Option.js
@@ -1,0 +1,43 @@
+var
+	kind = require('../../lib/kind');
+
+var
+	Select = require('../../lib/Select');
+
+describe('Option', function () {
+
+	describe('properties', function () {
+
+		var testSelect;
+
+		beforeEach(function () {
+			testSelect = new Select({
+				components: [
+					{value: 'one'},
+					{value: 'two'},
+					{value: 'three'},
+					{value: 'four', selected: true}
+				]
+			});
+			testSelect.render();
+		});
+
+		afterEach(function () {
+			testSelect.destroy();
+		});
+
+		describe('#selected', function () {
+			it ('should be 3 create-time', function () {
+				expect(testSelect.get('selected')).to.equal(3);
+			});
+		});
+
+		describe('#value', function () {
+			it ('should have the value "four" at create-time', function () {
+				expect(testSelect.get('value')).to.equal('four');
+			});
+		});
+
+	});
+
+});

--- a/test/tests/Select.js
+++ b/test/tests/Select.js
@@ -1,0 +1,44 @@
+var
+	kind = require('../../lib/kind');
+
+var
+	Select = require('../../lib/Select');
+
+describe('Select', function () {
+
+	describe('properties', function () {
+
+		var testSelect;
+
+		beforeEach(function () {
+			testSelect = new Select({
+				selected: 3,
+				components: [
+					{value: 'one'},
+					{value: 'two'},
+					{value: 'three'},
+					{value: 'four'}
+				]
+			});
+			testSelect.render();
+		});
+
+		afterEach(function () {
+			testSelect.destroy();
+		});
+
+		describe('#selected', function () {
+			it ('should be 3 create-time', function () {
+				expect(testSelect.get('selected')).to.equal(3);
+			});
+		});
+
+		describe('#value', function () {
+			it ('should have the value "four" at create-time', function () {
+				expect(testSelect.get('value')).to.equal('four');
+			});
+		});
+
+	});
+
+});

--- a/test/tests/Select.js
+++ b/test/tests/Select.js
@@ -5,40 +5,52 @@ var
 	Select = require('../../lib/Select');
 
 describe('Select', function () {
-
 	describe('properties', function () {
-
-		var testSelect;
+		var testSelect, testSelectDefault;
 
 		beforeEach(function () {
+			var comps = [
+				{value: 'one'},
+				{value: 'two'},
+				{value: 'three'},
+				{value: 'four'}
+			];
+
 			testSelect = new Select({
 				selected: 3,
-				components: [
-					{value: 'one'},
-					{value: 'two'},
-					{value: 'three'},
-					{value: 'four'}
-				]
+				components: comps
 			});
 			testSelect.render();
+
+			testSelectDefault = new Select({
+				components: comps
+			});
+			testSelectDefault.render();
 		});
 
 		afterEach(function () {
 			testSelect.destroy();
+			testSelectDefault.destroy();
 		});
 
 		describe('#selected', function () {
-			it ('should be 3 create-time', function () {
+			it ('should be 0 render', function () {
+				expect(testSelectDefault.get('selected')).to.equal(0);
+			});
+
+			it ('should be 3 render', function () {
 				expect(testSelect.get('selected')).to.equal(3);
 			});
 		});
 
 		describe('#value', function () {
-			it ('should have the value "four" at create-time', function () {
+			it ('should have the value "one" at render', function () {
+				expect(testSelectDefault.get('value')).to.equal('one');
+			});
+
+			it ('should have the value "four" at render', function () {
 				expect(testSelect.get('value')).to.equal('four');
 			});
 		});
-
 	});
-
 });


### PR DESCRIPTION
## Issue
Options couldn't be selected using their `selected` property at create time. It was overridden by the logic in `Select.rendered()`.

## Fix
Support selecting Option with selected on either Option or Select.
Added tests for Option and Select

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)