### PR TITLE
ENYO-1629: Add support for naming of managers. General clean-up.

### DIFF
--- a/lib/BackgroundTaskManager.js
+++ b/lib/BackgroundTaskManager.js
@@ -6,8 +6,7 @@ require('enyo');
 */
 
 var
-	kind = require('./kind'),
-	utils = require('./utils');
+	kind = require('./kind');
 
 var
 	CoreObject = require('./CoreObject'),
@@ -58,37 +57,12 @@ module.exports = kind.singleton(
 	*/
 	constructor: kind.inherit( function (sup) {
 		return function () {
-			var c, p, f = 0, d = 1000 / this.fpsThreshold;
-
 			sup.apply(this, arguments);
 
-			this.cb = this.bindSafely(function() {
-				if (this.customers.length) {
-					if (!SystemMonitor.active) {
-						SystemMonitor.trigger();
-					}
+			SystemMonitor.on('idle', this.notifyIdle, this);
 
-					if (!c) {
-						c = utils.perfNow();
-					} else {
-						p = c;
-						c = utils.perfNow();
-						f = ((c - p) < d) ? f + 1 : 0;
-					}
-					if (f == this.frameThreshold && SystemMonitor.idle()) {
-						this.run();
-						c = p = f = 0;
-					} else {
-						// reset fps check if threshold is met but system is not user-idle
-						if (f == this.frameThreshold) {
-							c = p = f = 0;
-						}
-						this.trigger();
-					}
-
-				} else if (SystemMonitor.active) {
-					SystemMonitor.stop();
-				}
+			this.cb = this.bindSafely( function () {
+				if (!SystemMonitor.get('active')) SystemMonitor.start();
 			});
 		};
 	}),
@@ -96,8 +70,8 @@ module.exports = kind.singleton(
 	/**
 	* @private
 	*/
-	trigger: function() {
-		Loop.request(this.cb);
+	trigger: function () {
+		if (this.hasActiveTasks()) Loop.request(this.cb);
 	},
 
 	/**
@@ -199,6 +173,18 @@ module.exports = kind.singleton(
 	},
 
 	/**
+	* Determines whether any of our customers has a task.
+	*
+	* @returns {Boolean} If `true`, we have at least one customer with a task; `false` otherwise.
+	* @private
+	*/
+	hasActiveTasks: function () {
+		for (var idx = 0; idx < this.customers.length; idx++) {
+			if (this.customers[idx].hasTasks()) return true;
+		}
+	},
+
+	/**
 	* Determines whether the priority of the last task added to a given customer is urgent
 	* enough to move the customer to the front of the queue.
 	*
@@ -218,6 +204,17 @@ module.exports = kind.singleton(
 				this.customers.unshift(customer);
 			}
 		}
+
+		this.trigger();
+	},
+
+	/**
+	* Handler for when the system is idle, whereupon we allow the next customer to run a task.
+	*
+	* @private
+	*/
+	notifyIdle: function () {
+		this.run();
 	},
 
 	/**

--- a/lib/BackgroundTaskManager.js
+++ b/lib/BackgroundTaskManager.js
@@ -61,9 +61,9 @@ module.exports = kind.singleton(
 
 			SystemMonitor.on('idle', this.notifyIdle, this);
 
-			this.cb = this.bindSafely( function () {
-				if (!SystemMonitor.get('active')) SystemMonitor.start();
-			});
+			this.cb = function () {
+				SystemMonitor.start();
+			};
 		};
 	}),
 

--- a/lib/BackgroundTaskManager.js
+++ b/lib/BackgroundTaskManager.js
@@ -46,6 +46,16 @@ module.exports = kind.singleton(
 	/**
 	* @private
 	*/
+	namedCustomers: {},
+
+	/**
+	* @private
+	*/
+	currentIndex: 0,
+
+	/**
+	* @private
+	*/
 	constructor: kind.inherit( function (sup) {
 		return function () {
 			var c, p, f = 0, d = 1000 / this.fpsThreshold;
@@ -94,30 +104,45 @@ module.exports = kind.singleton(
 	* Add a customer to the queue.
 	*
 	* @param {Object} customer - The item (customer) to add to the queue.
+	* @param {String} nom - The name of the customer for later reference.
 	* @public
 	*/
-	add: function (customer) {
-		// TODO: check if TaskManagerSupport has been mixed-in to this customer object
+	add: function (customer, nom) {
+		this.namedCustomers[nom] = customer;
 		this.customers.push(customer);
-		customer.managed = true;
+		customer.set('managed', true);
 		customer.on('priorityChanged', this.notifyPriority, this);
+
 		this.trigger();
 	},
 
 	/**
 	* Remove a specific customer.
 	*
-	* @param {Object} customer - The item (customer) to remove from the queue.
+	* @param {String} nom - The name of the customer to remove from the queue.
 	* @public
 	*/
-	remove: function (customer) {
-		var idx = this.customers.indexOf(customer);
-		if (idx > -1) {
+	remove: function (nom) {
+		var customer = this.namedCustomers[nom],
+			idx;
+
+		if (customer) {
 			customer.off('priorityChanged', this.notifyPriority, this);
 			customer.cancelTask(); // TODO: should this pause the task instead?
-			customer.managed = false;
-			this.customers.splice(idx, 1);
+			customer.set('managed', false);
+
+			idx = this.customers.indexOf(customer);
+			if (idx > -1) {
+				this.customers.splice(idx, 1);
+
+				if (idx < this.currentIndex || (idx && idx == this.customers.length)) {
+					this.currentIndex--;
+				}
+			}
+
+			delete this.namedCustomers[nom];
 		}
+
 		this.trigger();
 	},
 
@@ -132,6 +157,8 @@ module.exports = kind.singleton(
 			this.customers[idx].cancelTask(); // TODO: should this pause the task instead?
 		}
 		this.customers = [];
+		this.namedCustomers = {};
+		this.currentIndex = 0;
 	},
 
 	/**
@@ -158,6 +185,17 @@ module.exports = kind.singleton(
 			this.customers[idx].resumeTask();
 		}
 		this.trigger();
+	},
+
+	/**
+	* Retrieves a customer by name.
+	*
+	* @param {String} nom - The name of the customer.
+	* @returns {Object} The customer that was originally added with the passed-in name.
+	* @public
+	*/
+	getCustomer: function (nom) {
+		return this.namedCustomers[nom];
 	},
 
 	/**
@@ -188,12 +226,17 @@ module.exports = kind.singleton(
 	* @private
 	*/
 	run: function () {
-		var item;
+		var customer = this.customers[this.currentIndex],
+			nextIndex = this.currentIndex + 1;
 
-		if (!this.customers[0].paused) {
-			item = this.customers.shift();
-			this.customers.push(item); // move item to back of the queue
-			item.runTask();
+		if (customer.hasTasks()) {
+			customer.runTask();
+		}
+
+		if (nextIndex >= this.customers.length) {
+			this.currentIndex = 0;
+		} else {
+			this.currentIndex = nextIndex;
 		}
 
 		this.trigger();

--- a/lib/SystemMonitor.js
+++ b/lib/SystemMonitor.js
@@ -8,7 +8,7 @@ require('enyo');
 var
 	kind = require('./kind'),
 	dispatcher = require('./dispatcher'),
-	utils = require('./utils');
+	perfNow = require('./utils').perfNow;
 
 var
 	EventEmitter = require('./EventEmitter'),
@@ -81,10 +81,10 @@ module.exports = kind.singleton(
 
 			this.cb = this.bindSafely(function() {
 				if (!c) {
-					c = utils.perfNow();
+					c = perfNow();
 				} else {
 					p = c;
-					c = utils.perfNow();
+					c = perfNow();
 					f = ((c - p) < d) ? f + 1 : 0;
 				}
 
@@ -92,9 +92,9 @@ module.exports = kind.singleton(
 					this.active = false;
 					this.emit('idle');
 					if (this.listeners('idle').length === 0) {
-						var idx = dispatcher.features.indexOf(this.bindSafely(this.checkEvent));
+						var idx = dispatcher.features.indexOf(this._checkEvent);
 						if (idx > -1) dispatcher.features.splice(idx, 1);
-						this.listening = false;
+						this._checkEvent = null;
 					}
 					c = p = f = 0;
 				} else {
@@ -120,9 +120,10 @@ module.exports = kind.singleton(
 	* @public
 	*/
 	start: function () {
-		if (!this.listening) {
-			this.listening = true;
-			dispatcher.features.push(this.bindSafely(this.checkEvent));
+		if (!this.lastActive) this.lastActive = perfNow(); // setting initial value for lastActive
+		if (!this._checkEvent) {
+			this._checkEvent = this.bindSafely(this.checkEvent);
+			dispatcher.features.push(this._checkEvent);
 		}
 		if (!this.active) {
 			this.active = true;
@@ -138,7 +139,7 @@ module.exports = kind.singleton(
 	*/
 	idle: function () {
 		// check last idle time with some sensible threshold
-		return !this.lastActive || utils.perfNow() - this.lastActive > this.idleThreshold;
+		return (perfNow() - this.lastActive) > this.idleThreshold;
 	},
 
 	/**
@@ -151,23 +152,23 @@ module.exports = kind.singleton(
 		switch (ev.type) {
 			case 'mousemove':
 				if (!this.lastMouseMove || !this.lastX || !this.lastY ||
-					Math.abs((ev.clientX - this.lastX) / (utils.perfNow() - this.lastMouseMove)) * 1000 > this.moveTolerance) {
-					this.lastActive = utils.perfNow();
+					Math.abs((ev.clientX - this.lastX) / (perfNow() - this.lastMouseMove)) * 1000 > this.moveTolerance) {
+					this.lastActive = perfNow();
 				}
-				this.lastMouseMove = utils.perfNow();
+				this.lastMouseMove = perfNow();
 				this.lastX = ev.clientX;
 				this.lastY = ev.clientY;
 
 				break;
 			case 'keydown':
 				this._idleCheckJob = setTimeout(function () {
-					this.lastActive = utils.perfNow();
+					this.lastActive = perfNow();
 					this._idleCheckJob = null;
 				}, 32);
 
 				break;
 			case 'mousedown':
-				this.lastActive = utils.perfNow();
+				this.lastActive = perfNow();
 
 				break;
 		}

--- a/lib/SystemMonitor.js
+++ b/lib/SystemMonitor.js
@@ -11,7 +11,9 @@ var
 	utils = require('./utils');
 
 var
-	CoreObject = require('./CoreObject');
+	EventEmitter = require('./EventEmitter'),
+	CoreObject = require('./CoreObject'),
+	Loop = require('./Loop');
 
 module.exports = kind.singleton(
 	/** @lends module:enyo/SystemMonitor */ {
@@ -25,6 +27,21 @@ module.exports = kind.singleton(
 	* @private
 	*/
 	kind: CoreObject,
+
+	/**
+	* @private
+	*/
+	mixins: [EventEmitter],
+
+	/**
+	* @private
+	*/
+	fpsThreshold: 55,
+
+	/**
+	* @private
+	*/
+	frameThreshold: 4,
 
 	/**
 	* The threshold of pixel movement per second that must be met before we classify mouse
@@ -55,25 +72,61 @@ module.exports = kind.singleton(
 	active: false,
 
 	/**
+	* @method
+	* @private
+	*/
+	constructor: kind.inherit( function (sup) {
+		return function () {
+			var c, p, f = 0, d = 1000 / this.fpsThreshold;
+
+			this.cb = this.bindSafely(function() {
+				if (!c) {
+					c = utils.perfNow();
+				} else {
+					p = c;
+					c = utils.perfNow();
+					f = ((c - p) < d) ? f + 1 : 0;
+				}
+
+				if (f == this.frameThreshold && this.idle()) {
+					this.active = false;
+					this.emit('idle');
+					if (this.listeners('idle').length === 0) {
+						var idx = dispatcher.features.indexOf(this.bindSafely(this.checkEvent));
+						if (idx > -1) dispatcher.features.splice(idx, 1);
+						this.listening = false;
+					}
+					c = p = f = 0;
+				} else {
+					if (f == this.frameThreshold) {
+						c = p = f = 0;
+					}
+					this.trigger();
+				}
+			});
+		};
+	}),
+
+	/**
+	* @private
+	*/
+	trigger: function () {
+		Loop.request(this.cb);
+	},
+
+	/**
 	* Starts observing the system for idleness.
 	*
 	* @public
 	*/
-	trigger: function () {
-		dispatcher.features.push(this.bindSafely(this.checkEvent));
-		this.active = true;
-	},
-
-	/**
-	* Ends observation of the system for idleness.
-	*
-	* @public
-	*/
-	stop: function () {
-		var idx = dispatcher.features.indexOf(this.bindSafely(this.checkEvent));
-		if (idx > -1) {
-			dispatcher.features.splice(idx, 1);
-			this.active = false;
+	start: function () {
+		if (!this.listening) {
+			this.listening = true;
+			dispatcher.features.push(this.bindSafely(this.checkEvent));
+		}
+		if (!this.active) {
+			this.active = true;
+			this.trigger();
 		}
 	},
 

--- a/lib/TaskManagerSupport.js
+++ b/lib/TaskManagerSupport.js
@@ -52,14 +52,26 @@ module.exports = {
 	defaultPriority: Priorities.SOMETIME,
 
 	/**
+	* The name of this manager, which can be used to easily retrieve this specific manager from the
+	* {@link enyo.BackgroundTaskManager}.
+	*
+	* @type {String}
+	* @default ''
+	* @public
+	*/
+	managerName: '',
+
+	/**
 	* @method
 	* @private
 	*/
 	create: kind.inherit(function (sup) {
 		return function () {
 			sup.apply(this, arguments);
+			this.managerName = this.managerName || this.name;
+			BackgroundTaskManager.add(this, this.managerName, true);
 			this.tasks = new PriorityQueue();
-			this._namedTasks = {};
+			this.namedTasks = {};
 		};
 	}),
 
@@ -72,12 +84,14 @@ module.exports = {
 	* @public
 	*/
 	addTask: function (task, priority, nom) {
-		if (this._namedTasks[nom]) {
+		if (nom && this.namedTasks[nom]) {
 			this.removeTask(nom); // remove existing task so that it can be replaced
 		}
 
 		this.tasks.add(task, priority);
-		this._namedTasks[nom] = task;
+		if (nom) {
+			this.namedTasks[nom] = task;
+		}
 
 		if (!this.managed) { // add ourselves if we are not currently being managed
 			BackgroundTaskManager.add(this);
@@ -93,8 +107,9 @@ module.exports = {
 	* @public
 	*/
 	removeTask: function (nom) {
-		var task = this._namedTasks[nom];
+		var task = this.namedTasks[nom];
 		this.tasks.remove(task);
+		delete this.namedTasks[nom];
 	},
 
 
@@ -138,9 +153,20 @@ module.exports = {
 	* @public
 	*/
 	updateTask: function (nom, priority) {
-		var task = this._namedTasks[nom];
+		var task = this.namedTasks[nom];
 		this.tasks.updatePriority(task, priority);
 		this.emit('priorityChanged', this, priority);
+	},
+
+	/**
+	* Determines whether or not this {@link enyo.TaskManager} has tasks or not.
+	*
+	* @returns {Boolean} If there exist tasks and we are not paused, returns `true`; `false`
+	*	otherwise.
+	* @public
+	*/
+	hasTasks: function () {
+		return this.tasks.length && !this.paused;
 	},
 
 	/**
@@ -155,7 +181,7 @@ module.exports = {
 			this.task && this.task();
 
 			if (this.tasks.length === 0) { // remove ourselves if we no longer have tasks
-				BackgroundTaskManager.remove(this);
+				BackgroundTaskManager.remove(this.managerName, true);
 			}
 		}
 	}

--- a/lib/TaskManagerSupport.js
+++ b/lib/TaskManagerSupport.js
@@ -68,10 +68,10 @@ module.exports = {
 	create: kind.inherit(function (sup) {
 		return function () {
 			sup.apply(this, arguments);
-			this.managerName = this.managerName || this.name;
-			BackgroundTaskManager.add(this, this.managerName, true);
 			this.tasks = new PriorityQueue();
 			this.namedTasks = {};
+			this.managerName = this.managerName || this.name;
+			BackgroundTaskManager.add(this, this.managerName, true);
 		};
 	}),
 

--- a/lib/TaskManagerSupport.js
+++ b/lib/TaskManagerSupport.js
@@ -71,7 +71,7 @@ module.exports = {
 			this.tasks = new PriorityQueue();
 			this.namedTasks = {};
 			this.managerName = this.managerName || this.name;
-			BackgroundTaskManager.add(this, this.managerName, true);
+			BackgroundTaskManager.add(this, this.managerName);
 		};
 	}),
 
@@ -181,7 +181,7 @@ module.exports = {
 			this.task && this.task();
 
 			if (this.tasks.length === 0) { // remove ourselves if we no longer have tasks
-				BackgroundTaskManager.remove(this.managerName, true);
+				BackgroundTaskManager.remove(this.managerName);
 			}
 		}
 	}


### PR DESCRIPTION
### Issue
We need support for the naming of managers, so that they can be referenced in the future. Also, there is some technical debt where we have some logic for determining framerate in `BackgroundTaskManager`, which should be moved to `SystemMonitor`.

### Fix
We've added a `managerName` property in `TaskManagerSupport`, and have updated `BackgroundTaskManager` to maintain a hash of names and customers. Additionally, we have moved the framerate checking logic from `BackgroundTaskManager` to `SystemMonitor`.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>