### PR TITLE
ENYO-2227: RepeaterChildSupport mixin shouldn't stomp modelChanged

### DIFF
--- a/lib/RepeaterChildSupport.js
+++ b/lib/RepeaterChildSupport.js
@@ -75,9 +75,12 @@ var RepeaterChildSupport = {
 	* @method
 	* @private
 	*/
-	modelChanged: function () {
-		this.syncBindings();
-	},
+	modelChanged: kind.inherit(function (sup) {
+		return function () {
+			this.syncBindings();
+			sup.apply(this, arguments);
+		};
+	}),
 
 	/*
 	* @method


### PR DESCRIPTION
The RepeaterChildSupport mixin implements a modelChanged method to
update passive bindings, but this method unintentionally overrides
any implementation of that method that may exist in the kind that
applies the mixin.

We need to have the mixin's implementation call the method
inherited from the target kind.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)