### PR TITLE
ENYO-1981: Prevent pushing panels when transitioning. General clean-up.

### DIFF
--- a/lib/LightPanels/LightPanel.js
+++ b/lib/LightPanels/LightPanel.js
@@ -7,6 +7,18 @@ var
 	Control = require('../Control');
 
 /**
+* @enum {Number}
+* @memberof module:enyo/LightPanel~LightPanel
+* @public
+*/
+var States = {
+	ACTIVE: 1,
+	ACTIVATING: 2,
+	DEACTIVATING: 3,
+	INACTIVE: 4
+};
+
+/**
 * A light-weight panels implementation that has basic support for side-to-side transitions
 * between child components.
 *
@@ -29,13 +41,20 @@ module.exports = kind(
 	kind: Control,
 
 	/**
-	* Is `true` if the panel is currently active; `false` otherwise.
+	* @private
+	*/
+	handlers: {
+		ontransitionend: 'transitionEnd'
+	},
+
+	/**
+	* The current [state]{@link module:enyo/LightPanel~LightPanel#States}.
 	*
-	* @type {Boolean}
-	* @default false
+	* @type {module:enyo/LightPanel~LightPanel#States}
+	* @default null
 	* @public
 	*/
-	active: false,
+	state: States.INACTIVE,
 
 	/**
 	* This overridable method is called before a transition.
@@ -49,5 +68,15 @@ module.exports = kind(
 	*
 	* @public
 	*/
-	postTransition: function () {}
+	postTransition: function () {},
+
+	/**
+	* @private
+	*/
+	transitionEnd: function (sender, ev) {
+		if (ev.originator === this) this.set('state', this.state == States.ACTIVATING ? States.ACTIVE : States.INACTIVE);
+	}
+
 });
+
+module.exports.States = States;

--- a/lib/LightPanels/LightPanel.js
+++ b/lib/LightPanels/LightPanel.js
@@ -1,0 +1,60 @@
+require('enyo');
+
+var
+	kind = require('../kind');
+
+var
+	Control = require('../Control');
+
+/**
+* A light-weight panels implementation that has basic support for side-to-side transitions
+* between child components.
+*
+* @class LightPanel
+* @extends module:enyo/Control~Control
+* @ui
+* @public
+*/
+module.exports = kind(
+	/** @lends module:enyo/LightPanel~LightPanel.prototype */ {
+
+	/**
+	* @private
+	*/
+	name: 'enyo.LightPanel',
+
+	/**
+	* @private
+	*/
+	kind: Control,
+
+	/**
+	* @private
+	* @lends module:enyo/LightPanels~LightPanels.prototype
+	*/
+	published: {
+
+		/**
+		* Is `true` if the panel is currently active; `false` otherwise.
+		*
+		* @type {Boolean}
+		* @default false
+		* @public
+		*/
+		active: false
+	},
+
+	/**
+	* This overridable method is called before a transition.
+	*
+	* @public
+	*/
+	preTransition: function () {},
+
+	/**
+	* This overridable method is called after a transition.
+	*
+	* @public
+	*/
+	postTransition: function () {}
+});

--- a/lib/LightPanels/LightPanel.js
+++ b/lib/LightPanels/LightPanel.js
@@ -29,20 +29,13 @@ module.exports = kind(
 	kind: Control,
 
 	/**
-	* @private
-	* @lends module:enyo/LightPanels~LightPanels.prototype
+	* Is `true` if the panel is currently active; `false` otherwise.
+	*
+	* @type {Boolean}
+	* @default false
+	* @public
 	*/
-	published: {
-
-		/**
-		* Is `true` if the panel is currently active; `false` otherwise.
-		*
-		* @type {Boolean}
-		* @default false
-		* @public
-		*/
-		active: false
-	},
+	active: false,
 
 	/**
 	* This overridable method is called before a transition.

--- a/lib/LightPanels/LightPanels.js
+++ b/lib/LightPanels/LightPanels.js
@@ -16,11 +16,12 @@ var
 	TaskManagerSupport = require('../TaskManagerSupport');
 
 var
-	LightPanel = require('./LightPanel');
+	LightPanel = require('./LightPanel'),
+	States = LightPanel.States;
 
 /**
 * @enum {Number}
-* @memberof module:moonstone/LightPanels~LightPanels
+* @memberof module:enyo/LightPanels~LightPanels
 * @public
 */
 var Direction = {
@@ -30,7 +31,7 @@ var Direction = {
 
 /**
 * @enum {Number}
-* @memberof module:moonstone/LightPanels~LightPanels
+* @memberof module:enyo/LightPanels~LightPanels
 * @public
 */
 var Orientation = {
@@ -172,19 +173,13 @@ module.exports = kind(
 	direction: Direction.FORWARDS,
 
 	/**
-	* @private
-	*/
-	handlers: {
-		ontransitionend: 'transitionFinished'
-	},
-
-	/**
 	* @method
 	* @private
 	*/
 	create: kind.inherit(function (sup) {
 		return function () {
 			sup.apply(this, arguments);
+			this._handleStateChange = this.bindSafely('handleStateChange');
 			this.orientationChanged();
 			this.directionChanged();
 			this.indexChanged();
@@ -536,7 +531,25 @@ module.exports = kind(
 		return this.generated && this.getPanels().length > 1 && this.animate;
 	},
 
+	/**
+	* @private
+	*/
+	addChild: kind.inherit(function (sup) {
+		return function (control) {
+			control.observe('state', this._handleStateChange);
+			sup.apply(this, arguments);
+		};
+	}),
 
+	/**
+	* @private
+	*/
+	removeChild: kind.inherit(function (sup) {
+		return function (control) {
+			sup.apply(this, arguments);
+			control.unobserve('state', this._handleStateChange);
+		};
+	}),
 
 	/*
 		==============
@@ -547,23 +560,22 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	transitionFinished: function (sender, ev) {
-		var panel = ev.originator;
+	handleStateChange: function (was, is) {
+		var panel;
+		if (was == States.ACTIVATING || was == States.DEACTIVATING) {
+			panel = was == States.ACTIVATING ? this._currentPanel : this._previousPanel;
+			panel.removeClass('transitioning');
 
-		if (panel === this._currentPanel) {
-			if ((this._indexDirection < 0 && (this.popOnBack || this.cacheViews) && this.index < this.getPanels().length - 1) ||
-				(this._indexDirection > 0 && (this.popOnForward || this.cacheViews) && this.index > 0)) {
-				this.popPanels(this.index, this._indexDirection);
-			}
-			if (this.popQueue && this.popQueue.length) this.finalizePurge();
-			this.transitioning = false;
+			// async'ing this as it seems to improve ending transition performance on the TV. Requires
+			// further investigation into its behavior.
+			asyncMethod(function () {
+				if (panel.postTransition) panel.postTransition();
+			});
+
+			if ((this._currentPanel.state == States.ACTIVE) &&
+				(!this._previousPanel || this._previousPanel.state == States.INACTIVE))
+				this.finishTransition();
 		}
-
-		panel.removeClass('transitioning');
-
-		asyncMethod(function () {
-			if (panel.postTransition) panel.postTransition();
-		});
 	},
 
 
@@ -573,6 +585,20 @@ module.exports = kind(
 		Private support methods
 		=======================
 	*/
+
+	/**
+	* When all transitions (i.e. next/previous panel) have completed, we perform some clean-up work.
+	*
+	* @private
+	*/
+	finishTransition: function () {
+		if ((this._indexDirection < 0 && (this.popOnBack || this.cacheViews) && this.index < this.getPanels().length - 1) ||
+			(this._indexDirection > 0 && (this.popOnForward || this.cacheViews) && this.index > 0)) {
+			this.popPanels(this.index, this._indexDirection);
+		}
+		if (this.popQueue && this.popQueue.length) this.finalizePurge();
+		this.transitioning = false;
+	},
 
 	/**
 	* Retrieves a cached panel or, if not found, creates a new panel
@@ -614,7 +640,7 @@ module.exports = kind(
 			this.transitioning = true;
 
 			if (currPanel) {
-				currPanel.set('active', false);
+				currPanel.set('state', States.INACTIVE);
 				if (currPanel.preTransition) currPanel.preTransition();
 			}
 
@@ -622,7 +648,7 @@ module.exports = kind(
 				nextPanel.render();
 			}
 
-			nextPanel.set('active', true);
+			nextPanel.set('state', States.ACTIVE);
 			if (nextPanel.preTransition) nextPanel.preTransition();
 
 			// only animate transition if there is more than one panel and/or we're animating
@@ -656,19 +682,21 @@ module.exports = kind(
 	* @private
 	*/
 	applyTransitions: function (nextPanel, direct) {
-		var previousPanel = this._currentPanel;
+		var previousPanel = this._previousPanel = this._currentPanel;
 
 		// apply the transition for the next panel
+		nextPanel.set('state', States.ACTIVATING);
 		dom.transformValue(nextPanel, 'translate' + this.orientation, '0%');
 		if (this._currentPanel) { // apply the transition for the current panel
+			this._currentPanel.set('state', States.DEACTIVATING);
 			this.shiftPanel(this._currentPanel, this._indexDirection);
 		}
 
 		this._currentPanel = nextPanel;
 
 		if (!this.shouldAnimate() || direct) { // ensure that `transitionFinished is called, regardless of animation
-			this.transitionFinished(nextPanel, {originator: nextPanel});
-			if (previousPanel) this.transitionFinished(previousPanel, {originator: previousPanel});
+			nextPanel.set('state', States.ACTIVE);
+			if (previousPanel) previousPanel.set('state', States.INACTIVE);
 		}
 	},
 

--- a/lib/LightPanels/LightPanels.js
+++ b/lib/LightPanels/LightPanels.js
@@ -16,6 +16,9 @@ var
 	ViewPreloadSupport = require('../ViewPreloadSupport'),
 	TaskManagerSupport = require('../TaskManagerSupport');
 
+var
+	LightPanel = require('./LightPanel');
+
 /**
 * The configurable options used by {@link module:enyo/LightPanels~LightPanels} when pushing panels.
 *
@@ -59,6 +62,11 @@ module.exports = kind(
 	* @private
 	*/
 	classes: 'enyo-light-panels',
+
+	/**
+	* @private
+	*/
+	defaultKind: LightPanel,
 
 	/**
 	* @private
@@ -711,3 +719,5 @@ module.exports = kind(
 	}
 
 });
+
+module.exports.Panel = LightPanel;

--- a/lib/LightPanels/LightPanels.js
+++ b/lib/LightPanels/LightPanels.js
@@ -8,8 +8,7 @@ require('enyo');
 var
 	kind = require('../kind'),
 	dom = require('../dom'),
-	utils = require('../utils'),
-	asyncMethod = utils.asyncMethod;
+	asyncMethod = require('../utils').asyncMethod;
 
 var
 	Control = require('../Control'),
@@ -18,6 +17,26 @@ var
 
 var
 	LightPanel = require('./LightPanel');
+
+/**
+* @enum {Number}
+* @memberof module:moonstone/LightPanels~LightPanels
+* @public
+*/
+var Direction = {
+	FORWARDS: 1,
+	BACKWARDS: -1
+};
+
+/**
+* @enum {Number}
+* @memberof module:moonstone/LightPanels~LightPanels
+* @public
+*/
+var Orientation = {
+	HORIZONTAL: 'X',
+	VERTICAL: 'Y'
+};
 
 /**
 * The configurable options used by {@link module:enyo/LightPanels~LightPanels} when pushing panels.
@@ -69,97 +88,88 @@ module.exports = kind(
 	defaultKind: LightPanel,
 
 	/**
-	* @private
-	* @lends module:enyo/LightPanels~LightPanels.prototype
+	* The index of the active panel.
+	*
+	* @type {Number}
+	* @default -1
+	* @public
 	*/
-	published: {
+	index: -1,
 
-		/**
-		* The index of the active panel. Changing this value will trigger a non-animated transition
-		* to the new index.
-		*
-		* @type {Number}
-		* @default -1
-		* @public
-		*/
-		index: -1,
+	/**
+	* Indicates whether the panels animate when transitioning.
+	*
+	* @type {Boolean}
+	* @default true
+	* @public
+	*/
+	animate: true,
 
-		/**
-		* Indicates whether the panels animate when transitioning. This applies to the
-		* [next]{module:enyo/LightPanels#next}, [previous]{module:enyo/LightPanels#previous},
-		* [pushPanel]{module:enyo/LightPanels#pushPanel}, and
-		* [pushPanels]{module:enyo/LightPanels#pushPanels} methods.
-		*
-		* @type {Boolean}
-		* @default true
-		* @public
-		*/
-		animate: true,
+	/**
+	* Indicates whether panels "wrap around" when moving past the end.
+	*
+	* @type {Boolean}
+	* @default false
+	* @public
+	*/
+	wrap: false,
 
-		/**
-		* Indicates whether panels "wrap around" when moving past the end.
-		*
-		* @type {Boolean}
-		* @default false
-		* @public
-		*/
-		wrap: false,
+	/**
+	* When `true`, previous panels are automatically popped when moving backwards.
+	*
+	* @type {Boolean}
+	* @default true
+	* @public
+	*/
+	popOnBack: true,
 
-		/**
-		* When `true`, panels are automatically popped when the user moves back.
-		*
-		* @type {Boolean}
-		* @default true
-		* @public
-		*/
-		popOnBack: true,
+	/**
+	* When `true`, previous panels are automatically popped when moving forwards.
+	*
+	* @type {Boolean}
+	* @default false
+	* @public
+	*/
+	popOnForward: false,
 
-		/**
-		* When `true`, panels are automatically popped when the user moves forward (they remain
-		* components of the parent to maintain the proper hierarchy).
-		*
-		* @type {Boolean}
-		* @default true
-		* @public
-		*/
-		popOnForward: true,
+	/**
+	* The amount of time, in milliseconds, to run the transition animation between panels.
+	*
+	* @type {Number}
+	* @default 250
+	* @public
+	*/
+	duration: 250,
 
-		/**
-		* The amount of time, in milliseconds, to run the transition animation between panels.
-		*
-		* @type {Number}
-		* @default 250
-		* @public
-		*/
-		duration: 250,
+	/**
+	* The timing function to be applied to the transition animation between panels. Please refer
+	* to https://developer.mozilla.org/en-US/docs/Web/CSS/transition-timing-function.
+	*
+	* @type {String}
+	* @default 'ease-out'
+	* @public
+	*/
+	timingFunction: 'ease-out',
 
-		/**
-		* The timing function to be applied to the transition animation between panels.
-		*
-		* @type {String}
-		* @default 'ease-out'
-		* @public
-		*/
-		timingFunction: 'ease-out',
+	/**
+	* The orientation of the panels. Possible values from
+	* {@link module:moonstone/LightPanels~Orientation}.
+	*
+	* @type {String}
+	* @default Orientation.HORIZONTAL
+	* @public
+	*/
+	orientation: Orientation.HORIZONTAL,
 
-		/**
-		* The orientation of the panels. Possible values are 'vertical' and 'horizontal'.
-		*
-		* @type {String}
-		* @default 'horizontal'
-		* @public
-		*/
-		orientation: 'horizontal',
-
-		/**
-		* The direction of the panel movement. Possible values are 'forwards' and 'backwards'.
-		*
-		* @type {String}
-		* @default 'forwards'
-		* @public
-		*/
-		direction: 'forwards'
-	},
+	/**
+	* The direction of the panel movement. Possible values from
+	* {@link module:moonstone/LightPanels~Direction}.
+	*
+	* @type {String}
+	* @default Direction.FORWARDS
+	* @public
+	*/
+	direction: Direction.FORWARDS,
 
 	/**
 	* @private
@@ -175,10 +185,6 @@ module.exports = kind(
 	create: kind.inherit(function (sup) {
 		return function () {
 			sup.apply(this, arguments);
-
-			this.addClass(this.orientation);
-			this.addClass(this.direction);
-
 			this.orientationChanged();
 			this.directionChanged();
 			this.indexChanged();
@@ -196,29 +202,33 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	orientationChanged: function () {
-		this._axis = this.orientation == 'horizontal' ? 'X' : 'Y';
+	directionChanged: function (was) {
+		var key, value;
+		for (key in Direction) {
+			value = Direction[key];
+			if (value == was) this.removeClass(key.toLowerCase());
+			if (value == this.direction) this.addClass(key.toLowerCase());
+		}
 	},
 
 	/**
 	* @private
 	*/
-	directionChanged: function () {
-		this._direction = this.direction == 'forwards' ? 1 : this.direction == 'backwards' ? -1 : 0;
+	orientationChanged: function (was) {
+		var key, value;
+		for (key in Orientation) {
+			value = Orientation[key];
+			if (value == was) this.removeClass(key.toLowerCase());
+			if (value == this.orientation) this.addClass(key.toLowerCase());
+		}
 	},
+
 
 	/**
 	* @private
 	*/
 	indexChanged: function (was) {
 		this.setupTransitions(was);
-	},
-
-	/**
-	* @private
-	*/
-	cacheViewsChanged: function () {
-		this.popOnForward = this.cacheViews;
 	},
 
 
@@ -315,6 +325,8 @@ module.exports = kind(
 	* @public
 	*/
 	pushPanel: function (info, moreInfo, opts) {
+		if (this.transitioning) return;
+
 		if (opts && opts.purge) {
 			this.purge();
 		}
@@ -353,6 +365,8 @@ module.exports = kind(
 	* @public
 	*/
 	pushPanels: function (info, moreInfo, opts) {
+		if (this.transitioning) return true;
+
 		if (opts && opts.purge) {
 			this.purge();
 		}
@@ -391,6 +405,8 @@ module.exports = kind(
 	* depending on the direction.
 	*
 	* @param {Number} index - Index at which to start destroying panels.
+	* @param {Number} direction - The direction in which we want to destroy panels. A negative
+	*	number signifies popping backwards, otherwise we pop forwards.
 	* @public
 	*/
 	popPanels: function (index, direction) {
@@ -456,7 +472,7 @@ module.exports = kind(
 	*/
 	resetView: function (view) {
 		// reset position
-		dom.transformValue(view, 'translate' + this._axis, 100 * this._direction + '%');
+		dom.transformValue(view, 'translate' + this.orientation, 100 * this.direction + '%');
 	},
 
 
@@ -532,30 +548,22 @@ module.exports = kind(
 	* @private
 	*/
 	transitionFinished: function (sender, ev) {
-		if (ev.originator === this._currentPanel) {
-			if ((this._indexDirection < 0 && this.popOnBack && this.index < this.getPanels().length - 1) ||
-				(this._indexDirection > 0 && this.popOnForward && this.index > 0)) {
+		var panel = ev.originator;
+
+		if (panel === this._currentPanel) {
+			if ((this._indexDirection < 0 && (this.popOnBack || this.cacheViews) && this.index < this.getPanels().length - 1) ||
+				(this._indexDirection > 0 && (this.popOnForward || this.cacheViews) && this.index > 0)) {
 				this.popPanels(this.index, this._indexDirection);
 			}
-			if (this._currentPanel.postTransition) {
-				asyncMethod(this, function () {
-					this._currentPanel.postTransition();
-				});
-			}
-			if (this._garbagePanels && this._garbagePanels.length) {
-				this.finalizePurge();
-			}
-
-			if (this._currentPanel) {
-				this._currentPanel.removeClass('transitioning');
-				this._currentPanel.activated && this._currentPanel.activated();
-			}
-
-			if (this._previousPanel) {
-				this._previousPanel.removeClass('transitioning');
-				this._previousPanel.deactivated && this._previousPanel.deactivated();
-			}
+			if (this.popQueue && this.popQueue.length) this.finalizePurge();
+			this.transitioning = false;
 		}
+
+		panel.removeClass('transitioning');
+
+		asyncMethod(function () {
+			if (panel.postTransition) panel.postTransition();
+		});
 	},
 
 
@@ -597,14 +605,25 @@ module.exports = kind(
 	setupTransitions: function (previousIndex, animate) {
 		var panels = this.getPanels(),
 			nextPanel = panels[this.index],
+			currPanel = this._currentPanel,
 			trans, wTrans;
 
 		this._indexDirection = this.index - previousIndex;
 
 		if (nextPanel) {
+			this.transitioning = true;
+
+			if (currPanel) {
+				currPanel.set('active', false);
+				if (currPanel.preTransition) currPanel.preTransition();
+			}
+
 			if (!nextPanel.generated) {
 				nextPanel.render();
 			}
+
+			nextPanel.set('active', true);
+			if (nextPanel.preTransition) nextPanel.preTransition();
 
 			// only animate transition if there is more than one panel and/or we're animating
 			if (animate) {
@@ -613,10 +632,11 @@ module.exports = kind(
 				nextPanel.applyStyle('-webkit-transition', wTrans);
 				nextPanel.applyStyle('transition', trans);
 				nextPanel.addClass('transitioning');
-				if (this._currentPanel) {
-					this._currentPanel.applyStyle('-webkit-transition', wTrans);
-					this._currentPanel.applyStyle('transition', trans);
-					this._currentPanel.addClass('transitioning');
+
+				if (currPanel) {
+					currPanel.applyStyle('-webkit-transition', wTrans);
+					currPanel.applyStyle('transition', trans);
+					currPanel.addClass('transitioning');
 				}
 
 				setTimeout(this.bindSafely(function () {
@@ -636,16 +656,19 @@ module.exports = kind(
 	* @private
 	*/
 	applyTransitions: function (nextPanel, direct) {
+		var previousPanel = this._currentPanel;
+
 		// apply the transition for the next panel
-		dom.transformValue(nextPanel, 'translate' + this._axis, '0%');
+		dom.transformValue(nextPanel, 'translate' + this.orientation, '0%');
 		if (this._currentPanel) { // apply the transition for the current panel
 			this.shiftPanel(this._currentPanel, this._indexDirection);
 		}
 
-		this._previousPanel = this._currentPanel;
 		this._currentPanel = nextPanel;
+
 		if (!this.shouldAnimate() || direct) { // ensure that `transitionFinished is called, regardless of animation
-			this.transitionFinished(this._currentPanel, {originator: this._currentPanel});
+			this.transitionFinished(nextPanel, {originator: nextPanel});
+			if (previousPanel) this.transitionFinished(previousPanel, {originator: previousPanel});
 		}
 	},
 
@@ -658,8 +681,8 @@ module.exports = kind(
 	* @private
 	*/
 	shiftPanel: function (panel, indexDirection) {
-		var value = (indexDirection > 0 ? -100 : 100) * this._direction + '%';
-		dom.transformValue(panel, 'translate' + this._axis, value);
+		var value = (indexDirection > 0 ? -100 : 100) * this.direction + '%';
+		dom.transformValue(panel, 'translate' + this.orientation, value);
 	},
 
 	/**
@@ -669,7 +692,7 @@ module.exports = kind(
 	*/
 	purge: function () {
 		var panels = this.getPanels();
-		this._garbagePanels = panels.slice();
+		this.popQueue = panels.slice();
 		panels.length = 0;
 		this.index = -1;
 	},
@@ -680,7 +703,7 @@ module.exports = kind(
 	* @private
 	*/
 	finalizePurge: function () {
-		var panels = this._garbagePanels,
+		var panels = this.popQueue,
 			panel;
 		while (panels.length) {
 			panel = panels.pop();
@@ -721,3 +744,5 @@ module.exports = kind(
 });
 
 module.exports.Panel = LightPanel;
+module.exports.Direction = Direction;
+module.exports.Orientation = Orientation;


### PR DESCRIPTION
### Issue
When panels are transitioning, panels can still be pushed, which causes undesired or unexpected behavior.

### Fix
We set a `transitioning` flag and guard against pushing panels when transitioning. We also do some general clean-up and removal of cruft.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>