### PR TITLE
Fixes ENYO-1542

### DIFF
--- a/source/touch/Scroller.css
+++ b/source/touch/Scroller.css
@@ -10,6 +10,12 @@
 	overflow: hidden;
 }
 
+.enyo-touch-scroller-client::after,
+.enyo-touch-scroller-client::before {
+	content: "";
+	display: table-cell;
+}
+
 .enyo-touch-strategy-container {
 	overflow: hidden;
 }

--- a/source/touch/TouchScrollStrategy.js
+++ b/source/touch/TouchScrollStrategy.js
@@ -178,7 +178,7 @@
 		* @private
 		*/
 		components: [
-			{name: 'client', classes: 'enyo-touch-scroller'}
+			{name: 'client', classes: 'enyo-touch-scroller enyo-touch-scroller-client'}
 		],
 
 		/**

--- a/source/touch/TransitionScrollStrategy.js
+++ b/source/touch/TransitionScrollStrategy.js
@@ -66,7 +66,7 @@
 		*/
 		components: [
 			{name: 'clientContainer', classes: 'enyo-touch-scroller', components: [
-				{name: 'client'}
+				{name: 'client', classes: 'enyo-touch-scroller-client'}
 			]}
 		],
 

--- a/source/touch/TranslateScrollStrategy.js
+++ b/source/touch/TranslateScrollStrategy.js
@@ -43,7 +43,7 @@
 		*/
 		components: [
 			{name: 'clientContainer', classes: 'enyo-touch-scroller', components: [
-				{name: 'client'}
+				{name: 'client', classes: 'enyo-touch-scroller-client'}
 			]}
 		],
 


### PR DESCRIPTION
## Issue
Scroller contents with leading or trailing margins may not be included in the size calculations throwing off scrolling at the edges.

## Fix
Add pseudo elements to scroller to force block formatting context

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)