### PR TITLE
Fixes ENYO-2032

### DIFF
--- a/lib/floatingLayer.js
+++ b/lib/floatingLayer.js
@@ -6,6 +6,7 @@
 require('enyo');
 
 var
+	dispatcher = require('./dispatcher'),
 	kind = require('./kind'),
 	platform = require('./platform');
 
@@ -88,6 +89,31 @@ module.exports = function (Control) {
 				return sup.apply(this, arguments);
 			};
 		}),
+
+		/**
+		* @private
+		*/
+		rendered: kind.inherit(function (sup) {
+			return function () {
+				sup.apply(this, arguments);
+				this.preventScroll();
+			};
+		}),
+
+		/**
+		* Implemented primarily to prevent browser-initiated scrolling controls within the floating
+		* layer into view when those controls are explicitly focus()'ed
+		*
+		* @private
+		*/
+		preventScroll: function () {
+			var node = this.hasNode();
+			if (node) {
+				dispatcher.listen(node, 'scroll', function () {
+					node.scrollTop = 0;
+				});
+			}
+		},
 
 		/**
 		* @private


### PR DESCRIPTION
## Issue
Calling `focus()` on a control within the floating layer causes the browser to scroll it into view which can break things like moonstone/Popup that are designed to animate into view.

## Fix
Prevent scrolling of the floating layer

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)