### PR TITLE
ENYO-1609: setContent(0) on item is not changing content when it has …

### DIFF
--- a/source/dom/Control.js
+++ b/source/dom/Control.js
@@ -1412,7 +1412,7 @@
 			var was = this.content;
 			this.content = content;
 
-			if (was != content) this.notify('content', was, content);
+			if (was !== content) this.notify('content', was, content);
 
 			return this;
 		},


### PR DESCRIPTION
…initial value of empty string

Issue:
We are comparing content with previous content with != on setContent.
It is considering '' and 0 as the same.

Fix:
We are compare content with type checking by using '!==' instead of '!='.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com