### PR TITLE
ENYO-1906: Add Text to Speech Accessibility support to Popup and Cont…

### DIFF
--- a/lib/Popup/PopupAccessibilitySupport.js
+++ b/lib/Popup/PopupAccessibilitySupport.js
@@ -21,6 +21,7 @@ module.exports = {
 		return function (was, is, prop) {
 			sup.apply(this, arguments);
 			this.set('accessibilityAlert', this.accessibilityDisabled ? null : this.showing);
+			this.setAttribute('aria-live', 'off');
 		};
 	})
 };

--- a/lib/Popup/PopupAccessibilitySupport.js
+++ b/lib/Popup/PopupAccessibilitySupport.js
@@ -19,9 +19,11 @@ module.exports = {
 	*/
 	updateAccessibilityAttributes: kind.inherit(function (sup) {
 		return function (was, is, prop) {
+			var enabled = !this.accessibilityDisabled;
 			sup.apply(this, arguments);
-			this.set('accessibilityAlert', this.accessibilityDisabled ? null : this.showing);
+			this.set('accessibilityAlert', enabled ? this.showing : null);
 			this.setAttribute('aria-live', 'off');
+			this.setAttribute('aria-hidden', enabled ? !this.showing : true);
 		};
 	})
 };


### PR DESCRIPTION
…extual Popup

Basically alert role has 'aria-live' attribute, but in case popup
we only use when popup occurs so it doesn't need 'aria-live'.
If popuup has marquee text, it will read the text continuosly.
Set 'aria-live' to 'off'

https://jira2.lgsvl.com/browse/ENYO-1906
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>