### PR TITLE
Fixes ENYO-2032

### DIFF
--- a/lib/AccessibilitySupport/AccessibilitySupport.js
+++ b/lib/AccessibilitySupport/AccessibilitySupport.js
@@ -1,5 +1,22 @@
 var
+	dispatcher = require('../dispatcher'),
 	kind = require('../kind');
+
+
+/**
+* Prevents browser-initiated scrolling contained controls into view when those controls are
+* explicitly focus()'ed.
+*
+* @private
+*/
+function preventScroll (node) {
+	if (node) {
+		dispatcher.listen(node, 'scroll', function () {
+			node.scrollTop = 0;
+			node.scrollLeft = 0;
+		});
+	}
+}
 
 /**
 * @name AccessibilityMixin
@@ -80,6 +97,17 @@ module.exports = {
 	accessibilityDisabled: false,
 
 	/**
+	* When true, `onscroll` events will be observed and scrolling prevented by resetting the
+	* `scrollTop` and `scrollLeft` of the node. This prevents inadvertent layout issues introduced
+	* by the browser scrolling contained controls into view when `focus()`'ed.
+	*
+	* @type {Boolean}
+	* @default false
+	* @public
+	*/
+	accessibilityPreventScroll: false,
+
+	/**
 	* @private
 	*/
 	observers: [
@@ -150,4 +178,16 @@ module.exports = {
 		this.setAttribute('aria-live', this.accessibilityLive && enabled ? 'assertive' : null);
 		this.setAttribute('aria-hidden', enabled ? null : 'true');
 	},
+
+	/**
+	* @private
+	*/
+	rendered: kind.inherit(function (sup) {
+		return function () {
+			sup.apply(this, arguments);
+			if (this.accessibilityPreventScroll) {
+				preventScroll(this.hasNode());
+			}
+		};
+	})
 };

--- a/lib/floatingLayer.js
+++ b/lib/floatingLayer.js
@@ -6,7 +6,6 @@
 require('enyo');
 
 var
-	dispatcher = require('./dispatcher'),
 	kind = require('./kind'),
 	platform = require('./platform');
 
@@ -49,6 +48,11 @@ module.exports = function (Control) {
 		classes: 'enyo-fit enyo-clip enyo-untouchable',
 
 		/**
+		* @private
+		*/
+		accessibilityPreventScroll: true,
+
+		/**
 		* @method
 		* @private
 		*/
@@ -89,31 +93,6 @@ module.exports = function (Control) {
 				return sup.apply(this, arguments);
 			};
 		}),
-
-		/**
-		* @private
-		*/
-		rendered: kind.inherit(function (sup) {
-			return function () {
-				sup.apply(this, arguments);
-				this.preventScroll();
-			};
-		}),
-
-		/**
-		* Implemented primarily to prevent browser-initiated scrolling controls within the floating
-		* layer into view when those controls are explicitly focus()'ed
-		*
-		* @private
-		*/
-		preventScroll: function () {
-			var node = this.hasNode();
-			if (node) {
-				dispatcher.listen(node, 'scroll', function () {
-					node.scrollTop = 0;
-				});
-			}
-		},
 
 		/**
 		* @private


### PR DESCRIPTION
Because there are a few places that can exhibit this bug (all thus far
demonstrated by programmatic focus from Spotlight), we've moved this
logic in AccessibilitySupport which is mixed into Control so it's more
broadly available.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)