### PR TITLE
ENYO-1567: Guard against already-cached panels from being re-cached.

### DIFF
--- a/lib/LightPanels/LightPanels.js
+++ b/lib/LightPanels/LightPanels.js
@@ -668,15 +668,18 @@ module.exports = kind(
 	* @private
 	*/
 	startViewCacheJob: function (viewProps, priority) {
-		this.addTask(function () {
-			// TODO: once the data layer is hooked into the run loop, we should no longer need
-			// to forcibly trigger the post transition work.
-			this.preCacheView(viewProps, {}, function (view) {
-				if (view.postTransition) {
-					view.postTransition();
-				}
-			});
-		}, priority || this.defaultPriority, 'PRE-CACHE:' + viewProps.kind);
+		var viewId = this.getViewId(viewProps);
+		if (!this._cachedViews[viewId]) {
+			this.addTask(function () {
+				// TODO: once the data layer is hooked into the run loop, we should no longer need
+				// to forcibly trigger the post transition work.
+				this.preCacheView(viewProps, {}, function (view) {
+					if (view.postTransition) {
+						view.postTransition();
+					}
+				});
+			}, priority || this.defaultPriority, 'PRE-CACHE:' + viewId);
+		}
 	},
 
 	/**

--- a/lib/LightPanels/LightPanels.js
+++ b/lib/LightPanels/LightPanels.js
@@ -457,8 +457,19 @@ module.exports = kind(
 	* @param {Number} [priority] - The priority of the job.
 	* @public
 	*/
-	enqueueView: function (viewProps, priority) {
-		this.startViewCacheJob(viewProps, priority);
+	enqueuePanel: function (viewProps, priority) {
+		var viewId = this.getViewId(viewProps);
+		if (!this.isViewPreloaded(viewId)) {
+			this.addTask(function () {
+				// TODO: once the data layer is hooked into the run loop, we should no longer need
+				// to forcibly trigger the post transition work.
+				this.preCacheView(viewProps, {}, function (view) {
+					if (view.postTransition) {
+						view.postTransition();
+					}
+				});
+			}, priority || this.defaultPriority, viewId);
+		}
 	},
 
 	/**
@@ -468,9 +479,9 @@ module.exports = kind(
 	* @param {Number} [priority] - The priority of the job.
 	* @public
 	*/
-	enqueueViews: function (viewPropsArray, priority) {
+	enqueuePanels: function (viewPropsArray, priority) {
 		for (var idx = 0; idx < viewPropsArray.length; idx++) {
-			this.startViewCacheJob(viewPropsArray[idx], priority);
+			this.enqueuePanel(viewPropsArray[idx], priority);
 		}
 	},
 
@@ -661,28 +672,6 @@ module.exports = kind(
 	},
 
 	/**
-	* Starts a job to cache a given view at an opportune time.
-	*
-	* @param {String} viewProps - The properties of the view to be enqueued.
-	* @param {Number} [priority] - The priority of the job.
-	* @private
-	*/
-	startViewCacheJob: function (viewProps, priority) {
-		var viewId = this.getViewId(viewProps);
-		if (!this._cachedViews[viewId]) {
-			this.addTask(function () {
-				// TODO: once the data layer is hooked into the run loop, we should no longer need
-				// to forcibly trigger the post transition work.
-				this.preCacheView(viewProps, {}, function (view) {
-					if (view.postTransition) {
-						view.postTransition();
-					}
-				});
-			}, priority || this.defaultPriority, 'PRE-CACHE:' + viewId);
-		}
-	},
-
-	/**
 	* Prunes the queue of to-be-cached panels in the event that any panels in the queue have
 	* already been instanced.
 	*
@@ -691,7 +680,7 @@ module.exports = kind(
 	*/
 	pruneQueue: function (viewProps) {
 		for (var idx = 0; idx < viewProps.length; idx++) {
-			this.stopJob(viewProps[idx].kind);
+			this.removeTask(this.getViewId(viewProps[idx]));
 		}
 	}
 

--- a/lib/ViewPreloadSupport.js
+++ b/lib/ViewPreloadSupport.js
@@ -151,26 +151,25 @@ module.exports = {
 	*
 	* @param {Object} info - The declarative {@glossary kind} definition.
 	* @param {Object} commonInfo - Additional properties to be applied (defaults).
-	* @param {Boolean} [cbComplete] - If specified, this callback will be executed, with the
-	*	created view being passed as a parameter.
+	* @param {Boolean} [cbEach] - If specified, this callback will be executed once for each view
+	*	that is created, with the created view being passed as a parameter.
+	* @param {Boolean} [cbComplete] - If specified, this callback will be executed after all of the
+	*	views have been created, with the created views being passed as a parameter.
+	* @return {Object[]} The set of view components that were created.
 	* @public
 	*/
-	preCacheViews: function(info, commonInfo, cbComplete) {
-		var vc, views, i, view;
+	preCacheViews: function(info, commonInfo, cbEach, cbComplete) {
+		var views = [],
+			i;
 
-		if (this.cacheViews) {
-			vc = this.$.viewCache;
-			commonInfo = commonInfo || {};
-			commonInfo.owner = this;
-			views = vc.createComponents(info, commonInfo);
-			for (i = 0; i < views.length; i++) {
-				view = views[i];
-				this._cachedViews[this.getViewId(view)] = view;
-				if (cbComplete) {
-					cbComplete.call(this, view);
-				}
-			}
+		for (i = 0; i < info.length; i++) {
+			views.push(this.preCacheView(info[i], commonInfo, cbEach));
 		}
+		if (cbComplete) {
+			cbComplete.call(this, views);
+		}
+
+		return views;
 	},
 
 	/**
@@ -182,21 +181,36 @@ module.exports = {
 	* @param {Object} commonInfo - Additional properties to be applied (defaults).
 	* @param {Function} [cbComplete] - If specified, this callback will be executed, with the
 	*	created view being passed as a parameter.
+	* @return {Object} The view component that was created.
 	* @public
 	*/
 	preCacheView: function(info, commonInfo, cbComplete) {
-		var vc, view;
+		var viewId = this.getViewId(info),
+			vc, view;
 
-		if (this.cacheViews && !this._cachedViews[info.kind]) {
+		if (!this.isViewPreloaded(viewId)) {
 			vc = this.$.viewCache;
 			commonInfo = commonInfo || {};
 			commonInfo.owner = this;
 			view = vc.createComponent(info, commonInfo);
-			this._cachedViews[this.getViewId(info)] = view;
+			this._cachedViews[viewId] = view;
 			if (cbComplete) {
 				cbComplete.call(this, view);
 			}
 		}
+
+		return view;
+	},
+
+	/**
+	* Determines whether or not a given view has already been pre-loaded.
+	*
+	* @param {Object} viewId - The id of the view whose pre-load status is being determined.
+	* @return {Boolean} If `true`, the view has already been pre-loaded; `false` otherwise.
+	* @public
+	*/
+	isViewPreloaded: function (viewId) {
+		return !!(viewId && this._cachedViews[viewId]);
 	}
 
 };


### PR DESCRIPTION
### Issue
The pre-caching of a panel can trigger the `update` method of the same view that initiated the pre-caching of this panel, resulting in an infinite set of pre-caching tasks to be queued and run. This had previously been guarded by examining the unique identifier of the view, in the `ViewPreloadSupport` mixin, but this needs to be updated to support the latest modular changes.

### Fix
We guard against pre-caching a panel that has already been cached, which should have been guarded against to begin with. We also update the call to `addTask` to utilize the string identifier of the panel, instead of the `kind` object, due to the modular changes.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>