### PR TITLE
Refactor accessibility property observers

### DIFF
--- a/lib/AccessibilitySupport/AccessibilitySupport.js
+++ b/lib/AccessibilitySupport/AccessibilitySupport.js
@@ -35,7 +35,7 @@ module.exports = {
 
 	/**
 	* AccessibilityAlert is for alert message or page description.
-	* If accessibilityAlert is true, aria role will be set to "alert" and 
+	* If accessibilityAlert is true, aria role will be set to "alert" and
 	* screen reader will automatically reads content or accessibilityLabel
 	* regardless focus.
 	* Note that if you use accessibilityAlert, previous role will be
@@ -80,84 +80,71 @@ module.exports = {
 	accessibilityDisabled: false,
 
 	/**
+	* @private
+	*/
+	observers: [
+		{method: 'updateAccessibilityAttributes', path: [
+			'content',
+			'accessibilityHint',
+			'accessibilityLabel',
+			'accessibilityAlert',
+			'accessibilityLive',
+			'accessibilityDisabled'
+		]}
+	],
+
+	/**
 	* @method
 	* @private
 	*/
 	create: kind.inherit(function (sup) {
 		return function (props) {
 			sup.apply(this, arguments);
-			if (this.accessibilityDisabled) {
-				this.accessibilityDisabledChanged();
-			} else {
-				this.initAccessibility();
-			}
+			this.initAccessibility();
 		};
 	}),
 
 	/**
-	* @private
+	* One-time intialization logic for control accessibility should be done here. By default, it
+	* invokes the accessibility property observer,
+	* {@link AccessibilityMixin#updateAccessibilityAttributes}
+	*
+	* @protected
 	*/
 	initAccessibility: function () {
-		this.observe('content', 'updateAriaAttributes', this);
-		this.observe('accessibilityLabel', 'updateAriaAttributes', this);
-		this.observe('accessibilityHint', 'updateAriaAttributes', this);
-
-		this.updateAriaAttributes();
-
-		if (this.accessibilityAlert) {
-			this.accessibilityAlertChanged();
-		}
-
-		if (this.accessibilityLive) {
-			this.accessibilityLiveChanged();
-		}
-	},
-
-	updateAriaAttributes: function () {
-		var prefix = this.accessibilityLabel || this.content || null;
-		var label;
-
-		if (this.accessibilityDisabled) return;
-
-		if (this.accessibilityHint) {
-			label = prefix ? prefix + ' ' + this.accessibilityHint : this.accessibilityHint;
-		} else {
-			label = prefix;
-		}
-
-		this.setAttribute('tabindex', label ? 0 : null);
-		this.setAttribute('aria-label', label);
+		this.updateAccessibilityAttributes();
 	},
 
 	/**
-	* @private
+	* Observes changes on properties that affect the accessibility attributes. Control-specific
+	* accessibility mixins should add an observer block for any additional properties.
+	*
+	* ```javascript
+	* observers: [
+	* 	{method: 'updateAccessibilityAttributes', path: 'checked'}
+	* ],
+	*
+	* updateAccessibilityAttributes: kind.inherit(function (sup) {
+	* 	return function (was, is, prop) {
+	* 		var enabled = !this.accessibilityDisabled;
+	* 		sup.apply(this, arguments);
+	* 		this.setAttribute('aria-checked', enabled && this.checked || null);
+	* 	};
+	* });
+	* ```
+	*
+	* @protected
 	*/
-	accessibilityAlertChanged: function () {
-		if (this.accessibilityDisabled) return;
+	updateAccessibilityAttributes: function (was, is, prop) {
+		var enabled = !this.accessibilityDisabled,
+			prefix = this.accessibilityLabel || this.content || null,
+			label = this.accessibilityHint && prefix && (prefix + ' ' + this.accessibilityHint) ||
+					this.accessibilityHint ||
+					prefix;
 
-		this.setAttribute('role', this.accessibilityAlert ? 'alert' : null);
+		this.setAttribute('tabindex', label && enabled ? 0 : null);
+		this.setAttribute('aria-label', enabled ? label : null);
+		this.setAttribute('role', this.accessibilityAlert && enabled ? 'alert' : null);
+		this.setAttribute('aria-live', this.accessibilityLive && enabled ? 'assertive' : null);
 	},
-
-	/**
-	* @private
-	*/
-	accessibilityLiveChanged: function () {
-		if (this.accessibilityDisabled) return;
-
-		this.setAttribute('aria-live', this.accessibilityLive ? 'assertive' : null);
-	},
-
-	/**
-	* @private
-	*/
-	accessibilityDisabledChanged: function () {
-		if (this.accessibilityDisabled) {
-			this.setAttribute('role', null);
-			this.setAttribute('aria-label', null);
-			this.setAttribute('aria-live', null);
-			this.setAttribute('tabindex', null);
-		} else {
-			this.initAccessibility();
-		}
-	}
 };

--- a/lib/Button/ButtonAccessibilitySupport.js
+++ b/lib/Button/ButtonAccessibilitySupport.js
@@ -10,32 +10,20 @@ module.exports = {
 	/**
 	* @private
 	*/
-	initAccessibility: kind.inherit(function (sup) {
-		return function (props) {
-			sup.apply(this, arguments);
-			this.setAttribute('role', 'button');
-			this.setAttribute('tabindex', 0);
-		};
-	}),
+	observers: [
+		{method: 'updateAccessibilityAttributes', path: 'disabled'}
+	],
 
 	/**
 	* @private
 	*/
-	accessibilityDisabledChanged: kind.inherit(function (sup) {
-		return function (props) {
+	updateAccessibilityAttributes: kind.inherit(function (sup) {
+		return function (was, is, prop) {
+			var enabled = !this.accessibilityDisabled;
 			sup.apply(this, arguments);
-			this.setAttribute('aria-disabled', this.accessibilityDisabled ? null : this.disabled ? 'true' : null);
-		};
-	}),
-
-	/**
-	* @private
-	*/
-	disabledChanged: kind.inherit(function (sup) {
-		return function (props) {
-			sup.apply(this, arguments);
-			if (this.accessibilityDisabled) return;
-			this.setAttribute('aria-disabled', this.disabled ? 'true' : null);
+			this.setAttribute('role', enabled ? 'button' : null);
+			this.setAttribute('tabindex', enabled ? 0 : null);
+			this.setAttribute('aria-disabled', enabled && this.disabled ? 'true' : null);
 		};
 	})
 };

--- a/lib/Checkbox/CheckboxAccessibilitySupport.js
+++ b/lib/Checkbox/CheckboxAccessibilitySupport.js
@@ -11,7 +11,7 @@ module.exports = {
 	* @private
 	*/
 	observers: [
-		{method: 'updateAccessibilityAttributes', path: ['checked', 'disabled']}
+		{method: 'updateAccessibilityAttributes', path: 'checked'}
 	],
 
 	/**
@@ -21,10 +21,9 @@ module.exports = {
 		return function (was, is, prop) {
 			var enabled = !this.accessibilityDisabled;
 			sup.apply(this, arguments);
-			this.setAttribute('role', enabled ? 'textbox' : null);
+			this.setAttribute('role', enabled ? 'checkbox' : null);
 			this.setAttribute('tabindex', enabled ? 0 : null);
-			this.setAttribute('aria-checked', enabled ? this.checked : null);
-			this.setAttribute('aria-disabled', enabled && this.disabled ? 'true' : null);
+			this.setAttribute('aria-checked', enabled ? this.checked ? 'true' : 'false' : null);
 		};
 	})
 };

--- a/lib/Checkbox/CheckboxAccessibilitySupport.js
+++ b/lib/Checkbox/CheckboxAccessibilitySupport.js
@@ -10,32 +10,21 @@ module.exports = {
 	/**
 	* @private
 	*/
-	initAccessibility: kind.inherit(function (sup) {
-		return function (props) {
-			sup.apply(this, arguments);
-			this.setAttribute('role', 'checkbox');
-			this.setAttribute('tabindex', 0);
-		};
-	}),
+	observers: [
+		{method: 'updateAccessibilityAttributes', path: ['checked', 'disabled']}
+	],
 
 	/**
 	* @private
 	*/
-	accessibilityDisabledChanged: kind.inherit(function (sup) {
-		return function (props) {
+	updateAccessibilityAttributes: kind.inherit(function (sup) {
+		return function (was, is, prop) {
+			var enabled = !this.accessibilityDisabled;
 			sup.apply(this, arguments);
-			this.setAttribute('aria-checked', this.accessibilityDisabled ? null : this.checked ? 'true' : 'false');
-		};
-	}),
-
-	/**
-	* @private
-	*/
-	checkedChanged: kind.inherit(function (sup) {
-		return function (props) {
-			sup.apply(this, arguments);
-			if (this.accessibilityDisabled) return;
-			this.setAttribute('aria-checked', this.checked ? 'true' : 'false');
+			this.setAttribute('role', enabled ? 'textbox' : null);
+			this.setAttribute('tabindex', enabled ? 0 : null);
+			this.setAttribute('aria-checked', enabled ? this.checked : null);
+			this.setAttribute('aria-disabled', enabled && this.disabled ? 'true' : null);
 		};
 	})
 };

--- a/lib/Group/GroupAccessibilitySupport.js
+++ b/lib/Group/GroupAccessibilitySupport.js
@@ -10,32 +10,20 @@ module.exports = {
 	/**
 	* @private
 	*/
-	initAccessibility: kind.inherit(function (sup) {
-		return function (props) {
-			sup.apply(this, arguments);
-			this.setAttribute('role', 'group');
-			this.setAttribute('tabindex', 0);
-		};
-	}),
+	observers: [
+		{method: 'updateAccessibilityAttributes', path: 'active'}
+	],
 
 	/**
 	* @private
 	*/
-	accessibilityDisabledChanged: kind.inherit(function (sup) {
-		return function (props) {
+	updateAccessibilityAttributes: kind.inherit(function (sup) {
+		return function (was, is, prop) {
+			var enabled = !this.accessibilityDisabled;
 			sup.apply(this, arguments);
-			this.setAttribute('aria-activedescendant', this.accessibilityDisabled ? null : this.active? this.active.getId() : null);
-		};
-	}),
-
-	/**
-	* @private
-	*/
-	activeChanged: kind.inherit(function (sup) {
-		return function (props) {
-			sup.apply(this, arguments);
-			if (this.accessibilityDisabled) return;
-			this.setAttribute('aria-activedescendant', this.active? this.active.getId() : null);
+			this.setAttribute('role', enabled ? 'group' : null);
+			this.setAttribute('tabindex', enabled ? 0 : null);
+			this.setAttribute('aria-activedescendant', this.active && enabled ? this.active.getId() : null);
 		};
 	})
 };

--- a/lib/Input/InputAccessibilitySupport.js
+++ b/lib/Input/InputAccessibilitySupport.js
@@ -10,32 +10,20 @@ module.exports = {
 	/**
 	* @private
 	*/
-	initAccessibility: kind.inherit(function (sup) {
-		return function (props) {
-			sup.apply(this, arguments);
-			this.setAttribute('role', 'textbox');
-			this.setAttribute('tabindex', 0);
-		};
-	}),
+	observers: [
+		{method: 'updateAccessibilityAttributes', path: 'disabled'}
+	],
 
 	/**
 	* @private
 	*/
-	accessibilityDisabledChanged: kind.inherit(function (sup) {
-		return function (props) {
+	updateAccessibilityAttributes: kind.inherit(function (sup) {
+		return function (was, is, prop) {
+			var enabled = !this.accessibilityDisabled;
 			sup.apply(this, arguments);
-			this.setAttribute('aria-disabled', this.accessibilityDisabled ? null : this.disabled ? 'true' : null);
-		};
-	}),
-
-	/**
-	* @private
-	*/
-	disabledChanged: kind.inherit(function (sup) {
-		return function (props) {
-			sup.apply(this, arguments);
-			if (this.accessibilityDisabled) return;
-			this.setAttribute('aria-disabled', this.disabled ? 'true' : null);
+			this.setAttribute('role', enabled ? 'textbox' : null);
+			this.setAttribute('tabindex', enabled ? 0 : null);
+			this.setAttribute('aria-disabled', enabled && this.disabled ? 'true' : null);
 		};
 	})
 };

--- a/lib/Popup/PopupAccessibilitySupport.js
+++ b/lib/Popup/PopupAccessibilitySupport.js
@@ -10,10 +10,16 @@ module.exports = {
 	/**
 	* @private
 	*/
-	showingChanged: kind.inherit(function (sup) {
-		return function (props) {
+	observers: [
+		{method: 'updateAccessibilityAttributes', path: 'showing'}
+	],
+
+	/**
+	* @private
+	*/
+	updateAccessibilityAttributes: kind.inherit(function (sup) {
+		return function (was, is, prop) {
 			sup.apply(this, arguments);
-			if (this.accessibilityDisabled) return;
 			this.set('accessibilityAlert', this.accessibilityDisabled ? null : this.showing);
 		};
 	})

--- a/lib/RichText/RichTextAccessibilitySupport.js
+++ b/lib/RichText/RichTextAccessibilitySupport.js
@@ -10,12 +10,13 @@ module.exports = {
 	/**
 	* @private
 	*/
-	initAccessibility: kind.inherit(function (sup) {
-		return function (props) {
+	updateAccessibilityAttributes: kind.inherit(function (sup) {
+		return function (was, is, prop) {
+			var enabled = !this.accessibilityDisabled;
 			sup.apply(this, arguments);
-			this.setAttribute('role', 'textbox');
-			this.setAttribute('aria-multiline', true);
-			this.setAttribute('tabindex', 0);
+			this.setAttribute('role', enabled ? 'textbox' : null);
+			this.setAttribute('tabindex', enabled ? 0 : null);
+			this.setAttribute('aria-multiline', enabled ? true : null);
 		};
 	})
 };

--- a/lib/Table/TableAccessibilitySupport.js
+++ b/lib/Table/TableAccessibilitySupport.js
@@ -10,11 +10,12 @@ module.exports = {
 	/**
 	* @private
 	*/
-	initAccessibility: kind.inherit(function (sup) {
-		return function (props) {
+	updateAccessibilityAttributes: kind.inherit(function (sup) {
+		return function (was, is, prop) {
+			var enabled = !this.accessibilityDisabled;
 			sup.apply(this, arguments);
-			this.setAttribute('role', 'grid');
-			this.setAttribute('tabindex', 0);
+			this.setAttribute('role', enabled ? 'grid' : null);
+			this.setAttribute('tabindex', enabled ? 0 : null);
 		};
 	})
 };

--- a/lib/TableCell/TableCellAccessibilitySupport.js
+++ b/lib/TableCell/TableCellAccessibilitySupport.js
@@ -10,11 +10,12 @@ module.exports = {
 	/**
 	* @private
 	*/
-	initAccessibility: kind.inherit(function (sup) {
-		return function (props) {
+	updateAccessibilityAttributes: kind.inherit(function (sup) {
+		return function (was, is, prop) {
+			var enabled = !this.accessibilityDisabled;
 			sup.apply(this, arguments);
-			this.setAttribute('role', 'gridcell');
-			this.setAttribute('tabindex', 0);
+			this.setAttribute('role', enabled ? 'gridcell' : null);
+			this.setAttribute('tabindex', enabled ? 0 : null);
 		};
 	})
 };

--- a/lib/TableRow/TableRowAccessibilitySupport.js
+++ b/lib/TableRow/TableRowAccessibilitySupport.js
@@ -10,11 +10,12 @@ module.exports = {
 	/**
 	* @private
 	*/
-	initAccessibility: kind.inherit(function (sup) {
-		return function (props) {
+	updateAccessibilityAttributes: kind.inherit(function (sup) {
+		return function (was, is, prop) {
+			var enabled = !this.accessibilityDisabled;
 			sup.apply(this, arguments);
-			this.setAttribute('role', 'row');
-			this.setAttribute('tabindex', 0);
+			this.setAttribute('role', enabled ? 'row' : null);
+			this.setAttribute('tabindex', enabled ? 0 : null);
 		};
 	})
 };

--- a/lib/TextArea/TextAreaAccessibilitySupport.js
+++ b/lib/TextArea/TextAreaAccessibilitySupport.js
@@ -10,12 +10,21 @@ module.exports = {
 	/**
 	* @private
 	*/
-	initAccessibility: kind.inherit(function (sup) {
-		return function (props) {
+	observers: [
+		{method: 'updateAccessibilityAttributes', path: 'disabled'}
+	],
+
+	/**
+	* @private
+	*/
+	updateAccessibilityAttributes: kind.inherit(function (sup) {
+		return function (was, is, prop) {
+			var enabled = !this.accessibilityDisabled;
 			sup.apply(this, arguments);
-			this.setAttribute('role', 'textbox');
-			this.setAttribute('aria-multiline', true);
-			this.setAttribute('tabindex', 0);
+			this.setAttribute('role', enabled ? 'textbox' : null);
+			this.setAttribute('tabindex', enabled ? 0 : null);
+			this.setAttribute('aria-multiline', enabled ? 'true' : null);
+			this.setAttribute('aria-disabled', enabled && this.disabled ? 'true' : null);
 		};
 	})
 };

--- a/test/tests/AccessibilitySupport.js
+++ b/test/tests/AccessibilitySupport.js
@@ -9,7 +9,7 @@ describe('AccessibilitySupport', function () {
 
 	describe('usage', function () {
 
-		describe('#updateAriaAttributes', function () {
+		describe('#updateAccessibilityAttributes', function () {
 
 			var TestControl, testControl, content, label, hint;
 


### PR DESCRIPTION
The addition of the accessibilityDisabled property made is necessary
to consolidate the accessibility observers into a single handler so
we could toggle the values of any other property when the disabled
property changes.

Issue: ENYO-1689
Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)