### PR TITLE
ENYO-2177: Invalidate attributes to ensure changes...

### DIFF
--- a/lib/Control.js
+++ b/lib/Control.js
@@ -453,7 +453,9 @@ var Control = module.exports = kind(
 				if (value == null || value === false || value === '') {
 					node.removeAttribute(name);
 				} else node.setAttribute(name, value);
-			} else delegate.invalidate(this, 'attributes');
+			}
+
+			delegate.invalidate(this, 'attributes');
 		}
 
 		return this;


### PR DESCRIPTION
...will be preserved when re-rendering a Control. We were already
doing this in the special case of the `classes` attribute, but not
in the more general case, so post-render changes made via
`setAttribute()` were being lost if the control were subsequently
re-rendered.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)