### PR TITLE
ENYO-1285: Marquee ellipse 

### DIFF
--- a/source/dom/Control.js
+++ b/source/dom/Control.js
@@ -982,6 +982,24 @@
 
 			return this;
 		},
+			
+		/**
+		* A function that fires after the control has rendered. This performs a
+		* reflow.
+		*
+		* @public
+		*/
+		reflow: function () {
+			var child,
+				i = 0;
+
+			// notify children of reflow
+			this.inherited();
+
+			for (; (child = this.children[i]); ++i) {
+				if (child.generated) child.reflow();
+			}
+		},
 
 		/**
 		* A function that fires after the control has rendered. This performs a


### PR DESCRIPTION
Issue.

Children are not notified of a parents reflow event, but are re-rendered, which causes their own reflow. 

Fix.

Notify children of reflow, so that they do not need to be re-rendered to take reflow action

Enyo-DCO-1.1-Signed-off-by: Derek Anderson <derek.anderson@lge.com>