### PR TITLE
ENYO-1667: Add support for specifying resolution-independence parameters via command line.

### DIFF
--- a/tools/deploy.js
+++ b/tools/deploy.js
@@ -282,7 +282,7 @@ if (!opt.mapfrom || opt.mapfrom.indexOf("enyo") < 0) {
 		'-destdir', opt.out,
 		'-output', path.join(opt.build, 'enyo'),
 		(less ? '-less' : '-no-less'),
-		(ri ? '-ri' : '-no-ri'), opt.ri,
+		'-ri', opt.ri,
 		(beautify ? '-beautify' : '-no-beautify'),
 		path.join(opt.enyo, 'minify', 'package.js')];
 	if (opt.mapfrom) {
@@ -302,7 +302,7 @@ args = [node, minifier,
 	'-destdir', opt.out,
 	'-output', path.join(opt.build, 'app'),
 	(less ? '-less' : '-no-less'),
-	(ri ? '-ri' : '-no-ri'), opt.ri,
+	'-ri', opt.ri,
 	(beautify ? '-beautify' : '-no-beautify'),
 	opt.packagejs];
 if (opt.mapfrom) {

--- a/tools/deploy.js
+++ b/tools/deploy.js
@@ -114,7 +114,7 @@ var node = process.argv[0],
 function printUsage() {
 	// format generated using node-optimist...
 	console.log('\n' +
-		'Usage: ' + node + ' ' + deploy + ' [-c][-g][-v][-B][-e enyo_dir][-l lib_dir][-b build_dir][-o out_dir][-p package_js][-s source_dir][-f map_from -t map_to ...]\n' +
+		'Usage: ' + node + ' ' + deploy + ' [-c][-g][-v][-B][-e enyo_dir][-l lib_dir][-b build_dir][-o out_dir][-p package_js][-s source_dir][-f map_from -t map_to ...][-r ri_opts]\n' +
 		'\n' +
 		'Options:\n' +
 		'  -v  verbose operation                         [boolean]  [default: ' + verbose + ']\n' +
@@ -138,7 +138,7 @@ function printUsage() {
 var opt = nopt(/*knownOpts*/ {
 	"build": String,	// relative path
 	"less": Boolean,
-	"ri": Boolean,
+	"ri": String,
 	"enyo": String,		// relative path
 	"lib": String,		// relative path
 	"out": path,		// absolute path
@@ -281,7 +281,8 @@ if (!opt.mapfrom || opt.mapfrom.indexOf("enyo") < 0) {
 		'-enyo', opt.enyo,
 		'-destdir', opt.out,
 		'-output', path.join(opt.build, 'enyo'),
-		(ri ? '-ri' : '-no-ri'),
+		(less ? '-less' : '-no-less'),
+		(ri ? '-ri' : '-no-ri'), opt.ri,
 		(beautify ? '-beautify' : '-no-beautify'),
 		path.join(opt.enyo, 'minify', 'package.js')];
 	if (opt.mapfrom) {
@@ -301,7 +302,7 @@ args = [node, minifier,
 	'-destdir', opt.out,
 	'-output', path.join(opt.build, 'app'),
 	(less ? '-less' : '-no-less'),
-	(ri ? '-ri' : '-no-ri'),
+	(ri ? '-ri' : '-no-ri'), opt.ri,
 	(beautify ? '-beautify' : '-no-beautify'),
 	opt.packagejs];
 if (opt.mapfrom) {

--- a/tools/minifier/lessc.js
+++ b/tools/minifier/lessc.js
@@ -40,10 +40,14 @@ function finish(loader, objs, doneCB) {
 				}
 			} else {
 				try {
-					var riOpts = opt.ri && JSON.parse(opt.ri.replace(re, '"$2": ')),
-						generatedCss, riPlugin;
-					if (riOpts) {
-						riPlugin = new RezInd(riOpts);
+					var riOpts, generatedCss, riPlugin;
+					if (opt.ri && opt.ri != 'false') {
+						riOpts = JSON.parse(opt.ri.replace(re, '"$2": '));
+						if (riOpts) {
+							riPlugin = new RezInd(riOpts);
+						} else {
+							riPlugin = new RezInd();
+						}
 						// console.log("ri:", RezInd, ri);
 						generatedCss = tree.toCSS({plugins: [riPlugin]});
 					} else {

--- a/tools/minifier/lessc.js
+++ b/tools/minifier/lessc.js
@@ -12,6 +12,8 @@ if(!path.relative){
 	path.relative = require('./path-relative-shim').relative;
 }
 
+var re = /(['"])?([a-zA-Z0-9_]+)(['"])?:/g; // RegExp for adding missing quotes, to convert to JSON format
+
 var w = console.log;
 
 function printUsage() {
@@ -40,7 +42,7 @@ function finish(loader, objs, doneCB) {
 				try {
 					var generatedCss, ri;
 					if (opt.ri) {
-						ri = new RezInd(JSON.parse(opt.ri));
+						ri = new RezInd(JSON.parse(opt.ri.replace(re, '"$2": ')));
 						// console.log("ri:", RezInd, ri);
 						generatedCss = tree.toCSS({plugins: [ri]});
 					} else {

--- a/tools/minifier/lessc.js
+++ b/tools/minifier/lessc.js
@@ -42,13 +42,13 @@ function finish(loader, objs, doneCB) {
 			} else {
 				try {
 					var riOpts, generatedCss;
-					if (opt.ri && opt.ri != 'false') {
+					if (opt.ri && opt.ri != 'false') { // ensure we have not ommitted the switch or the switch option has not been explicitly set to `false`
 						if (!riPlugin) {
-							riOpts = JSON.parse(opt.ri.replace(re, '"$2": '));
-							if (riOpts) {
-								riPlugin = new RezInd(riOpts);
-							} else {
+							if (opt.ri == 'true') { // case where we're using only the switch with no options or switch option is explicitly set to `true`
 								riPlugin = new RezInd();
+							} else {
+								riOpts = JSON.parse(opt.ri.replace(re, '"$2": '));
+								riPlugin = new RezInd(riOpts);
 							}
 						}
 						// console.log("ri:", RezInd, ri);

--- a/tools/minifier/lessc.js
+++ b/tools/minifier/lessc.js
@@ -40,11 +40,12 @@ function finish(loader, objs, doneCB) {
 				}
 			} else {
 				try {
-					var generatedCss, ri;
-					if (opt.ri) {
-						ri = new RezInd(JSON.parse(opt.ri.replace(re, '"$2": ')));
+					var riOpts = opt.ri && JSON.parse(opt.ri.replace(re, '"$2": ')),
+						generatedCss, riPlugin;
+					if (riOpts) {
+						riPlugin = new RezInd(riOpts);
 						// console.log("ri:", RezInd, ri);
-						generatedCss = tree.toCSS({plugins: [ri]});
+						generatedCss = tree.toCSS({plugins: [riPlugin]});
 					} else {
 						generatedCss = tree.toCSS();
 					}

--- a/tools/minifier/lessc.js
+++ b/tools/minifier/lessc.js
@@ -16,11 +16,11 @@ var w = console.log;
 
 function printUsage() {
 	w("Enyo Less->CSS Compiler");
-	w("Usage: lessc.sh|bat [-enyo <path>] [-w] <package-file>");
+	w("Usage: lessc.sh|bat [-enyo <path>] [-w] <package-file> [-ri] <ri-options>");
 	w("<package-file>\t", "Path to package file to walk; all LESS files encountered will be compiled");
 	w("-enyo <path>\t", "Path to enyo loader (enyo/enyo.js)");
 	w("-w\t", "Watch the file and any dependencies, and re-compile on changes");
-	w("-ri\t", "Perform resolution-independence conversion of measurements i.e. px -> rem");
+	w("-ri\t", "Perform resolution-independence conversion of measurements i.e. px -> rem. Specify optional parameter overrides as a JSON string i.e. '{\"baseSize\":16,\"minSize\":12,\"precision\":3}'");
 	w("-h, -?, -help\t", "Show this message");
 }
 
@@ -40,7 +40,7 @@ function finish(loader, objs, doneCB) {
 				try {
 					var generatedCss, ri;
 					if (opt.ri) {
-						ri = new RezInd();
+						ri = new RezInd(JSON.parse(opt.ri));
 						// console.log("ri:", RezInd, ri);
 						generatedCss = tree.toCSS({plugins: [ri]});
 					} else {
@@ -154,7 +154,7 @@ var knownOpts = {
 	"output": String,
 	"watch": Boolean,
 	"help": Boolean,
-	"ri": Boolean
+	"ri": String
 };
 
 var shortHands = {

--- a/tools/minifier/lessc.js
+++ b/tools/minifier/lessc.js
@@ -12,7 +12,8 @@ if(!path.relative){
 	path.relative = require('./path-relative-shim').relative;
 }
 
-var re = /(['"])?([a-zA-Z0-9_]+)(['"])?:/g; // RegExp for adding missing quotes, to convert to JSON format
+var re = /(['"])?([a-zA-Z0-9_]+)(['"])?:/g, // RegExp for adding missing quotes, to convert to JSON format
+	riPlugin;
 
 var w = console.log;
 
@@ -40,13 +41,15 @@ function finish(loader, objs, doneCB) {
 				}
 			} else {
 				try {
-					var riOpts, generatedCss, riPlugin;
+					var riOpts, generatedCss;
 					if (opt.ri && opt.ri != 'false') {
-						riOpts = JSON.parse(opt.ri.replace(re, '"$2": '));
-						if (riOpts) {
-							riPlugin = new RezInd(riOpts);
-						} else {
-							riPlugin = new RezInd();
+						if (!riPlugin) {
+							riOpts = JSON.parse(opt.ri.replace(re, '"$2": '));
+							if (riOpts) {
+								riPlugin = new RezInd(riOpts);
+							} else {
+								riPlugin = new RezInd();
+							}
 						}
 						// console.log("ri:", RezInd, ri);
 						generatedCss = tree.toCSS({plugins: [riPlugin]});

--- a/tools/minifier/minify.js
+++ b/tools/minifier/minify.js
@@ -121,7 +121,7 @@
 							console.error(err);
 						} else {
 							var generatedCss;
-							if (opt.ri) {
+							if (opt.ri && opt.ri != 'false') {
 								generatedCss = tree.toCSS({plugins: [riPlugin]});
 							} else {
 								generatedCss = tree.toCSS();

--- a/tools/minifier/minify.js
+++ b/tools/minifier/minify.js
@@ -91,7 +91,17 @@
 		// recurses again from the async callback until no sheets left, then calls doneCB
 		function readAndParse() {
 			var sheet = sheets.shift(),
-				ri = new RezInd();
+				riOpts;
+
+			if (!this.riPlugin) {
+				riOpts = opt.ri && JSON.parse(opt.ri.replace(/(['"])?([a-zA-Z0-9_]+)(['"])?:/g, '"$2": '));
+				if (riOpts) {
+					this.riPlugin = new RezInd(riOpts);
+				} else {
+					this.riPlugin = new RezInd();
+				}
+			}
+
 			if (sheet) {
 				w(sheet);
 				var isLess = (sheet.slice(-4) == "less");
@@ -109,7 +119,7 @@
 						} else {
 							var generatedCss;
 							if (opt.ri) {
-								generatedCss = tree.toCSS({plugins: [ri]});
+								generatedCss = tree.toCSS({plugins: [this.riPlugin]});
 							} else {
 								generatedCss = tree.toCSS();
 							}
@@ -237,7 +247,7 @@
 		"mapfrom": [String, Array],
 		"mapto": [String, Array],
 		"gathering": Boolean,
-		"ri": Boolean
+		"ri": String
 	};
 
 	var shortHands = {

--- a/tools/minifier/minify.js
+++ b/tools/minifier/minify.js
@@ -16,6 +16,9 @@
 		defaultLibLoc = "lib",
 		opt;
 
+	var re = /(['"])?([a-zA-Z0-9_]+)(['"])?:/g,
+		riPlugin;
+
 	// Shimming path.relative with 0.8.8's version if it doesn't exist
 	if(!path.relative){
 		path.relative = require('./path-relative-shim').relative;
@@ -93,12 +96,12 @@
 			var sheet = sheets.shift(),
 				riOpts;
 
-			if (!this.riPlugin) {
-				riOpts = opt.ri && JSON.parse(opt.ri.replace(/(['"])?([a-zA-Z0-9_]+)(['"])?:/g, '"$2": '));
+			if (!riPlugin) {
+				riOpts = opt.ri && JSON.parse(opt.ri.replace(re, '"$2": '));
 				if (riOpts) {
-					this.riPlugin = new RezInd(riOpts);
+					riPlugin = new RezInd(riOpts);
 				} else {
-					this.riPlugin = new RezInd();
+					riPlugin = new RezInd();
 				}
 			}
 
@@ -119,7 +122,7 @@
 						} else {
 							var generatedCss;
 							if (opt.ri) {
-								generatedCss = tree.toCSS({plugins: [this.riPlugin]});
+								generatedCss = tree.toCSS({plugins: [riPlugin]});
 							} else {
 								generatedCss = tree.toCSS();
 							}

--- a/tools/minifier/minify.js
+++ b/tools/minifier/minify.js
@@ -16,7 +16,7 @@
 		defaultLibLoc = "lib",
 		opt;
 
-	var re = /(['"])?([a-zA-Z0-9_]+)(['"])?:/g,
+	var re = /(['"])?([a-zA-Z0-9_]+)(['"])?:/g, // RegExp for adding missing quotes, to convert to JSON format
 		riPlugin;
 
 	// Shimming path.relative with 0.8.8's version if it doesn't exist

--- a/tools/minifier/minify.js
+++ b/tools/minifier/minify.js
@@ -6,7 +6,7 @@
 		walker = require("walker"),
 		uglify = require("uglify-js"),
 		nopt = require("nopt"),
-		less = require("less");
+		less = require("less"),
 		RezInd = require('less-plugin-resolution-independence');
 
 	var basename = path.basename(__filename),
@@ -112,13 +112,13 @@
 							console.error(err);
 						} else {
 							var generatedCss;
-							if (opt.ri && opt.ri != 'false') {
+							if (opt.ri && opt.ri != 'false') { // ensure we have not ommitted the switch or the switch option has not been explicitly set to `false`
 								if (!riPlugin) {
-									riOpts = JSON.parse(opt.ri.replace(re, '"$2": '));
-									if (riOpts) {
-										riPlugin = new RezInd(riOpts);
-									} else {
+									if (opt.ri == 'true') { // case where we're using only the switch with no options or the switch option is explicitly set to `true`
 										riPlugin = new RezInd();
+									} else {
+										riOpts = JSON.parse(opt.ri.replace(re, '"$2": '));
+										riPlugin = new RezInd(riOpts);
 									}
 								}
 								generatedCss = tree.toCSS({plugins: [riPlugin]});

--- a/tools/minifier/minify.js
+++ b/tools/minifier/minify.js
@@ -96,15 +96,6 @@
 			var sheet = sheets.shift(),
 				riOpts;
 
-			if (!riPlugin) {
-				riOpts = opt.ri && JSON.parse(opt.ri.replace(re, '"$2": '));
-				if (riOpts) {
-					riPlugin = new RezInd(riOpts);
-				} else {
-					riPlugin = new RezInd();
-				}
-			}
-
 			if (sheet) {
 				w(sheet);
 				var isLess = (sheet.slice(-4) == "less");
@@ -122,6 +113,14 @@
 						} else {
 							var generatedCss;
 							if (opt.ri && opt.ri != 'false') {
+								if (!riPlugin) {
+									riOpts = JSON.parse(opt.ri.replace(re, '"$2": '));
+									if (riOpts) {
+										riPlugin = new RezInd(riOpts);
+									} else {
+										riPlugin = new RezInd();
+									}
+								}
 								generatedCss = tree.toCSS({plugins: [riPlugin]});
 							} else {
 								generatedCss = tree.toCSS();


### PR DESCRIPTION
### Issue
We allowed for the specification of the configuration options for the LESS resolution-independence plugin  programmatically, but not via the command-line.

### Fix
A JSON string can now be specified with the configuration options, as the value of the `--ri` switch.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>