### PR TITLE
ENYO-2198: Added support for new `groupable` option

### DIFF
--- a/lib/Group/Group.js
+++ b/lib/Group/Group.js
@@ -60,17 +60,17 @@ module.exports = kind(
 	* @private
 	*/
 	mixins: options.accessibility ? [GroupAccessibilitySupport] : null,
-	
+
 	/**
 	* @private
 	*/
-	published: 
+	published:
 		/** @lends module:enyo/Group~Group.prototype */ {
-		
+
 		/**
-		* If `true`, only one [GroupItem]{@link module:enyo/GroupItem~GroupItem} in the 
+		* If `true`, only one [GroupItem]{@link module:enyo/GroupItem~GroupItem} in the
 		* [component]{@link module:enyo/Component~Component} list may be active at a given time.
-		* 
+		*
 		* @type {Boolean}
 		* @default true
 		* @public
@@ -79,7 +79,7 @@ module.exports = kind(
 
 		/**
 		* If `true`, an active highlander item may be deactivated.
-		* 
+		*
 		* @type {Boolean}
 		* @default false
 		* @public
@@ -88,19 +88,19 @@ module.exports = kind(
 
 		/**
 		* The [control]{@link module:enyo/Control~Control} that was last selected.
-		* 
+		*
 		* @type {Object}
 		* @default null
 		* @public
 		*/
 		active: null,
-	
+
 		/**
 		* This property is used to scope this [group]{@link module:enyo/Group~Group} to a certain
 		* set of [controls]{@link module:enyo/Control~Control}.  When this is used, the group only
 		* controls activation of controls that have the same `groupName` property set
 		* on them.
-		* 
+		*
 		* @type {String}
 		* @default null
 		* @public
@@ -114,7 +114,7 @@ module.exports = kind(
 	events: {
 		onActiveChanged: ""
 	},
-	
+
 	/**
 	* @private
 	*/
@@ -126,12 +126,12 @@ module.exports = kind(
 	* @private
 	*/
 	activate: function (sender, e) {
-		if ((this.groupName || e.originator.groupName) && (e.originator.groupName != this.groupName)) {
+		if (((this.groupName || e.originator.groupName) && (e.originator.groupName != this.groupName)) || !e.originator.groupable) {
 			return;
 		}
 		if (this.highlander) {
-			// we can optionally accept an `allowHighlanderDeactivate` property in e without directly 
-			// specifying it when instatiating the group - used mainly for custom kinds requiring deactivation  
+			// we can optionally accept an `allowHighlanderDeactivate` property in e without directly
+			// specifying it when instatiating the group - used mainly for custom kinds requiring deactivation
 			if (e.allowHighlanderDeactivate !== undefined && e.allowHighlanderDeactivate !== this.allowHighlanderDeactivate) {
 				this.setAllowHighlanderDeactivate(e.allowHighlanderDeactivate);
 			}

--- a/lib/Group/Group.js
+++ b/lib/Group/Group.js
@@ -126,7 +126,7 @@ module.exports = kind(
 	* @private
 	*/
 	activate: function (sender, e) {
-		if (((this.groupName || e.originator.groupName) && (e.originator.groupName != this.groupName)) || !e.originator.groupable) {
+		if (((this.groupName || e.originator.groupName) && (e.originator.groupName != this.groupName)) || e.originator.groupable === false) {
 			return;
 		}
 		if (this.highlander) {


### PR DESCRIPTION
`Groupable:false` will ignore the fact that it's inside a group. 😥
Evidently also much trailing whitespace cleanup.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
