### PR TITLE
ENYO-1590: Allow for properly popping of panels when returning to the first panel.

### DIFF
--- a/lib/LightPanels/LightPanels.js
+++ b/lib/LightPanels/LightPanels.js
@@ -366,8 +366,8 @@ module.exports = kind(
 	},
 
 	/**
-	* Destroys panels whose index is either greater than or equal, or less than or equal to the
-	* specified value, depending on the direction.
+	* Destroys panels whose index is either greater than, or less than, the specified value,
+	* depending on the direction.
 	*
 	* @param {Number} index - Index at which to start destroying panels.
 	* @public
@@ -375,14 +375,12 @@ module.exports = kind(
 	popPanels: function (index, direction) {
 		var panels = this.getPanels();
 
-		index = direction < 0 ? index || panels.length - 1 : index;
-
 		if (direction < 0) {
-			while (panels.length > index && index >= 0) {
+			while (panels.length > index + 1 && index >= 0) {
 				this.popPanel(panels.length - 1);
 			}
 		} else {
-			for (var panelIndex = index; panelIndex >= 0; panelIndex--) {
+			for (var panelIndex = index - 1; panelIndex >= 0; panelIndex--) {
 				this.popPanel(panelIndex, true);
 			}
 		}
@@ -518,7 +516,7 @@ module.exports = kind(
 		if (ev.originator === this._currentPanel) {
 			if ((this._indexDirection < 0 && this.popOnBack && this.index < this.getPanels().length - 1) ||
 				(this._indexDirection > 0 && this.popOnForward && this.index > 0)) {
-				this.popPanels(this.index - this._indexDirection, this._indexDirection);
+				this.popPanels(this.index, this._indexDirection);
 			}
 			if (this._currentPanel.postTransition) {
 				asyncMethod(this, function () {


### PR DESCRIPTION
### Issue
When pushing several panels, and then returning to the first panel (index 0), navigating to the next panel (index 1) does not work when using `pushPanel` or `pushPanel`, in conjunction with the caching mechanism. This is due to the previous panels not having been popped (and properly cached) when returning to the first panel.

### Fix
In `transitionFinished`, we were determining the starting index for popping based on summing the direction with the current index. If the direction jump was more than one panel, which was the case here, the starting index would be incorrect. Rather than normalizing the direction before summing, the logic has been simplified such that the starting index logic is handled by `popPanels`, which is already examining the direction. Also, removed some crufty login in `popPanels` meant to handle a similar case (returning to the first panel), but was superseded by changes to how we were treating the starting index.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>