### PR TITLE
ENYO-2129 : add aria-pressed to child Item of Group

### DIFF
--- a/lib/Group/GroupAccessibilitySupport.js
+++ b/lib/Group/GroupAccessibilitySupport.js
@@ -25,5 +25,35 @@ module.exports = {
 			this.setAttribute('tabindex', enabled ? 0 : null);
 			this.setAttribute('aria-activedescendant', this.active && enabled ? this.active.getId() : null);
 		};
+	}),
+
+	/**
+	* @private
+	*/
+	activeChanged: kind.inherit(function (sup) {
+		return function (was, is, prop) {
+			var enabled = !this.accessibilityDisabled;
+			sup.apply(this, arguments);
+			if (was && !was.destroyed) {
+				was.setAttribute('aria-pressed', enabled ? String(was.active) : null);
+			}
+			if (this.active) {
+				this.active.setAttribute('aria-pressed', enabled ? String(this.active.active) : null);
+			}
+		};
+	}),
+
+	/**
+	* @private
+	*/
+	rendered: kind.inherit(function (sup) {
+		return function (was, is, prop) {
+			var enabled = !this.accessibilityDisabled,
+				i = 0;
+			sup.apply(this, arguments);
+			for (; i < this.controls.length; ++i) {
+				this.controls[i].setAttribute('aria-pressed', enabled ? String(this.controls[i].active) : null);
+			}
+		};
 	})
 };

--- a/lib/Group/GroupAccessibilitySupport.js
+++ b/lib/Group/GroupAccessibilitySupport.js
@@ -30,29 +30,24 @@ module.exports = {
 	/**
 	* @private
 	*/
-	activeChanged: kind.inherit(function (sup) {
-		return function (was, is, prop) {
+	activate: kind.inherit(function (sup) {
+		return function (sender, e) {
 			var enabled = !this.accessibilityDisabled;
 			sup.apply(this, arguments);
-			if (was && !was.destroyed && (was.getAttribute('role') === 'button')) {
-				was.setAttribute('aria-pressed', enabled ? String(was.active) : null);
+			if ((this.groupName || e.originator.groupName) && (e.originator.groupName != this.groupName)) {
+				return;
 			}
-			if (this.active && (this.active.getAttribute('role') === 'button')) {
-				this.active.setAttribute('aria-pressed', enabled ? String(this.active.active) : null);
-			}
-		};
-	}),
-
-	/**
-	* @private
-	*/
-	rendered: kind.inherit(function (sup) {
-		return function (was, is, prop) {
-			var enabled = !this.accessibilityDisabled,
-				i = 0;
-			sup.apply(this, arguments);
-			for (; i < this.controls.length; ++i) {
-				this.controls[i].setAttribute('aria-pressed', enabled && (this.controls[i].getAttribute('role') === 'button') ? String(this.controls[i].active) : null);
+			if (this.highlander) {
+				if (!e.originator.active) {
+					e.originator.setAttribute('aria-pressed', enabled ? 'false' : null);
+					if (e.originator == this.active) {
+						if (!this.allowHighlanderDeactivate) {
+							this.active.setAttribute('aria-pressed', enabled ? 'true' : null);
+						}
+					}
+				} else {
+					e.originator.setAttribute('aria-pressed', enabled ? 'true' : null);
+				}
 			}
 		};
 	})

--- a/lib/Group/GroupAccessibilitySupport.js
+++ b/lib/Group/GroupAccessibilitySupport.js
@@ -34,10 +34,10 @@ module.exports = {
 		return function (was, is, prop) {
 			var enabled = !this.accessibilityDisabled;
 			sup.apply(this, arguments);
-			if (was && !was.destroyed) {
+			if (was && !was.destroyed && (was.getAttribute('role') === 'button')) {
 				was.setAttribute('aria-pressed', enabled ? String(was.active) : null);
 			}
-			if (this.active) {
+			if (this.active && (this.active.getAttribute('role') === 'button')) {
 				this.active.setAttribute('aria-pressed', enabled ? String(this.active.active) : null);
 			}
 		};
@@ -52,7 +52,7 @@ module.exports = {
 				i = 0;
 			sup.apply(this, arguments);
 			for (; i < this.controls.length; ++i) {
-				this.controls[i].setAttribute('aria-pressed', enabled ? String(this.controls[i].active) : null);
+				this.controls[i].setAttribute('aria-pressed', enabled && (this.controls[i].getAttribute('role') === 'button') ? String(this.controls[i].active) : null);
 			}
 		};
 	})


### PR DESCRIPTION
## Issue 
Accessibility: Do not read the active status of the grouped buttons

## Cause
Button wrapped using enyo Group does not have aria-pressed attribute, which is neccessary for reading own status. However, If Button is not child of Group, Button should not have aria-pressed attribute since it is used in ToggleButton for reading toggle status, so we should add only aria-pressed attribute when button is child of group. 

## Fix
Add aria-pressed attribute when button is child of Group.

Enyo-DCO-1.1-Signed-off-by: Bongsub Kim bongsub.kim@lgepartner.com
