### PR TITLE
Fixes ENYO-2223

### DIFF
--- a/lib/Scrollable/Scrollable.js
+++ b/lib/Scrollable/Scrollable.js
@@ -222,6 +222,7 @@ module.exports = {
 				defProps = this.defaultProps;
 
 			this.defaultProps = {};
+			this.accessibilityPreventScroll = true;
 			
 			this.createComponents(smc, {isChrome: true, owner: this});
 			if (this.scrollControls) {


### PR DESCRIPTION
## Issue
Programmatic `focus()`-ing controls causes the browser to scroll the control into view using `scrollTop` and `scrollLeft` on the nearest scrolling context ancestor that would bring it into view

## Fix
Set `accessibilityPreventScroll` on controls applying enyo/Scrollable.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)