### PR TITLE
ENYO-1795: Enable configuration of resolution-independence plugin in browser.

### DIFF
--- a/tools/less.js
+++ b/tools/less.js
@@ -1,24 +1,40 @@
 // Client-side less.js configurator / loader
 (function() {
+	// parse script for options
+	var scripts = document.getElementsByTagName('script'),
+		index = scripts.length - 1,
+		riParams = scripts[index].getAttribute('ri-params'),
+		opts;
+
+	if (riParams) {
+		opts = {};
+		riParams.replace(
+			new RegExp('([^,=&]+)(=([^,]*))?', 'g'),
+			function($0, $1, $2, $3) {
+				opts[$1] = $3;
+			}
+		);
+	}
+
 	var less = window.less || {};
 	if (less.relativeUrls === undefined) {
 		less.relativeUrls = true;
 	}
 	if (less.environment === undefined) {
-		less.environment = "production";
+		less.environment = 'production';
 	}
 	window.less = less;
 	var script = document.createElement('script');
-	script.src = "enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js";
-	script.charset = "utf-8";
+	script.src = 'enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js';
+	script.charset = 'utf-8';
 	document.getElementsByTagName('head')[0].appendChild(script);
 
 	script = document.createElement('script');
-	script.src = "enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js";
-	script.charset = "utf-8";
+	script.src = 'enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js';
+	script.charset = 'utf-8';
 	script.onload = function () {
 		var less = window.less || {};
-		var ri = new enyoLessRiPlugin();
+		var ri = new enyoLessRiPlugin(opts);
 		less.plugins = [ri];
 		window.less = less;
 	}

--- a/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
+++ b/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
@@ -31,17 +31,7 @@
 	*/
 
 	var ResolutionIndependence = function (opts) {
-		this._baseSize = (opts && opts.hasOwnProperty('baseSize')) ? opts.baseSize : this._baseSize;
-		this._riUnit = (opts && opts.hasOwnProperty('riUnit')) ? opts.riUnit : this._riUnit;
-		this._unit = (opts && opts.hasOwnProperty('unit')) ? opts.unit : this._unit;
-		this._absoluteUnit = (opts && opts.hasOwnProperty('absoluteUnit')) ? opts.absoluteUnit : this._absoluteUnit;
-		this._minUnitSize = (opts && opts.hasOwnProperty('minUnitSize')) ? opts.minUnitSize : this._minUnitSize;
-		this._minSize = (opts && opts.hasOwnProperty('minSize')) ? opts.minSize : this._minSize;
-		this._precision = (opts && opts.hasOwnProperty('precision')) ? opts.precision : this._precision;
-
-		// One-time computation of the minimum scale factor that will be used for determining
-		// whether or not to clamp measurement values to the minimum unit size `_minUnitSize`.
-		this._minScaleFactor = this._minSize / this._baseSize;
+		this.configure(opts);
 	};
 
 	ResolutionIndependence.prototype = {
@@ -125,6 +115,26 @@
 		run: function (root) {
 			this._visitor = this._visitor || new less.tree.visitor(this);
 			return this._visitor.visit(root);
+		},
+
+		/**
+		* Updates the parameters for this plugin based on a set of options
+		*
+		* @param {Object} opts - A hash of options.
+		* @public
+		*/
+		configure: function (opts) {
+			this._baseSize = (opts && opts.baseSize !== undefined) ? opts.baseSize : this._baseSize;
+			this._riUnit = (opts && opts.riUnit !== undefined) ? opts.riUnit : this._riUnit;
+			this._unit = (opts && opts.unit !== undefined) ? opts.unit : this._unit;
+			this._absoluteUnit = (opts && opts.absoluteUnit !== undefined) ? opts.absoluteUnit : this._absoluteUnit;
+			this._minUnitSize = (opts && opts.minUnitSize !== undefined) ? opts.minUnitSize : this._minUnitSize;
+			this._minSize = (opts && opts.minSize !== undefined) ? opts.minSize : this._minSize;
+			this._precision = (opts && opts.precision !== undefined) ? opts.precision : this._precision;
+
+			// One-time computation of the minimum scale factor that will be used for determining
+			// whether or not to clamp measurement values to the minimum unit size `_minUnitSize`.
+			this._minScaleFactor = this._minSize / this._baseSize;
 		},
 
 		/*


### PR DESCRIPTION
### Issue
There did not exist a mechanism to specify configuration options for the LESS resolution-independence plugin when the script is loaded in the browser.

### Fix
As long as `less.js` is being loaded synchronously, we can parse the query string of its `src` path by examining the last script tag in the document. This *should* work for the case of `bootplate-moonstone` (and various related `bootplate` implementations) as we have control over the default implementation and how the script is being loaded. Also, cleaned up the option parsing a bit.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>