### PR TITLE
ENYO-1575: Fix enyo.SpriteAnimation 'paused' property

### DIFF
--- a/lib/SpriteAnimation/SpriteAnimation.js
+++ b/lib/SpriteAnimation/SpriteAnimation.js
@@ -428,6 +428,7 @@ module.exports = kind(
 	*/
 	_forceAnimationReset: function () {
 		this.stop();
+		if (this.get('paused')) return;
 		this.startJob('forceAnimationReset', function() {
 			this.start();
 		}, 100);	// This long delay is needed to force webkit to un-set and re-set the animation.


### PR DESCRIPTION
Issue:
When we set paused as true, sprite animation is set 'paused' css by itself.
But, it is reset animation when duration is set regardless of the paused status.

Fix:
We are stop but not reset animation on _forceAnimationReset.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com