### PR TITLE
ENYO-1618: Hardening to better deal with various states of cacheViews.

### DIFF
--- a/lib/LightPanels/LightPanels.js
+++ b/lib/LightPanels/LightPanels.js
@@ -289,7 +289,8 @@ module.exports = kind(
 		}
 
 		var lastIndex = this.getPanels().length - 1,
-			nextPanel = (this.cacheViews && this.restoreView(this.getViewId(info))) || this.createComponent(info, moreInfo),
+			panelId = this.getViewId(info),
+			nextPanel = (this.cacheViews && panelId && this.restoreView(panelId)) || this.createComponent(info, moreInfo),
 			newIndex = lastIndex + 1;
 		if (this.cacheViews) {
 			this.pruneQueue([info]);
@@ -333,10 +334,11 @@ module.exports = kind(
 
 		var lastIndex = this.getPanels().length,
 			newPanels = [],
-			newPanel, targetIdx, compareIdx, idx;
+			newPanel, panelId, targetIdx, compareIdx, idx;
 
 		for (idx = 0; idx < info.length; idx++) {
-			newPanel = (this.cacheViews && this.restoreView(this.getViewId(info[idx]))) || this.createComponent(info[idx], moreInfo);
+			panelId = this.getViewId(info[idx]);
+			newPanel = (this.cacheViews && panelId && this.restoreView(panelId)) || this.createComponent(info[idx], moreInfo);
 			newPanels.push(newPanel);
 			if ((opts && opts.targetIndex != null && lastIndex + idx == opts.targetIndex) || idx == info.length - 1) {
 				newPanel.render();

--- a/lib/LightPanels/LightPanels.js
+++ b/lib/LightPanels/LightPanels.js
@@ -204,6 +204,13 @@ module.exports = kind(
 		this.setupTransitions(was, this.shouldAnimate());
 	},
 
+	/**
+	* @private
+	*/
+	cacheViewsChanged: function () {
+		this.popOnForward = this.cacheViews;
+	},
+
 
 
 	/*

--- a/lib/LightPanels/LightPanels.js
+++ b/lib/LightPanels/LightPanels.js
@@ -296,8 +296,7 @@ module.exports = kind(
 		}
 
 		var lastIndex = this.getPanels().length - 1,
-			panelId = this.getViewId(info),
-			nextPanel = (this.cacheViews && panelId && this.restoreView(panelId)) || this.createComponent(info, moreInfo),
+			nextPanel = this.createPanel(info, moreInfo),
 			newIndex = lastIndex + 1;
 		if (this.cacheViews) {
 			this.pruneQueue([info]);
@@ -341,11 +340,10 @@ module.exports = kind(
 
 		var lastIndex = this.getPanels().length,
 			newPanels = [],
-			newPanel, panelId, targetIdx, compareIdx, idx;
+			newPanel, targetIdx, compareIdx, idx;
 
 		for (idx = 0; idx < info.length; idx++) {
-			panelId = this.getViewId(info[idx]);
-			newPanel = (this.cacheViews && panelId && this.restoreView(panelId)) || this.createComponent(info[idx], moreInfo);
+			newPanel = this.createPanel(info[idx], moreInfo);
 			newPanels.push(newPanel);
 			if ((opts && opts.targetIndex != null && lastIndex + idx == opts.targetIndex) || idx == info.length - 1) {
 				newPanel.render();
@@ -557,6 +555,26 @@ module.exports = kind(
 		Private support methods
 		=======================
 	*/
+
+	/**
+	* Retrieves a cached panel or, if not found, creates a new panel
+	*
+	* @param {Object} info - The declarative {@glossary kind} definition.
+	* @param {Object} moreInfo - Additional properties to be applied (defaults).
+	* @return {Object} - Found or created control
+	* @private
+	*/
+	createPanel: function (info, moreInfo) {
+		var panel,
+			panelId = this.getViewId(info);
+
+		if (this.cacheViews && panelId) {
+			panel = this.restoreView(panelId);
+		}
+
+		panel = panel || this.createComponent(info, moreInfo);
+		return panel;
+	},
 
 	/**
 	* Sets up the transitions between the current and next panel.


### PR DESCRIPTION
### Issue
When `cacheViews` was set to `true`, we assumed that a view id would be specified. This caused some issues when the view id was not specified, resulting in erratic panel behavior.

### Fix
We should not try to restore a view when the id is not specified, and should default to creating a new view instead. Additionally, we make a tweak to support the state where `cacheViews` is `false`.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>