### PR TITLE
ENYO-1857: Fix Component.defaultKind declaration

### DIFF
--- a/lib/Component.js
+++ b/lib/Component.js
@@ -246,11 +246,6 @@ var Component = module.exports = kind(
 	/**
 	* @private
 	*/
-	defaultKind: Component,
-
-	/**
-	* @private
-	*/
 	handlers: {},
 
 	/**
@@ -992,6 +987,8 @@ var Component = module.exports = kind(
 		return this;
 	}
 });
+
+Component.prototype.defaultKind = Component;
 
 /**
 * @private


### PR DESCRIPTION
Since the defaultKind for Component is Component itself, we need
to wait until after the constructor is defined and then assign
defaultKind on the prototype.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)