### PR TITLE
ENYO-2126: Always attempt to update the source, regardless of generated state.

### DIFF
--- a/lib/Image/Image.js
+++ b/lib/Image/Image.js
@@ -247,8 +247,8 @@ module.exports = kind(
 		if (this.sizing) {
 			this.addClass(this.sizing);
 		}
+		this.updateSource();
 		if (this.generated) {
-			this.updateSource();
 			this.render();
 		}
 	},


### PR DESCRIPTION
### Issue
When setting the `sizing` property at component declaration time, the source is not properly set to be a background image.

### Fix
We move the call to `updateSource` outside the guard for the generated state.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>