### PR TITLE
ENYO-1687 : add aria-hidden attribute for accessibilityDisabled

### DIFF
--- a/lib/AccessibilitySupport/AccessibilitySupport.js
+++ b/lib/AccessibilitySupport/AccessibilitySupport.js
@@ -148,5 +148,6 @@ module.exports = {
 		this.setAttribute('aria-label', enabled ? label : null);
 		this.setAttribute('role', this.accessibilityAlert && enabled ? 'alert' : null);
 		this.setAttribute('aria-live', this.accessibilityLive && enabled ? 'assertive' : null);
+		this.setAttribute('aria-hidden', enabled ? null : 'true');
 	},
 };


### PR DESCRIPTION
## Issue 
Though accessiblityDisabled is set to true, screen reader reads contents like moonstone checkbox icon

## Cause
Screen reader reads dom node contents or aria-related attribute content like aria-label or aria-hint if accessibilityDisabled is not true. However, In the moonstone Icon, general unicode content is read out like 'checkbox' because browser supports it. 

## Fix
screen reader doesn't read node with aria-hidden attribute, so we add aria-hidden with true value when accessibilityDisabled is true

Enyo-DCO-1.1-Signed-off-by: Bongsub Kim bongsub.kim@lgepartner.com
