### PR TITLE
ENYO-1556: Utilize the getViewId method for determining view id, rather than assuming the kind property.

### DIFF
--- a/lib/LightPanels/LightPanels.js
+++ b/lib/LightPanels/LightPanels.js
@@ -426,9 +426,6 @@ module.exports = kind(
 	* @public
 	*/
 	getViewId: function (view) {
-		// TODO: This works for Settings use case,
-		// but we need to support an alternative
-		// identifier for panel-caching purposes
 		return view.viewId;
 	},
 

--- a/lib/LightPanels/LightPanels.js
+++ b/lib/LightPanels/LightPanels.js
@@ -429,7 +429,7 @@ module.exports = kind(
 		// TODO: This works for Settings use case,
 		// but we need to support an alternative
 		// identifier for panel-caching purposes
-		return view.id;
+		return view.viewId;
 	},
 
 	/**

--- a/lib/LightPanels/LightPanels.js
+++ b/lib/LightPanels/LightPanels.js
@@ -336,7 +336,7 @@ module.exports = kind(
 			newPanel, targetIdx, compareIdx, idx;
 
 		for (idx = 0; idx < info.length; idx++) {
-			newPanel = (this.cacheViews && this.restoreView(info[idx].kind)) || this.createComponent(info[idx], moreInfo);
+			newPanel = (this.cacheViews && this.restoreView(this.getViewId(info[idx]))) || this.createComponent(info[idx], moreInfo);
 			newPanels.push(newPanel);
 			if ((opts && opts.targetIndex != null && lastIndex + idx == opts.targetIndex) || idx == info.length - 1) {
 				newPanel.render();

--- a/lib/LightPanels/LightPanels.js
+++ b/lib/LightPanels/LightPanels.js
@@ -426,7 +426,7 @@ module.exports = kind(
 	* @public
 	*/
 	getViewId: function (view) {
-		return view.viewId;
+		return view.panelId;
 	},
 
 	/**


### PR DESCRIPTION
### Issue
We had previously been assuming that the `kind` property of a view would be the unique identifier when pre-caching views. This had been abstracted into a mixin, and the `getViewId` method is implemented by the control utilizing that mixin.

### Fix
After this change, we forgot to update `pushPanels` (only `pushPanel` was updated) to utilize the `getViewId` method. This has now been corrected. Additionally, the `id` property has been changed to `panelId` to prevent collisions with the actual `id` property.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>