### PR TITLE
ENYO-1624: DataList Record value Hides after the ExpandableInput Collapses

### DIFF
--- a/lib/VerticalDelegate.js
+++ b/lib/VerticalDelegate.js
@@ -409,7 +409,8 @@ module.exports = {
 
 		var cpp = this.controlsPerPage(list),
 			end = Math.max(list.$.page1.start, list.$.page2.start) + cpp - 1,
-			idx = props.index - 1;
+			idx = props.index,
+			count = Object.getOwnPropertyNames(list.metrics.pages).length * cpp - 1;
 
 		// note that this will refresh the following scenarios
 		// 1. if the dataset was spliced in above the current indices and the last index added was
@@ -437,7 +438,7 @@ module.exports = {
 		if (idx <= end ) this.refresh(list);
 		else {
 			// we should confirm that the page which new models are added is need to update list.metrics
-				var lastPageIndex = Object.getOwnPropertyNames(list.metrics.pages).length == 2 ?   this.pageForIndex(list, end) : this.pageForIndex(list, idx),
+				var lastPageIndex = this.pageForIndex(list, count),
 				// the last page before model added
 				lastPage = list.metrics.pages[lastPageIndex],
 				sp = list.psizeProp,

--- a/lib/VerticalDelegate.js
+++ b/lib/VerticalDelegate.js
@@ -408,7 +408,8 @@ module.exports = {
 		if (!list.hasReset) return this.reset(list);
 
 		var cpp = this.controlsPerPage(list),
-			end = Math.max(list.$.page1.start, list.$.page2.start) + cpp;
+			end = Math.max(list.$.page1.start, list.$.page2.start) + cpp - 1,
+			idx = props.index - 1;
 
 		// note that this will refresh the following scenarios
 		// 1. if the dataset was spliced in above the current indices and the last index added was
@@ -433,10 +434,10 @@ module.exports = {
 
 		// if we need to refresh, do it now and ensure that we're properly setup to scroll
 		// if we were adding to a partially filled page
-		if (props.index <= end ) this.refresh(list);
+		if (idx <= end ) this.refresh(list);
 		else {
 			// we should confirm that the page which new models are added is need to update list.metrics
-			var lastPageIndex = this.pageForIndex(list, props.index),
+				var lastPageIndex = Object.getOwnPropertyNames(list.metrics.pages).length == 2 ?   this.pageForIndex(list, end) : this.pageForIndex(list, idx),
 				// the last page before model added
 				lastPage = list.metrics.pages[lastPageIndex],
 				sp = list.psizeProp,


### PR DESCRIPTION
### Issue 
The moon Datalist recordCount is not getting displayed in some cases.

### Cause 1:
When the Datalist is not scrolled it will generate only 2 pages. The recordCount value became more than 389 means the previous index (props.index) is more than 38 which result  the lastPageIndex will more than 1 (pagesPerControl  = 19) in the VerticalDelegate modelsAdded () function. This will result wrong page index.
### Solution: 
Use end value to calculate the lastPageIndex instead of previous index (props.index)  if the DataList having only 2 pages ( not scrolled).

### Cause 2:
The previous index (props.index) and end value is based on count will always give incremented lastPageIndex in the boundary condition. This is boundary value issue
### Solution:
Reduce the end value and pros.index value by 1 to get the proper index.

DCO-1.1-Signed-Off-By: Anish TD anish.td@lge.com
