### PR TITLE
ENYO-1832: Fix typo that caused utils and dispatcher to be in the global scope.

### DIFF
--- a/lib/Popup/Popup.js
+++ b/lib/Popup/Popup.js
@@ -9,7 +9,7 @@ require('enyo');
 
 var
 	kind = require('../kind'),
-	options = require('../options');
+	options = require('../options'),
 	utils = require('../utils'),
 	dispatcher = require('../dispatcher');
 var


### PR DESCRIPTION
### Issue
Both `utils` and `dispatcher` were in the global scope.

### Fix
There was a typo where we had inadvertently used a semi-colon instead of a comma in a group `var` statement. The semi-colon has now been replaced with the comma.
 
Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>