### PR TITLE
ENYO-2166 : compareDocumentPosition null error

### DIFF
--- a/source/dom/dom.js
+++ b/source/dom/dom.js
@@ -220,9 +220,9 @@
 		// Workaround for lack of compareDocumentPosition support in IE8
 		// Code MIT Licensed, John Resig; source: http://ejohn.org/blog/comparing-document-position/
 		compareDocumentPosition: function(a, b) {
-			return a.compareDocumentPosition ?
+			return a && a.compareDocumentPosition && b ?
 			a.compareDocumentPosition(b) :
-			a.contains ?
+			a.contains && b ?
 				(a != b && a.contains(b) && 16) +
 				(a != b && b.contains(a) && 8) +
 				(a.sourceIndex >= 0 && b.sourceIndex >= 0 ?


### PR DESCRIPTION
This cropped up again through a patch that was not forward ported. After inspecting the patch that was done in back in 2.5.5 , I wonder if this fix wouldn't be a better solution at a lower level.

Issue.

When using spotlight a null exception is thrown when using contains with a null node.

Fix.

Enhance the former j.resig code with guards. If a or b are null, then 0000 is returned back to spotlight, indicating there is no need for the spot to move, as it is still on the originating node.

Enyo-DCO-1.1-Signed-off-by: Derek Anderson derek.anderson@lge.com