### PR TITLE
ENYO-1764: Remove 'aria-label' on controls witch added as default wit…

### DIFF
--- a/lib/AccessibilitySupport/AccessibilitySupport.js
+++ b/lib/AccessibilitySupport/AccessibilitySupport.js
@@ -137,12 +137,14 @@ module.exports = {
 	*/
 	updateAccessibilityAttributes: function (was, is, prop) {
 		var enabled = !this.accessibilityDisabled,
+			focusable = this.accessibilityLabel || this.content || this.accessibilityHint || null,
 			prefix = this.accessibilityLabel || this.content || null,
 			label = this.accessibilityHint && prefix && (prefix + ' ' + this.accessibilityHint) ||
 					this.accessibilityHint ||
-					prefix;
+					this.accessibilityLabel ||
+					null;
 
-		this.setAttribute('tabindex', label && enabled ? 0 : null);
+		this.setAttribute('tabindex', focusable && enabled ? 0 : null);
 		this.setAttribute('aria-label', enabled ? label : null);
 		this.setAttribute('role', this.accessibilityAlert && enabled ? 'alert' : null);
 		this.setAttribute('aria-live', this.accessibilityLive && enabled ? 'assertive' : null);

--- a/test/tests/AccessibilitySupport.js
+++ b/test/tests/AccessibilitySupport.js
@@ -31,13 +31,13 @@ describe('AccessibilitySupport', function () {
 				TestControl = null;
 			});
 
-			it ('should equal content', function () {
+			it ('should equal null with only content', function () {
 
 				testControl.set('content', content);
 				testControl.set('accessibilityLabel', '');
 				testControl.set('accessibilityHint', '');
 
-				expect(testControl.getAttribute('aria-label')).to.equal(content);
+				expect(testControl.getAttribute('aria-label')).to.equal(null);
 			});
 
 			it ('should equal accessibilityLabel without content', function () {


### PR DESCRIPTION
…h content value

As per blink engine turned out to support read content without adding
'aria-label', we will remove aria-label with same value as content. Enyo
control will have only tabindex=0 for supporting accessibility.
aria-label will be used only when we need to read something else.

https://jira2.lgsvl.com/browse/ENYO-1764
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>