### PR TITLE
ENYO-2145: More robust value parsing.

### DIFF
--- a/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
+++ b/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js
@@ -15,10 +15,10 @@
 	* @typedef {Object} ResolutionIndependence~Options
 	* @property {Number} baseSize - The root font-size we wish to use to base all of our conversions
 	*	upon.
-	* @property {String} riUnit - The unit of measurement to we wish to use for
-	*	resolution-independent units.
-	* @property {String} unit - The unit of measurement to that we wish to convert to
-	*	resolution-independent units.
+	* @property {String} riUnit - The unit of measurement we wish to use for resolution-independent
+	*	units.
+	* @property {String} unit - The unit of measurement we wish to convert to resolution-independent
+	*	units.
 	* @property {String} absoluteUnit - The unit of measurement to ignore for
 	*	resolution-independence conversion, and instead should be 1:1 converted to our `_unit` unit.
 	* @property {Number} minUnitSize - The minimum unit size (as an absolute value) that any
@@ -29,10 +29,16 @@
 	* @property {Number} precision - How precise our measurements will be, namely the maximum amount
 	*	of fractional digits that will appear in our converted measurements.
 	*/
-
 	var ResolutionIndependence = function (opts) {
 		this.configure(opts);
-	};
+	}
+
+	// The set of properties that can have comma-separated values, some of which can be in pixel units
+	var csvProps = [
+		'background',
+		'background-size',
+		'background-position'
+	];
 
 	ResolutionIndependence.prototype = {
 
@@ -46,7 +52,7 @@
 		_baseSize: 24,
 
 		/**
-		* The unit of measurement to we wish to use for resolution-independent units.
+		* The unit of measurement we wish to use for resolution-independent units.
 		*
 		* @type {String}
 		* @default 'rem'
@@ -55,7 +61,7 @@
 		_riUnit: 'rem',
 
 		/**
-		* The unit of measurement to that we wish to convert to resolution-independent units.
+		* The unit of measurement we wish to convert to resolution-independent units.
 		*
 		* @type {String}
 		* @default 'px'
@@ -140,24 +146,59 @@
 		/*
 		* Hook into each rule node
 		*
-		* @private
+		* @param {Object} node - The current LESS node to parse.
+		* @public
 		*/
 		visitRule: function (node) {
-			var ruleNode = node && !node.inline && node.value && node.value.value && node.value.value.length && node.value.value[0],
-				stringValues;
+			var ruleNode = node && !node.inline && node.value && node.value.value && node.value.value.length && node.value.value[0];
+			this._currentPropName = node.name;
+			this.processRuleNode(ruleNode);
+		},
 
-			// The value(s) of a CSS function call
-			if (Array.isArray(ruleNode.args)) {
-				ruleNode.args.forEach(this.updateNode.bind(this));
+		/**
+		* Processes a LESS rule node for conversion.
+		*
+		* @param {Object} ruleNode - A LESS rule node we wish to parse and convert.
+		* @private
+		*/
+		processRuleNode: function (ruleNode) {
+			var parsedString = '',
+				isString = false,
+				csvStrings, idx;
+
+			if (Array.isArray(ruleNode.args)) { // The value(s) of a CSS function call
+				for (idx = 0; idx < ruleNode.args.length; idx++) {
+					this.updateNode(ruleNode.args[idx]);
+				}
+			} else { // Value(s) that are not parameters of a function call
+				isString = typeof ruleNode.value == 'string';
+				if (csvProps.indexOf(this._currentPropName) > -1 && isString) {
+					csvStrings = ruleNode.value.split(',');
+				}
+
+				if (csvStrings && csvStrings.length) { // Multiple sets of comma-separated string values
+					for (idx = 0; idx < csvStrings.length; idx++) {
+						parsedString += (parsedString ? ', ' : '') + this.parseString(ruleNode, csvStrings[idx]);
+					}
+				} else if (isString) { // Multiple string values
+					parsedString = this.parseString(ruleNode);
+				} else { // A single value object
+					this.updateNode(ruleNode);
+				}
+
+				if (parsedString) ruleNode.value = parsedString;
 			}
-			// Directly set string values that have a number
-			else if (typeof ruleNode.value == 'string' && ruleNode.value.match(/\d+/g)) {
-				stringValues = ruleNode.value.match(/\S+/g) || [];
-				ruleNode.value = stringValues.map(this.parseValueString.bind(this)).join(' ');
-			}
-			// A single value
-			else {
-				this.updateNode(ruleNode);
+		},
+
+		/**
+		* Processes an array of LESS rule nodes for conversion.
+		*
+		* @param {Object[]} ruleNodes - An array of LESS rule nodes we wish to parse and convert.
+		* @private
+		*/
+		processRuleNodes: function (ruleNodes) {
+			for (var idx = 0; idx < ruleNodes.length; idx++) {
+				this.processRuleNode(ruleNodes[idx]);
 			}
 		},
 
@@ -179,7 +220,7 @@
 				// Multiple property values where at least one value is a LESS variable (LESS
 				// automatically converts all of the values into array items)
 				if (Array.isArray(value)) {
-					value.forEach(this.updateNode.bind(this));
+					this.processRuleNodes(value);
 				}
 
 				if (unitNode) {
@@ -190,6 +231,22 @@
 					ruleNode.value = this.parseValueString(value);
 				}
 			}
+		},
+
+		/**
+		* Parses a string value (which might need to be parsed into individual values).
+		*
+		* @param {Object} ruleNode - The rule node we are currently examining and will convert.
+		* @param {String} [stringValues] - The optional set of string values; if not present, then
+		*	the node's value will be used.
+		* @return {String[]} The set of parsed and converted values.
+		* @private
+		*/
+		parseString: function (ruleNode, stringValues) {
+			var value = stringValues || ruleNode.value;
+			stringValues = value.match(/\d+[\.]?\d+[^\s\.!]*|[!]*[^\s!]+/g);
+
+			if (stringValues) return stringValues.map(this.parseValueString.bind(this)).join(' ');
 		},
 
 		/**
@@ -271,6 +328,7 @@
 		convertValue: function (value) {
 			return parseFloat((value / this._baseSize).toFixed(this._precision));
 		}
+
 	};
 
 	if (typeof window != 'undefined') {


### PR DESCRIPTION
### Issue
The LESS API is fairly lacking and the initial pass of the resolution-independence plugin felt more like fumbling around in the dark. Now that we have a better idea of the API's behavior, we can take a step back and rework the parsing logic to more broadly handle different cases we will encounter.

### Fix
The parsing has been reworked to handle a variety of cases by recursively parsing each "value" until it can be resolved via conversion or is a string that does not require conversion. This is a version of https://github.com/enyojs/less-plugin-resolution-independence/pull/1 without tests. It would require some rejiggering of the plugin in order to make it effectively testable, and because the 2.6.x version was the high-priority need, we can either spend some more time on the 2.5.x version to make it testable (and integrate later), or move forward without tests for this version as it is effectively a dead-end branch.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>