### PR TITLE
ENYO-2027: Prevent shared data object.

### DIFF
--- a/src/FluxStore.js
+++ b/src/FluxStore.js
@@ -51,13 +51,6 @@ module.exports = kind(
 	*/
 	kind: CoreObject,
 
-
-	/**
-	* @private
-	*/
-	data: {},
-
-
 	/**
 	* How a store is identitified to the Flux Dispatcher. This ID is used for
 	* subscribing to a store's state notification change.
@@ -68,6 +61,9 @@ module.exports = kind(
 	*/
 	id: -1,
 
+	/**
+	* @private
+	*/
 	mixins: [EventEmitter, StateSupport],
 
 	/**
@@ -79,6 +75,10 @@ module.exports = kind(
 	*/
 	source: '',
 
+	/**
+	* @private
+	* @lends module:enyo/FluxStore~FluxStore.prototype
+	*/
 	published: {
 
 		/**
@@ -99,6 +99,7 @@ module.exports = kind(
 	constructor: kind.inherit(function (sup) {
 		return function () {
 			sup.apply(this, arguments);
+			this.reset();
 			//id the store with the dispatcher
 			this.id = FluxDispatcher.subscribe();
 


### PR DESCRIPTION
### Issue
The `data` object was being shared by all subkinds of `FluxStore`.

### Fix
We instantiate the `data` object in `create`.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>