### PR TITLE
ENYO-1648: Allow for combining and resetting of global holdpulse config.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -4,7 +4,8 @@
     "require": false,
     "exports": true,
     "module": true,
-    "module.exports": true
+    "module.exports": true,
+    "JSON": true
   },
   "es3": true,
   "evil": false,

--- a/lib/gesture/drag.js
+++ b/lib/gesture/drag.js
@@ -134,9 +134,22 @@ var drag = module.exports =
 	*
 	* @public
 	*/
-	configureHoldPulse: function(config) {
+	configureHoldPulse: function (config) {
 		// TODO: Might be nice to do some validation, error handling
-		this.holdPulseDefaultConfig = config;
+
+		// _holdPulseConfig represents the current, global `holdpulse` settings, if the default
+		// settings have been overridden in some way.
+		this._holdPulseConfig = this._holdPulseConfig || utils.clone(this.holdPulseDefaultConfig, true);
+		utils.mixin(this._holdPulseConfig, config);
+	},
+
+	/**
+	* Resets the `holdPulse` behavior to the default settings.
+	*
+	* @public
+	*/
+	resetHoldPulse: function () {
+		this._holdPulseConfig = null;
 	},
 
 	/**
@@ -470,7 +483,7 @@ var drag = module.exports =
 	*/
 	prepareHold: function(e) {
 		// quick copy as the prototype of the new overridable config
-		this.holdPulseConfig = utils.clone(this.holdPulseDefaultConfig, true);
+		this.holdPulseConfig = utils.clone(this._holdPulseConfig || this.holdPulseDefaultConfig, true);
 
 		// expose method for configuring holdpulse options
 		e.configureHoldPulse = this._configureHoldPulse.bind(this);

--- a/lib/gesture/drag.js
+++ b/lib/gesture/drag.js
@@ -148,7 +148,7 @@ var drag = module.exports =
 	*
 	* @public
 	*/
-	resetHoldPulse: function () {
+	resetHoldPulseConfig: function () {
 		this._holdPulseConfig = null;
 	},
 


### PR DESCRIPTION
### Issue
Previously the default holdPulseConfig would be overwritten by a call to `configureHoldPulse`, allowing no way of resetting to the default. Additionally, because the configuration was set by assignment, rather than mixed-in, the full configuration had to be specified when calling `configureHoldPulse`, rather than just the properties to override.

### Fix
We now mixin the passed-in config when calling `configureHoldPulse`. Additionally, a `resetHoldPulseConfig` method has been added. Also, updated the JSHint configuration to expose `JSON` as a global var, to prevent Travis failures.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>