### PR TITLE
Fixes ENYO-1677

### DIFF
--- a/lib/kind.js
+++ b/lib/kind.js
@@ -123,15 +123,12 @@ var concatenated = exports.concatenated = [];
 *
 * @public
 */
-exports.singleton = function (conf, context) {
+exports.singleton = function (conf) {
 	// extract 'name' property (the name of our singleton)
-	var name = conf.name;
 	delete(conf.name);
 	// create an unnamed kind and save its constructor's function
 	var Kind = kind(conf);
-	var inst;
-	// create the singleton with the previous name and constructor
-	utils.setPath.call(context || global, name, (inst = new Kind()));
+	var inst = new Kind();
 	return inst;
 };
 


### PR DESCRIPTION
Remove global namespace export of kind.singleton

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)