### PR TITLE
Enyo 1624 Allow the last page to update its metric only when it was generated before 

### DIFF
--- a/lib/VerticalDelegate.js
+++ b/lib/VerticalDelegate.js
@@ -403,12 +403,13 @@ module.exports = {
 	* @private
 	*/
 	modelsAdded: function (list, props) {
+		var cpp, end, pages, firstModifiedPage;
 
 		// if the list has not already reset, reset
 		if (!list.hasReset) return this.reset(list);
 
-		var cpp = this.controlsPerPage(list),
-			end = Math.max(list.$.page1.start, list.$.page2.start) + cpp - 1;
+		cpp = this.controlsPerPage(list);
+		end = Math.max(list.$.page1.start, list.$.page2.start) + cpp - 1;
 
 		// note that this will refresh the following scenarios
 		// 1. if the dataset was spliced in above the current indices and the last index added was
@@ -433,25 +434,18 @@ module.exports = {
 
 		// if we need to refresh, do it now and ensure that we're properly setup to scroll
 		// if we were adding to a partially filled page
-		if (props.index <= end ) this.refresh(list);
+		if (props.index <= end ) {
+			this.refresh(list);
+		}
 		else {
-			// The last page which more models are added needs to update list.metrics or not
-			var lastPageIndex = this.pageForIndex(list, props.index),
-				// the last page before model added
-				lastPage = list.metrics.pages[lastPageIndex];
+			// The first page affected by the added models and all pages thereafter
+			// need to have their metrics invalidated
+			pages = list.metrics.pages;
+			firstModifiedPage = this.pageForIndex(list, props.index);
 
-			// if last page was generated once, we may need to update the last page	
-			if (lastPage) {
-				var	sp = list.psizeProp,
-					// current page count after models added
-					pc = this.pageCount(list),
-					pageSize;
-
-				// if there is more pages after lastPage, the lastPage metric needs to be updated
-				if (lastPageIndex < pc) {
-					pageSize = this.defaultPageSize(list);
-					// if last page was not fully filled, we should update its metric
-					if (lastPage[sp] < pageSize) lastPage[sp] = pageSize;
+			for (var page in pages) {
+				if (page >= firstModifiedPage) {
+					pages[page] = null;
 				}
 			}
 

--- a/lib/VerticalDelegate.js
+++ b/lib/VerticalDelegate.js
@@ -435,20 +435,23 @@ module.exports = {
 		// if we were adding to a partially filled page
 		if (props.index <= end ) this.refresh(list);
 		else {
-			// we should confirm that the page which new models are added is need to update list.metrics
+			// The last page which more models are added needs to update list.metrics or not
 			var lastPageIndex = this.pageForIndex(list, props.index),
 				// the last page before model added
-				lastPage = list.metrics.pages[lastPageIndex],
-				sp = list.psizeProp,
-				// current page count after models added
-				pc = this.pageCount(list),
-				pageSize;
+				lastPage = list.metrics.pages[lastPageIndex];
 
-			// if there is more pages after lastPage, the lastPage metric needs to be updated
-			if (lastPageIndex < pc) {
-				pageSize = this.defaultPageSize(list);
-				if (lastPage[sp] < pageSize) {
-					lastPage[sp] = pageSize;
+			// if last page was generated once, we may need to update the last page	
+			if (lastPage) {
+				var	sp = list.psizeProp,
+					// current page count after models added
+					pc = this.pageCount(list),
+					pageSize;
+
+				// if there is more pages after lastPage, the lastPage metric needs to be updated
+				if (lastPageIndex < pc) {
+					pageSize = this.defaultPageSize(list);
+					// if last page was not fully filled, we should update its metric
+					if (lastPage[sp] < pageSize) lastPage[sp] = pageSize;
 				}
 			}
 

--- a/lib/VerticalDelegate.js
+++ b/lib/VerticalDelegate.js
@@ -408,7 +408,7 @@ module.exports = {
 		if (!list.hasReset) return this.reset(list);
 
 		var cpp = this.controlsPerPage(list),
-			end = Math.max(list.$.page1.start, list.$.page2.start) + cpp;
+			end = Math.max(list.$.page1.start, list.$.page2.start) + cpp - 1;
 
 		// note that this will refresh the following scenarios
 		// 1. if the dataset was spliced in above the current indices and the last index added was


### PR DESCRIPTION
Issue
-------
If more models are added to collection when the last page is not generated yet,  it fires error.

Cause
--------
I committed guard code to update the last page's metric which is not fully filled when we add more models. Because the last page which was not fully filled has smaller metric, so we will mis calculate a bufferSize.
However I didn't consider that the last page could not render yet. So it makes err.

Fix
----
Add guard code for the last page which is not rendered

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com 