### PR TITLE
Guard enyo/RepeaterChildSupport.decorateEvent()...

### DIFF
--- a/lib/RepeaterChildSupport.js
+++ b/lib/RepeaterChildSupport.js
@@ -72,9 +72,12 @@ module.exports = {
 	*/
 	decorateEvent: kind.inherit(function (sup) {
 		return function (sender, event) {
-			event.model = this.model;
-			event.child = this;
-			event.index = this.repeater.collection.indexOf(this.model);
+			var c = this.repeater.collection;
+			if (c) {
+				event.model = this.model;
+				event.child = this;
+				event.index = this.repeater.collection.indexOf(this.model);
+			}
 			sup.apply(this, arguments);
 		};
 	}),


### PR DESCRIPTION
...for the case where this.repeater.collection is not defined.

This case occurred in an app where a waterfalling onShowingChanged
event passed through a child of enyo/VirtualDataRepeater at a time
when no collection was attached. (For efficiency / perf reasons,
VirtualDataRepeater doesn't destroy children when they are
decommissioned; it merely hides them.)

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)