### PR TITLE
Removing enyo/Scrollable's dependency on old scroller styles

### DIFF
--- a/lib/Scrollable/Scrollable.js
+++ b/lib/Scrollable/Scrollable.js
@@ -1,12 +1,12 @@
 var
-	kind = require('./kind'),
-	utils = require('./utils'),
-	dom = require('./dom'),
-	dispatcher = require('./dispatcher');
+	kind = require('../kind'),
+	utils = require('../utils'),
+	dom = require('../dom'),
+	dispatcher = require('../dispatcher');
 
 var
-	EventEmitter = require('./EventEmitter'),
-	ScrollMath = require('./ScrollMath');
+	EventEmitter = require('../EventEmitter'),
+	ScrollMath = require('../ScrollMath');
 
 var blockOptions = {
 	start: true,
@@ -204,7 +204,7 @@ module.exports = {
 		onShouldDrag: ''
 	},
 
-	classes: 'enyo-scroller enyo-touch-strategy-container enyo-fill',
+	classes: 'enyo-scrollable enyo-fill',
 
 	create: kind.inherit(function (sup) {
 		return function() {

--- a/lib/Scrollable/Scrollable.less
+++ b/lib/Scrollable/Scrollable.less
@@ -1,0 +1,3 @@
+.enyo-scrollable {
+	overflow: hidden;
+}

--- a/lib/Scrollable/package.json
+++ b/lib/Scrollable/package.json
@@ -1,0 +1,6 @@
+{
+  "main": "Scrollable.js",
+  "styles": [
+    "Scrollable.less"
+  ]
+}


### PR DESCRIPTION
The enyo/Scrollable mixin was previously using classnames defined
in the old scroller modules. Replacing with its own styling.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)