### PR TITLE
ENYO-1013: Always attempt to update the source, regardless of generated state.

### DIFF
--- a/source/ui/Image.js
+++ b/source/ui/Image.js
@@ -190,8 +190,8 @@
 			if (this.sizing) {
 				this.addClass(this.sizing);
 			}
+			this.srcChanged();
 			if (this.generated) {
-				this.srcChanged();
 				this.render();
 			}
 		},


### PR DESCRIPTION
### Issue
When setting the `sizing` property at component declaration time, the source is not properly set to be a background image.

### Fix
We move the call to `srcChanged` outside the guard for the generated state.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>