### PR TITLE
ENYO-1580: Utilize translation for initial positioning.

### DIFF
--- a/lib/LightPanels/LightPanels.css
+++ b/lib/LightPanels/LightPanels.css
@@ -2,8 +2,8 @@
 	position: absolute;
 	top: 0;
 	left: 0;
-	width: 100%;
-	height: 100%;
+	bottom: 0;
+	right: 0;
 	overflow: hidden;
 }
 
@@ -11,8 +11,8 @@
 	position: absolute;
 	top: 0;
 	left: 0;
-	width: 100%;
-	height: 100%;
+	bottom: 0;
+	right: 0;
 	box-sizing: border-box;
 }
 

--- a/lib/LightPanels/LightPanels.css
+++ b/lib/LightPanels/LightPanels.css
@@ -17,17 +17,21 @@
 }
 
 .enyo-light-panels.horizontal.forwards > * {
-	left: 100%;
+	transform: translateX(100%);
+	-webkit-transform: translateX(100%);
 }
 
 .enyo-light-panels.horizontal.backwards > * {
-	left: -100%;
+	transform: translateX(-100%);
+	-webkit-transform: translateX(-100%);
 }
 
 .enyo-light-panels.vertical.forwards > * {
-	top: 100%;
+	transform: translateY(100%);
+	-webkit-transform: translateY(100%);
 }
 
 .enyo-light-panels.vertical.backwards > * {
-	top: -100%;
+	transform: translateY(-100%);
+	-webkit-transform: translateY(-100%);
 }

--- a/lib/LightPanels/LightPanels.js
+++ b/lib/LightPanels/LightPanels.js
@@ -437,9 +437,7 @@ module.exports = kind(
 	*/
 	resetView: function (view) {
 		// reset position
-		var trans = {};
-		trans['translate' + this._axis] = 100 * this._direction + '%';
-		dom.transform(view, trans);
+		dom.transformValue(view, 'translate' + this._axis, 100 * this._direction + '%');
 	},
 
 
@@ -600,9 +598,7 @@ module.exports = kind(
 	*/
 	applyTransitions: function (nextPanel, direct) {
 		// apply the transition for the next panel
-		var nextTransition = {};
-		nextTransition['translate' + this._axis] = '0%';
-		dom.transform(nextPanel, nextTransition);
+		dom.transformValue(nextPanel, 'translate' + this._axis, '0%');
 		if (this._currentPanel) { // apply the transition for the current panel
 			this.shiftPanel(this._currentPanel, this._indexDirection);
 		}
@@ -623,9 +619,8 @@ module.exports = kind(
 	* @private
 	*/
 	shiftPanel: function (panel, indexDirection) {
-		var trans = {};
-		trans['translate' + this._axis] = (indexDirection > 0 ? -100 : 100) * this._direction + '%';
-		dom.transform(panel, trans);
+		var value = (indexDirection > 0 ? -100 : 100) * this._direction + '%';
+		dom.transformValue(panel, 'translate' + this._axis, value);
 	},
 
 	/**

--- a/lib/LightPanels/LightPanels.js
+++ b/lib/LightPanels/LightPanels.js
@@ -438,7 +438,7 @@ module.exports = kind(
 	resetView: function (view) {
 		// reset position
 		var trans = {};
-		trans['translate' + this._axis] = '0%';
+		trans['translate' + this._axis] = 100 * this._direction + '%';
 		dom.transform(view, trans);
 	},
 
@@ -590,7 +590,7 @@ module.exports = kind(
 	applyTransitions: function (nextPanel, direct) {
 		// apply the transition for the next panel
 		var nextTransition = {};
-		nextTransition['translate' + this._axis] = -100 * this._direction + '%';
+		nextTransition['translate' + this._axis] = '0%';
 		dom.transform(nextPanel, nextTransition);
 		if (this._currentPanel) { // apply the transition for the current panel
 			this.shiftPanel(this._currentPanel, this._indexDirection);
@@ -613,7 +613,7 @@ module.exports = kind(
 	*/
 	shiftPanel: function (panel, indexDirection) {
 		var trans = {};
-		trans['translate' + this._axis] = indexDirection > 0 ? -200 * this._direction + '%' : '0%';
+		trans['translate' + this._axis] = (indexDirection > 0 ? -100 : 100) * this._direction + '%';
 		dom.transform(panel, trans);
 	},
 


### PR DESCRIPTION
### Issue
There was some leftover cruft from the initial implementation of `enyo.LightPanels` that utilized left/top positioning instead of translations.

### Fix
The positioning has been replaced in favor of translations. Additionally, the dimension properties have been replaced with positioning properties for specifying full height and width.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>