### PR TITLE
Setup the default configuration for resolution independence support.

### DIFF
--- a/lib/resolution.js
+++ b/lib/resolution.js
@@ -93,7 +93,7 @@ var ri = module.exports = {
 		if (_oldScreenType) {
 			Dom.removeClass(document.body, 'enyo-res-' + _oldScreenType.toLowerCase());
 			var oldScrObj = getScreenTypeObject(_oldScreenType);
-			if (oldScrObj.aspectRatioName) {
+			if (oldScrObj && oldScrObj.aspectRatioName) {
 				Dom.removeClass(document.body, 'enyo-aspect-ratio-' + oldScrObj.aspectRatioName.toLowerCase());
 			}
 		}
@@ -248,3 +248,5 @@ var ri = module.exports = {
 		_riRatio = this.getRiRatio();
 	}
 };
+
+ri.init();


### PR DESCRIPTION
Includes a fix for a missing `oldScrObj` which can't exist on first run.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens <blake.stephens@lge.com>