### PR TITLE
ENYO-1685: Add try/catch on notify to guard unexpected error.

### DIFF
--- a/source/kernel/mixins/ComputedSupport.js
+++ b/source/kernel/mixins/ComputedSupport.js
@@ -135,9 +135,13 @@
 		notify: enyo.inherit(function (sup) {
 			return function (path, was, is) {
 				this.isComputedDependency(path) && queueComputed(this, path);
-				this._computedRecursion++;
-				sup.apply(this, arguments);
-				this._computedRecursion--;
+				try {
+					this._computedRecursion++;
+					sup.apply(this, arguments);
+					this._computedRecursion--;
+				} catch(e) {
+					this._computedRecursion = 0;
+				}
 				this._computedQueue && this._computedRecursion === 0 && flushComputed(this);
 				return this;
 			};


### PR DESCRIPTION
Issue:
If paths of computed property have an observer. And the observer function meet error for some reason.
Then the computed value will never flushed again. Because '_computedRecursion' will be never get to 0.

Fix:
We add try/catch to catch error on super call of notify then recover _computedRecursion to 0.
So that it can safely flushComputed even after error.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com