### PR TITLE
ENYO-1651: Add updateComponents feature

### DIFF
--- a/lib/UiComponent.js
+++ b/lib/UiComponent.js
@@ -15,7 +15,7 @@ var
 
 /**
 * {@link module:enyo/UiComponent~UiComponent} implements a container strategy suitable for presentation layers.
-* 
+*
 * `UiComponent` itself is abstract. Concrete [subkinds]{@glossary subkind} include
 * {@link module:enyo/Control~Control} (for HTML/DOM) and
 * {@link module:enyo/canvas~canvas.Control} (for Canvas contexts).
@@ -34,14 +34,53 @@ var UiComponent = module.exports = kind(
 	*/
 	kind: Component,
 
+	statics: {
+
+		/**
+		* The default set of keys which are effectively "ignored" when determining whether or not the
+		* this control has changed in such a way that warrants a complete re-render. When
+		* {@link enyo.UIComponent#updateComponents} is invoked on a parent component, this set of
+		* stateful keys is utilized by default, if no stateful keys are provided by us.
+		*
+		* @type {String[]}
+		* @default ['content', active', 'disabled']
+		* @private
+		*/
+		statefulKeys: [
+			'content',
+			'active',
+			'disabled'
+		],
+
+		/**
+		* Finds static properties by walking up the inheritance chain, until the property is found.
+		* By default this will return the property from {@link module:enyo/UiComponent} if the
+		* property is not found anywhere along the chain.
+		*
+		* @param {module:enyo/kind} kind - The kind which we are attempting to retrieve the property
+		*	from; if the property is not found on this kind, its parent kind will be examined.
+		* @param {String} prop - The property we are trying to retrieve.
+		* @returns {String[]} The array of stateful key strings.
+		* @public
+		*/
+		findStatic: function (kind, prop) {
+			if (kind) {
+				if (kind[prop]) return kind[prop];
+				return UiComponent.findStatic(kind.kind, prop);
+			} else {
+				return UiComponent[prop];
+			}
+		}
+	},
+
 	/**
 	* @private
 	*/
-	published: 
+	published:
 		/** @lends module:enyo/UiComponent~UiComponent.prototype */ {
 
-		/** 
-		* The [UiComponent]{@link module:enyo/UiComponent~UiComponent} that physically contains this 
+		/**
+		* The [UiComponent]{@link module:enyo/UiComponent~UiComponent} that physically contains this
 		* [component]{@link module:enyo/Component~Component} in the DOM.
 		*
 		* @type {module:enyo/UiComponent~UiComponent}
@@ -70,9 +109,9 @@ var UiComponent = module.exports = kind(
 		* @public
 		*/
 		controlParentName: 'client',
-		
-		/** 
-		* A {@glossary kind} used to manage the size and placement of child 
+
+		/**
+		* A {@glossary kind} used to manage the size and placement of child
 		* [components]{@link module:enyo/Component~Component}.
 		*
 		* @type {String}
@@ -104,7 +143,7 @@ var UiComponent = module.exports = kind(
 	* @public
 	*/
 	addBefore: undefined,
-	
+
 	/**
 	* @private
 	*/
@@ -156,10 +195,10 @@ var UiComponent = module.exports = kind(
 
 	/**
 	* Creates [components]{@link module:enyo/Component~Component} as defined by the [arrays]{@glossary Array}
-	* of base and additional property [hashes]{@glossary Object}. The standard and 
+	* of base and additional property [hashes]{@glossary Object}. The standard and
 	* additional property hashes are combined as described in
 	* {@link module:enyo/Component~Component#createComponent}.
-	* 
+	*
 	* ```
 	* // ask foo to create components 'bar' and 'zot', but set the owner of
 	* // both components to 'this'.
@@ -171,21 +210,21 @@ var UiComponent = module.exports = kind(
 	*
 	* As implemented, [controlParentName]{@link module:enyo/UiComponent~UiComponent#controlParentName} only works
 	* to identify an owned control created via `createComponents()`
-	* (i.e., usually in our `components` block). To attach a `controlParent` via other means, 
-	* one must call [discoverControlParent()]{@link module:enyo/UiComponent~UiComponent#discoverControlParent} or 
+	* (i.e., usually in our `components` block). To attach a `controlParent` via other means,
+	* one must call [discoverControlParent()]{@link module:enyo/UiComponent~UiComponent#discoverControlParent} or
 	* set `controlParent` directly.
-	* 
+	*
 	* We could call `discoverControlParent()` in
 	* [addComponent()]{@link module:enyo/Component~Component#addComponent}, but that would
 	* cause a lot of useless checking.
-	* 
+	*
 	* @param {Object[]} props The array of {@link module:enyo/Component~Component} definitions to be created.
 	* @param {Object} ext - Additional properties to be supplied as defaults for each.
 	* @returns {module:enyo/Component~Component[]} The array of components that were created.
 	* @method
 	* @public
 	*/
-	// 
+	//
 	createComponents: kind.inherit(function (sup) {
 		return function() {
 			var results = sup.apply(this, arguments);
@@ -193,6 +232,104 @@ var UiComponent = module.exports = kind(
 			return results;
 		};
 	}),
+
+		/**
+	* An alternative component update path that attempts to intelligently update only the
+	* relevant portions of the component which have changed.
+	*
+	* @param {Array} comps - An array of kind definitions to be set as the child components of
+	*	this component.
+	* @returns {Boolean} - Whether or not the component should be re-rendered.
+	* @public
+	*/
+	updateComponents: function (comps) {
+		var allStatefulKeys = {},
+			isChanged = this.computeComponentsDiff(comps, allStatefulKeys),
+			comp, controls, control, keys, key, idxKey, idxComp, kind;
+
+		if (isChanged) {
+			this.destroyClientControls();
+			this.createComponents(comps);
+			return true;
+		} else {
+			controls = this.getClientControls();
+			for (idxComp = 0; idxComp < comps.length; idxComp++) {
+				comp = comps[idxComp];
+				control = controls[idxComp];
+				kind = comp.kind || this.defaultKind;
+				keys = allStatefulKeys[idxComp];
+
+				for (idxKey = 0; idxKey < keys.length; idxKey++) { // for each key, determine if there is a change
+					key = keys[idxKey];
+					if (comp[key] != control[key]) {
+						control.set(key, comp[key]);
+					}
+				}
+			}
+		}
+
+		return false;
+	},
+
+	/**
+	* @private
+	*/
+	computeComponentsDiff: function (comps, allStatefulKeys) {
+		var hash = this.computeComponentsHash(comps, allStatefulKeys),
+			isChanged = false;
+
+		if (this._compHash) isChanged = this._compHash != hash;
+		else isChanged = true;
+
+		this._compHash = hash;
+
+		return isChanged;
+	},
+
+	/**
+	* @private
+	*/
+	computeComponentsHash: function (comps, allStatefulKeys) {
+		var keyCount = 0,
+			hash, str, filtered, chr, len, idx;
+
+		// http://jsperf.com/json-parse-and-iteration-vs-array-map
+		filtered = comps.map(this.bindSafely(function (comp, itemIdx) {
+			var kind = comp.kind || this.defaultKind,
+				keys = UiComponent.findStatic(kind, 'statefulKeys'),
+				objKeys = Object.keys(comp),
+				obj = {},
+				idx, key, value;
+
+			allStatefulKeys[itemIdx] = keys; // cache statefulKeys
+
+			for (idx = 0; idx < objKeys.length; idx++) {
+				key = objKeys[idx];
+
+				if (keys.indexOf(key) == -1) { // ignore stateful keys
+					value = comp[key];
+					if (typeof value == 'function') value = (value.prototype && value.prototype.kindName) || value.toString();
+					obj[key] = value;
+					keyCount++;
+				}
+
+			}
+
+			return obj;
+		}));
+
+		// Adapted from http://stackoverflow.com/a/7616484
+		str = JSON.stringify(filtered) + keyCount;
+		hash = 0;
+
+		for (idx = 0, len = str.length; idx < len; idx++) {
+			chr = str.charCodeAt(idx);
+			hash = ((hash << 5) - hash) + chr;
+			hash |= 0; // Convert to 32bit integer
+		}
+
+		return hash;
+	},
 
 	/**
 	* Determines and sets the current [control's]{@link module:enyo/Control~Control} parent.
@@ -217,7 +354,7 @@ var UiComponent = module.exports = kind(
 
 	/**
 	* Containment
-	* 
+	*
 	* @method
 	* @private
 	*/
@@ -232,7 +369,7 @@ var UiComponent = module.exports = kind(
 
 	/**
 	* Parentage
-	* 
+	*
 	* @method
 	* @private
 	*/
@@ -245,7 +382,7 @@ var UiComponent = module.exports = kind(
 	/**
 	* Determines whether the [control]{@link module:enyo/Control~Control} is a descendant of
 	* another control.
-	* 
+	*
 	* Note: Oddly, a control is considered to be a descendant of itself.
 	*
 	* @method
@@ -290,7 +427,7 @@ var UiComponent = module.exports = kind(
 	},
 
 	/**
-	* Destroys "client controls", the same set of [controls]{@link module:enyo/Control~Control} returned by 
+	* Destroys "client controls", the same set of [controls]{@link module:enyo/Control~Control} returned by
 	* [getClientControls()]{@link module:enyo/UiComponent~UiComponent#getClientControls}.
 	*
 	* @method
@@ -302,7 +439,7 @@ var UiComponent = module.exports = kind(
 			c.destroy();
 		}
 	},
-	
+
 	/**
 	* @method
 	* @private
@@ -372,7 +509,7 @@ var UiComponent = module.exports = kind(
 	controlAtIndex: function (idx) {
 		return this.controls[idx];
 	},
-	
+
 	/**
 	* Determines what the following sibling [control]{@link module:enyo/Control~Control} is for the current
 	* [control]{@link module:enyo/Control~Control}.
@@ -387,19 +524,19 @@ var UiComponent = module.exports = kind(
 			comp,
 			sibling,
 			i;
-	
+
 		for (i = comps.length - 1; i >= 0; i--) {
 			comp = comps[i];
 			if (comp === this) return sibling ? sibling : null;
 			if (comp.generated) sibling = comp;
 		}
-	
+
 		return null;
 	},
-	
+
 	/**
 	* Children
-	* 
+	*
 	* @method
 	* @private
 	*/
@@ -474,7 +611,7 @@ var UiComponent = module.exports = kind(
 	},
 
 	/**
-	* CAVEAT: currently we use the entry point for both post-render layout work *and* 
+	* CAVEAT: currently we use the entry point for both post-render layout work *and*
 	* post-resize layout work.
 	* @method
 	* @private
@@ -486,10 +623,10 @@ var UiComponent = module.exports = kind(
 	},
 
 	/**
-	* Call after this [control]{@link module:enyo/Control~Control} has been resized to allow it to process the 
-	* size change. To respond to a resize, override `handleResize()` instead. Acts as syntactic 
+	* Call after this [control]{@link module:enyo/Control~Control} has been resized to allow it to process the
+	* size change. To respond to a resize, override `handleResize()` instead. Acts as syntactic
 	* sugar for `waterfall('onresize')`.
-	* 
+	*
 	* @method
 	* @public
 	*/
@@ -497,7 +634,7 @@ var UiComponent = module.exports = kind(
 		this.waterfall('onresize', UiComponent._resizeFlags);
 		this.waterfall('onpostresize', UiComponent._resizeFlags);
 	},
-	
+
 	/**
 	* @method
 	* @private
@@ -516,7 +653,7 @@ var UiComponent = module.exports = kind(
 	* [waterfall]{@link module:enyo/Component~Component#waterfall} into [components]{@link module:enyo/Component~Component}
 	* owned by a receiving [object]{@glossary Object} by returning a truthy value from the
 	* {@glossary event} [handler]{@link module:enyo/Component~Component~EventHandler}.
-	* 
+	*
 	* @method
 	* @param {String} nom - The name of the {@glossary event}.
 	* @param {Object} [event] - The event object to pass along.

--- a/test/tests/Control.js
+++ b/test/tests/Control.js
@@ -2,16 +2,17 @@ var
 	kind = require('../../lib/kind');
 
 var
-	Control = require('../../lib/Control');
+	Control = require('../../lib/Control'),
+	UiComponent = require('../../lib/UiComponent');
 
 describe('Control', function () {
-	
+
 	describe('usage', function () {
-		
+
 		describe('renderOnShow', function () {
-			
+
 			var TestControl, testControl;
-			
+
 			before(function () {
 				TestControl = kind({
 					name: 'TestControl',
@@ -21,51 +22,51 @@ describe('Control', function () {
 						{name: 'child', id: 'TESTCONTROL2', renderOnShow: true}
 					]
 				});
-				
+
 				testControl = new TestControl({parentNode: document.body});
 			});
-			
+
 			after(function () {
 				testControl.destroy();
 				TestControl = null;
 			});
-			
+
 			it ('should not render a control with renderOnShow true until it has its showing ' +
 				'value set to true', function () {
-				
+
 				var pn, node;
-				
+
 				testControl.render();
 				pn = document.querySelector('#TESTCONTROL1');
-				
+
 				expect(pn).to.exist;
-				
+
 				node = pn.querySelector('#TESTCONTROL2');
-				
+
 				expect(node).to.not.exist;
-				
+
 				testControl.$.child.set('showing', true);
-				
+
 				node = pn.querySelector('#TESTCONTROL2');
-				
+
 				expect(node).to.exist;
 			});
-			
+
 		});
-		
+
 	});
-	
+
 	describe('statics', function () {
-		
+
 		describe('concat', function () {
-			
+
 			// we will share a single instance of the subclassed control for inspection
 			var control;
-			
+
 			var TestControl1, TestControl2;
-			
+
 			before(function () {
-				
+
 				// we want to create two classes, one that the second can base off of, so as to
 				// test what happens to the concatenated properties when being subclassed
 				TestControl1 = kind({
@@ -78,7 +79,7 @@ describe('Control', function () {
 					classes: 'class1 class2',
 					style: 'height: 50px; width: 50px;'
 				});
-				
+
 				TestControl2 = kind({
 					name: 'TestControl2',
 					kind: TestControl1,
@@ -89,17 +90,17 @@ describe('Control', function () {
 					classes: 'class3 class4',
 					style: 'color: #000;'
 				});
-				
+
 				control = new TestControl2();
 			});
-			
+
 			after(function () {
-				
+
 				// dereference our globals
 				TestControl1 = null;
 				TestControl2 = null;
 			});
-		
+
 			it ('should merge attributes', function () {
 				// by the time it is instanced the attributes hash may have additional properties
 				// we don't wish to test
@@ -107,14 +108,14 @@ describe('Control', function () {
 				expect(control.attributes).to.have.property('attr2', 'attr2');
 				expect(control.attributes).to.have.property('attr3', 'attr3');
 			});
-			
+
 			it ('should merge the style property as kindStyle (internal) and style', function () {
 				expect(control.kindStyle).to.equal('height: 50px; width: 50px; color: #000;');
 				expect(control.style).to.equal(control.kindStyle);
 			});
-			
+
 			it ('should merge classes as kindClasses (internal) and classes', function () {
-				
+
 				// it should be noted the difference between classes and style (not sure why
 				// the difference) but classes, when merged, do not add incoming classes to
 				// the kindClasses property and instead replace the classes property merging
@@ -122,9 +123,190 @@ describe('Control', function () {
 				expect(control.kindClasses.trim()).to.equal('class1 class2');
 				expect(control.classes.trim()).to.equal('class1 class2 class3 class4');
 			});
-		
+
 		});
-		
+
 	});
-	
+
+	describe('stateful keys', function () {
+		var TestControl, testControl, defaultData = [
+				{
+					kind: Control,
+					nonstateful: 'foo',
+					active: true
+				},
+				{
+					kind: Control,
+					nonstateful: 'bar',
+					active: false
+				}
+			];
+
+		TestControl = kind({
+			name: 'TestControl',
+			kind: Control
+		});
+
+		describe('simple', function () {
+
+			beforeEach(function () {
+				testControl = new TestControl({parentNode: document.body});
+
+				testControl.updateComponents(defaultData);
+			});
+
+			afterEach(function () {
+				testControl.destroy();
+			});
+
+			it('should detect that a re-render is needed when non-state is changed', function () {
+				var result = testControl.updateComponents([
+					{
+						kind: Control,
+						nonstateful: 'foo',
+						active: true
+					},
+					{
+						kind: Control,
+						nonstateful: 'baz',
+						active: false
+					}
+				]);
+				expect(result).to.equal(true);
+			});
+
+			it('should detect that a re-render is not needed when state is the same', function () {
+				var result = testControl.updateComponents(defaultData);
+				expect(result).to.equal(false);
+			});
+
+			it('should detect that a re-render is not needed when stateful key changes', function () {
+				var result = testControl.updateComponents([
+					{
+						kind: Control,
+						nonstateful: 'foo',
+						active: false
+					},
+					{
+						kind: Control,
+						nonstateful: 'bar',
+						active: true
+					}]);
+				expect(result).to.equal(false);
+			});
+
+			it('should detect different number of controls', function () {
+				var result = testControl.updateComponents(defaultData.concat({active: true}));
+				expect(result).to.equal(true);
+			});
+
+			it('should detect empty array', function () {
+				var result = testControl.updateComponents([]);
+				expect(result).to.equal(true);
+			});
+
+			it('should detect fewer keys', function () {
+				var result = testControl.updateComponents([
+					{
+						kind: Control,
+						nonstateful: 'foo',
+						active: false
+					},
+					{
+						kind: Control,
+						active: true
+					}]);
+				expect(result).to.equal(true);
+			});
+
+		});
+
+		describe('advanced', function () {
+			var SubControl = kind({
+					kind: Control,
+					name: 'SubControl',
+					statics: {
+						statefulKeys: UiComponent.findStatic(Control, 'statefulKeys').concat('stateful', 'statefulFn')
+					}
+				}),
+			subDefinition = [
+					{
+						kind: Control,
+						nonstateful: 'foo',
+						nonstatefulFn: function () { console.log('foo'); },
+						active: true
+					},
+					{
+						kind: SubControl,
+						stateful: 'bar',
+						statefulFn: function () { console.log('bar'); },
+						active: false
+					}
+				];
+
+			it('should detect control type changes', function () {
+				testControl = new TestControl({parentNode: document.body});
+				testControl.updateComponents(defaultData);
+
+				var result = testControl.updateComponents([
+					{
+						kind: Control,
+						nonstateful: 'foo',
+						nonstatefulFn: function () { console.log('foo'); },
+						active: true
+					},
+					{
+						kind: SubControl,
+						nonstateful: 'bar',
+						statefulFn: function () { console.log('bar'); },
+						active: false
+					}
+				]);
+				expect(result).to.equal(true);
+			});
+
+			it('should detect function changes', function () {
+				testControl = new TestControl({parentNode: document.body});
+				testControl.updateComponents(subDefinition);
+
+				var result = testControl.updateComponents([
+					{
+						kind: Control,
+						nonstateful: 'foo',
+						nonstatefulFn: function () { console.log('fooz'); },
+						active: true
+					},
+					{
+						kind: SubControl,
+						stateful: 'bar',
+						statefulFn: function () { console.log('bar'); },
+						active: false
+					}
+				]);
+				expect(result).to.equal(true);
+			});
+
+			it('should use subkind stateful keys', function () {
+				testControl = new TestControl({parentNode: document.body});
+				testControl.updateComponents(subDefinition);
+
+				var result = testControl.updateComponents([
+					{
+						kind: Control,
+						nonstateful: 'foo',
+						nonstatefulFn: function () { console.log('foo'); },
+						active: true
+					},
+					{
+						kind: SubControl,
+						stateful: 'baz',
+						statefulFn: function () { console.log('baz'); },
+						active: false
+					}
+				]);
+				expect(result).to.equal(false);
+			});
+		});
+	});
+
 });


### PR DESCRIPTION
### Issue
The addition of a Flux-like data flow necessitated that we differentially update components to prevent wholesale regeneration of components each time a view was notified of a data update. A feature was needed to determine what component properties had changed and update or recreate components accordingly.

### Fix
We have added an `updateComponents` method that diffs the passed-in component declarations against the previous component declarations. More specifically, values for all keys that are not in `statefulKeys`, are hashed and compared to their previous values. For the values of the keys that match those in `statefulKeys`, these values are updated on the corresponding components, on the condition that we are not in a situation where we have to regenerate the components (the non-stateful key values have remained the same).

### Limitations
The `updateComponents` method must always be used for creating/updating/adding/removing components, otherwise the diffing will be ineffective and inaccurate. Additionally, if a new component is to be inserted between existing components, all of the components will be recreated (rather than just the delta to be inserted in the appropriate position); I'm exploring some ways of handling these cases, but they are rare enough in our current use cases that it didn't seem like a priority to get a first-pass of this feature implemented.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>