### PR TITLE
ENYO-1617: Factor Spotlight support out of enyo/VirtualDataRepeater

### DIFF
--- a/lib/VirtualDataRepeater.js
+++ b/lib/VirtualDataRepeater.js
@@ -9,10 +9,7 @@ var
 	kind = require('./kind');
 
 var
-	DataRepeater = require('./DataRepeater'),
-	// OBVIOUSLY WE CAN'T HAVE THIS HERE AND DON'T WANT TO SEE CODE IN CORE OPTIONALLY DEPENDENT
-	// ON ANOTHER LIBRARY...
-	Spotlight = require('spotlight');
+	DataRepeater = require('./DataRepeater');
 
 /**
 * @namespace enyo
@@ -99,14 +96,8 @@ module.exports = kind({
 	},
 	assignChild: function(model, index, child) {
 		var s = this.isSelected(model),
-			sc = child.selectedClass || 'selected',
-			spc;
-		// TODO: Something better. Shouldn't have
-		// Spotlight-specific code here.
-		spc = Spotlight && Spotlight.getCurrent();
-		if (spc && child === spc && child.model !== model) {
-			Spotlight.unspot;
-		}
+			sc = child.selectedClass || 'selected';
+
 		child.set('model', model);
 		child.set('index', index);
 		child.set('selected', s);


### PR DESCRIPTION
For expediency during initial development, enyo/VirtualDataRepeater
had direct awareness of (and therefore a dependency on) Spotlight.

We now factor this out so that enyo/VirtualDataRepeater knows
nothing of Spotlight, and Spotlight itself provides a mixin
allowing Spotlight awareness to be added to VDR as needed by
library or app code.

ENYO-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)