### PR TITLE
Fixes ENYO-1638

### DIFF
--- a/lib/Button/Button.js
+++ b/lib/Button/Button.js
@@ -6,9 +6,11 @@ require('enyo');
 */
 
 var
-	kind = require('../kind');
+	kind = require('../kind'),
+	options = require('../options');
 var
-	ToolDecorator = require('../ToolDecorator');
+	ToolDecorator = require('../ToolDecorator'),
+	ButtonAccessibilitySupport = require('./ButtonAccessibilitySupport');
 
 /**
 * {@link enyo.Button} implements an HTML [button]{@glossary button}, with support
@@ -37,6 +39,11 @@ module.exports = kind(
 	* @private
 	*/
 	kind: ToolDecorator,
+
+	/**
+	* @private
+	*/
+	mixins: options.accessibility ? [ButtonAccessibilitySupport] : null,
 
 	/**
 	* @private

--- a/lib/Button/ButtonAccessibilitySupport.js
+++ b/lib/Button/ButtonAccessibilitySupport.js
@@ -1,0 +1,30 @@
+var
+	kind = require('../kind');
+
+/**
+* @name ButtonAccessibilityMixin
+* @mixin
+*/
+module.exports = {
+
+	/**
+	* @private
+	*/
+	initAccessibility: kind.inherit(function (sup) {
+		return function (props) {
+			sup.apply(this, arguments);
+			this.setAttribute('role', 'button');
+			this.setAttribute('tabindex', 0);
+		};
+	}),
+
+	/**
+	* @private
+	*/
+	disabledChanged: kind.inherit(function (sup) {
+		return function (props) {
+			sup.apply(this, arguments);
+			this.setAttribute('aria-disabled', this.disabled);
+		};
+	})
+};

--- a/lib/Checkbox/Checkbox.js
+++ b/lib/Checkbox/Checkbox.js
@@ -6,11 +6,13 @@ require('enyo');
 */
 
 var
-	kind = require('./kind'),
-	utils = require('./utils'),
-	platform = require('./platform');
+	kind = require('../kind'),
+	options = require('../options'),
+	utils = require('../utils'),
+	platform = require('../platform');
 var
-	Input = require('./Input');
+	Input = require('../Input'),
+	CheckboxAccessibilitySupport = require('./CheckboxAccessibilitySupport');
 
 /**
 * Fires when checkbox is tapped.
@@ -46,6 +48,11 @@ module.exports = kind(
 	* @private
 	*/
 	kind: Input,
+
+	/**
+	* @private
+	*/
+	mixins: options.accessibility ? [CheckboxAccessibilitySupport] : null,
 
 	/**
 	* @private

--- a/lib/Checkbox/CheckboxAccessibilitySupport.js
+++ b/lib/Checkbox/CheckboxAccessibilitySupport.js
@@ -1,0 +1,30 @@
+var
+	kind = require('../kind');
+
+/**
+* @name CheckboxAccessibilityMixin
+* @mixin
+*/
+module.exports = {
+
+	/**
+	* @private
+	*/
+	initAccessibility: kind.inherit(function (sup) {
+		return function (props) {
+			sup.apply(this, arguments);
+			this.setAttribute('role', 'checkbox');
+			this.setAttribute('tabindex', 0);
+		};
+	}),
+	
+	/**
+	* @private
+	*/
+	checkedChanged: kind.inherit(function (sup) {
+		return function (props) {
+			sup.apply(this, arguments);
+			this.setAttribute('aria-checked', this.checked ? 'true' : 'false');
+		};
+	})
+};

--- a/lib/Checkbox/package.json
+++ b/lib/Checkbox/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "Checkbox.js"
+}

--- a/lib/Input/Input.js
+++ b/lib/Input/Input.js
@@ -6,12 +6,14 @@ require('enyo');
 */
 
 var
-	kind = require('./kind'),
-	utils = require('./utils'),
-	dispatcher = require('./dispatcher'),
-	platform = require('./platform');
+	kind = require('../kind'),
+	utils = require('../utils'),
+	dispatcher = require('../dispatcher'),
+	options = require('../options'),
+	platform = require('../platform');
 var
-	Control = require('./Control');
+	Control = require('../Control'),
+	InputAccessibilitySupport = require('./InputAccessibilitySupport');
 
 /**
 * Fires immediately when the text changes.
@@ -78,6 +80,11 @@ module.exports = kind(
 	* @private
 	*/
 	kind: Control,
+
+	/**
+	* @private
+	*/
+	mixins: options.accessibility ? [InputAccessibilitySupport] : null,
 
 	/**
 	* @private

--- a/lib/Input/InputAccessibilitySupport.js
+++ b/lib/Input/InputAccessibilitySupport.js
@@ -1,0 +1,30 @@
+var
+	kind = require('../kind');
+
+/**
+* @name InputAccessibilityMixin
+* @mixin
+*/
+module.exports = {
+
+	/**
+	* @private
+	*/
+	initAccessibility: kind.inherit(function (sup) {
+		return function (props) {
+			sup.apply(this, arguments);
+			this.setAttribute('role', 'textbox');
+			this.setAttribute('tabindex', 0);
+		};
+	}),
+
+	/**
+	* @private
+	*/
+	disabledChanged: kind.inherit(function (sup) {
+		return function (props) {
+			sup.apply(this, arguments);
+			this.setAttribute('aria-disabled', this.disabled);
+		};
+	})
+};

--- a/lib/Input/package.json
+++ b/lib/Input/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "Input.js"
+}

--- a/lib/Popup/Popup.js
+++ b/lib/Popup/Popup.js
@@ -9,13 +9,15 @@ require('enyo');
 
 var
 	kind = require('../kind'),
+	options = require('../options');
 	utils = require('../utils'),
 	dispatcher = require('../dispatcher');
 var
 	Control = require('../Control'),
 	Signals = require('../Signals'),
 	Scrim = require('../Scrim'),
-	Dom = require('../dom');
+	Dom = require('../dom'),
+	PopupAccessibilitySupport = require('./PopupAccessibilitySupport');
 
 /**
 * Fires after the [popup]{@link enyo.Popup} is shown.
@@ -87,6 +89,11 @@ var Popup = module.exports = kind(
 	* @private
 	*/
 	kind: Control,
+
+	/**
+	* @private
+	*/
+	mixins: options.accessibility ? [PopupAccessibilitySupport] : null,
 
 	/**
 	* @private

--- a/lib/Popup/PopupAccessibilitySupport.js
+++ b/lib/Popup/PopupAccessibilitySupport.js
@@ -1,0 +1,19 @@
+var
+	kind = require('../kind');
+
+/**
+* @name PopupAccessibilityMixin
+* @mixin
+*/
+module.exports = {
+
+	/**
+	* @private
+	*/
+	showingChanged: kind.inherit(function (sup) {
+		return function (props) {
+			sup.apply(this, arguments);
+			this.set('accessibilityAlert', this.showing);
+		};
+	})
+};

--- a/lib/RichText/RichText.js
+++ b/lib/RichText/RichText.js
@@ -9,10 +9,12 @@ require('enyo');
 
 var
 	kind = require('../kind'),
+	options = require('../options'),
 	utils = require('../utils'),
 	platform = require('../platform');
 var
-	Input = require('../Input');
+	Input = require('../Input'),
+	RichTextAccessibilitySupport = require('./RichTextAccessibilitySupport');
 
 /**
 * The type of change to apply. Possible values are `'move'` and `'extend'`.
@@ -65,6 +67,11 @@ var RichText = module.exports = kind(
 	* @private
 	*/
 	kind: Input,
+
+	/**
+	* @private
+	*/
+	mixins: options.accessibility ? [RichTextAccessibilitySupport] : null,
 
 	/**
 	* @private

--- a/lib/RichText/RichTextAccessibilitySupport.js
+++ b/lib/RichText/RichTextAccessibilitySupport.js
@@ -1,0 +1,21 @@
+var
+	kind = require('../kind');
+
+/**
+* @name RichTextAccessibilityMixin
+* @mixin
+*/
+module.exports = {
+
+	/**
+	* @private
+	*/
+	initAccessibility: kind.inherit(function (sup) {
+		return function (props) {
+			sup.apply(this, arguments);
+			this.setAttribute('role', 'textbox');
+			this.setAttribute('aria-multiline', true);
+			this.setAttribute('tabindex', 0);
+		};
+	})
+};

--- a/lib/TextArea/TextArea.js
+++ b/lib/TextArea/TextArea.js
@@ -6,9 +6,11 @@ require('enyo');
 */
 
 var
-	kind = require('./kind');
+	kind = require('../kind'),
+	options = require('../options');
 var
-	Input = require('./Input');
+	Input = require('../Input'),
+	TextAreaAccessibilitySupport = require('./TextAreaAccessibilitySupport');
 
 /**
 * {@link enyo.TextArea} implements an HTML [&lt;textarea&gt;]{@glossary textarea}
@@ -37,6 +39,11 @@ module.exports = kind(
 	* @private
 	*/
 	kind: Input,
+
+	/**
+	* @private
+	*/
+	mixins: options.accessibility ? [TextAreaAccessibilitySupport] : null,
 
 	/**
 	* @private

--- a/lib/TextArea/TextAreaAccessibilitySupport.js
+++ b/lib/TextArea/TextAreaAccessibilitySupport.js
@@ -1,0 +1,21 @@
+var
+	kind = require('../kind');
+
+/**
+* @name TextAreaAccessibilityMixin
+* @mixin
+*/
+module.exports = {
+
+	/**
+	* @private
+	*/
+	initAccessibility: kind.inherit(function (sup) {
+		return function (props) {
+			sup.apply(this, arguments);
+			this.setAttribute('role', 'textbox');
+			this.setAttribute('aria-multiline', true);
+			this.setAttribute('tabindex', 0);
+		};
+	})
+};

--- a/lib/TextArea/package.json
+++ b/lib/TextArea/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "TextArea.js"
+}


### PR DESCRIPTION
Accessibility supporting for enyo UI - Button, Checkbox, Popup, Input,
TextArea, RichText

- Button: set button role and add 'aria-disabled' attribute matching
disabled property.
- Checkbox: set checkbox role and add 'aria-checked' attribute matching
checked property.
- Input: set textbox role and add 'aria-disabled' attribute matching
disabled property.
- Popup: set the 'accessibilityAlert' to read content of popup when it
is shown.
- RichText: set textbox role and 'aria-multiline' to true because
RichText supports multiline.
- TextArea: set textbox role and 'aria-multiline' to true.
At the moment RichText mixin and TextArea mixin are same, but I
separated them for maintenance.

Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>