### PR TITLE
ENYO-1793: Allow for the use of falsy values when overriding parameters.

### DIFF
--- a/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
+++ b/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
@@ -31,13 +31,13 @@
 	*/
 
 	var ResolutionIndependence = function (opts) {
-		this._baseSize = opts && opts.baseSize || this._baseSize;
-		this._riUnit = opts && opts.riUnit || this._riUnit;
-		this._unit = opts && opts.unit || this._unit;
-		this._absoluteUnit = opts && opts.absoluteUnit || this._absoluteUnit;
-		this._minUnitSize = opts && opts.minUnitSize || this._minUnitSize;
-		this._minSize = opts && opts.minSize || this._minSize;
-		this._precision = opts && opts.precision || this._precision;
+		this._baseSize = (opts && opts.hasOwnProperty('baseSize')) ? opts.baseSize : this._baseSize;
+		this._riUnit = (opts && opts.hasOwnProperty('riUnit')) ? opts.riUnit : this._riUnit;
+		this._unit = (opts && opts.hasOwnProperty('unit')) ? opts.unit : this._unit;
+		this._absoluteUnit = (opts && opts.hasOwnProperty('absoluteUnit')) ? opts.absoluteUnit : this._absoluteUnit;
+		this._minUnitSize = (opts && opts.hasOwnProperty('minUnitSize')) ? opts.minUnitSize : this._minUnitSize;
+		this._minSize = (opts && opts.hasOwnProperty('minSize')) ? opts.minSize : this._minSize;
+		this._precision = (opts && opts.hasOwnProperty('precision')) ? opts.precision : this._precision;
 
 		// One-time computation of the minimum scale factor that will be used for determining
 		// whether or not to clamp measurement values to the minimum unit size `_minUnitSize`.


### PR DESCRIPTION
### Issue
We were not previously allowing for falsy values when overriding resolution-independence plugin properties, such as the use of the value 0.

### Fix
We now check if the property exists and use its value if so, otherwise we use the default value.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>