### PR TITLE
ENYO-1787: Convert nested measurement values.

### DIFF
--- a/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
+++ b/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
@@ -112,7 +112,7 @@
 		* unit, or measurements that are adjusted to the minimum unit size, in the event that
 		* `_minUnitSize` has more precision than what is specified here, as `_minUnitSize` would be
 		* user-overridden and assumed intentional.
-		* 
+		*
 		* @type {Number}
 		* @default 5
 		* @private
@@ -140,11 +140,6 @@
 			if (Array.isArray(ruleNode.args)) {
 				ruleNode.args.forEach(this.updateNode.bind(this));
 			}
-			// Multiple property values where at least one value is a LESS variable (LESS
-			// automatically converts all of the values into array items)
-			else if (Array.isArray(ruleNode.value)) {
-				ruleNode.value.forEach(this.updateNode.bind(this));
-			}
 			// Directly set string values that have a number
 			else if (typeof ruleNode.value == 'string' && ruleNode.value.match(/\d+/g)) {
 				stringValues = ruleNode.value.match(/\S+/g) || [];
@@ -171,6 +166,12 @@
 					unitNode = ruleNode.unit,
 					result;
 
+				// Multiple property values where at least one value is a LESS variable (LESS
+				// automatically converts all of the values into array items)
+				if (Array.isArray(value)) {
+					value.forEach(this.updateNode.bind(this));
+				}
+
 				if (unitNode) {
 					result = this.parseValueObject(value, unitNode);
 					ruleNode.value = result.value;
@@ -183,7 +184,7 @@
 
 		/**
 		* Parses measurement values that have a separate unit object.
-		* 
+		*
 		* @param {Number} value - The measurement value we wish to convert.
 		* @param {Object} unitNode - An object representing the unit associated with the measurement
 		*	value.
@@ -198,7 +199,7 @@
 			// The standard unit to convert (if no unit, we assume the base unit)
 			if (unit == this._unit) {
 				scaledValue = Math.abs(value * this._minScaleFactor);
-				return (scaledValue && scaledValue <= this._minUnitSize) ? 
+				return (scaledValue && scaledValue <= this._minUnitSize) ?
 					{
 						value: Math.abs(value) < this._minUnitSize ? value : this._minUnitSize * (value < 0 ? -1 : 1),
 						unit: this._unit
@@ -224,7 +225,7 @@
 
 		/**
 		* Parses measurements that contain both the value and unit as a single string.
-		* 
+		*
 		* @param {String} value - The measurement in the base unit which we wish to convert.
 		* @returns {String} The measurement, in resolution-independent units.
 		* @private
@@ -251,7 +252,7 @@
 
 		/**
 		* Converts a value from our base unit to a value in resolution-independent units.
-		* 
+		*
 		* @param {Number} value - The value, in base units, to be converted to a value that is in
 		*	resolution-independent units.
 		* @returns {Number} - The converted value in resolution-independent units.


### PR DESCRIPTION
### Issue
Parameter values of functions that are effectively nested in the LESS structure (in this case, they are part of other parameters) were not being converted for resolution-independence. See the ticket for more specific examples.

### Fix
We've updated the `updateNode` method to effectively drill into any nested values and convert them all.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>