### PR TITLE
ENYO-1880: Add animateTo function.

### DIFF
--- a/lib/LightPanels/LightPanels.js
+++ b/lib/LightPanels/LightPanels.js
@@ -199,7 +199,7 @@ module.exports = kind(
 	* @private
 	*/
 	indexChanged: function (was) {
-		this.setupTransitions(was, false);
+		this.setupTransitions(was);
 	},
 
 	/**

--- a/lib/LightPanels/LightPanels.js
+++ b/lib/LightPanels/LightPanels.js
@@ -199,7 +199,7 @@ module.exports = kind(
 	* @private
 	*/
 	indexChanged: function (was) {
-		this.setupTransitions(was, this.shouldAnimate());
+		this.setupTransitions(was, false);
 	},
 
 	/**
@@ -247,6 +247,18 @@ module.exports = kind(
 	*/
 
 	/**
+	* Animates to the specified panel index.
+	*
+	* @param {Number} index - The index of the panel we wish to animate a transition to.
+	* @public
+	*/
+	animateTo: function (index) {
+		var from = this.index;
+		this.index = index;
+		this.setupTransitions(from, true);
+	},
+
+	/**
 	* Transitions to the previous panel--i.e., the panel whose index value is one
 	* less than that of the current active panel.
 	*
@@ -258,7 +270,8 @@ module.exports = kind(
 			prevIndex = this.getPanels().length - 1;
 		}
 		if (prevIndex >= 0) {
-			this.set('index', prevIndex);
+			if (this.animate) this.animateTo(prevIndex);
+			else this.set('index', prevIndex);
 		}
 	},
 
@@ -274,7 +287,8 @@ module.exports = kind(
 			nextIndex = 0;
 		}
 		if (nextIndex < this.getPanels().length) {
-			this.set('index', nextIndex);
+			if (this.animate) this.animateTo(nextIndex);
+			else this.set('index', nextIndex);
 		}
 	},
 
@@ -306,13 +320,8 @@ module.exports = kind(
 			nextPanel.postTransition();
 		}
 
-		if (opts && opts.direct) {
-			var currentIndex = this.index;
-			this.index = newIndex;
-			this.setupTransitions(currentIndex, false);
-		} else {
-			this.set('index', newIndex);
-		}
+		if (!this.animate || (opts && opts.direct)) this.set('index', newIndex);
+		else this.animateTo(newIndex);
 
 		// TODO: When pushing panels after we have gone back (but have not popped), we need to
 		// adjust the position of the panels after the previous index before our push.
@@ -359,13 +368,8 @@ module.exports = kind(
 
 		targetIdx = (opts && opts.targetIndex != null) ? opts.targetIndex : lastIndex + newPanels.length - 1;
 
-		if (opts && opts.direct) {
-			var currentIndex = this.index;
-			this.index = targetIdx;
-			this.setupTransitions(currentIndex, false);
-		} else {
-			this.set('index', targetIdx);
-		}
+		if (!this.animate || (opts && opts.direct)) this.set('index', targetIdx);
+		else this.animateTo(targetIdx);
 
 		return newPanels;
 	},

--- a/lib/LightPanels/LightPanels.js
+++ b/lib/LightPanels/LightPanels.js
@@ -67,7 +67,8 @@ module.exports = kind(
 	published: {
 
 		/**
-		* The index of the active panel.
+		* The index of the active panel. Changing this value will trigger a non-animated transition
+		* to the new index.
 		*
 		* @type {Number}
 		* @default -1
@@ -76,7 +77,10 @@ module.exports = kind(
 		index: -1,
 
 		/**
-		* Indicates whether the panels animate when transitioning.
+		* Indicates whether the panels animate when transitioning. This applies to the
+		* [next]{module:enyo/LightPanels#next}, [previous]{module:enyo/LightPanels#previous},
+		* [pushPanel]{module:enyo/LightPanels#pushPanel}, and
+		* [pushPanels]{module:enyo/LightPanels#pushPanels} methods.
 		*
 		* @type {Boolean}
 		* @default true


### PR DESCRIPTION
### Issue
We needed to initiate a panel index change to an existing panel, without a transition animation.

### Fix
We did some refactoring and made a standard panel index change a non-animated function, and added an explicit `animateTo` function for initiating an animated panel index transition.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>