### PR TITLE
ENYO-2205 Initialize selected items when collection changed

### DIFF
--- a/lib/DataRepeater.js
+++ b/lib/DataRepeater.js
@@ -16,6 +16,14 @@ function at (idx) {
 	return this[idx];
 }
 
+function arrayFilter (record) {
+	return record[this.selectionProperty];
+}
+
+function modelFilter (record) {
+	return record.get(this.selectionProperty);
+}
+
 /**
 * {@link module:enyo/DataRepeater~DataRepeater} iterates over the items in an {@link module:enyo/Collection~Collection} to
 * repeatedly render and synchronize records (instances of {@link module:enyo/Model~Model}) to its
@@ -60,9 +68,9 @@ var DataRepeater = module.exports = kind(
 	* selection and deselection of a single item at a time. The 'multi' selection mode allows
 	* multiple children to be selected simultaneously, while the 'group' selection mode allows
 	* group-selection behavior such that only one child may be selected at a time and, once a
-	* child is selected, it cannot be deselected via user input. The child may still be 
+	* child is selected, it cannot be deselected via user input. The child may still be
 	* deselected via the selection API methods.
-	* 
+	*
 	* @type {String}
 	* @default 'single'
 	* @public
@@ -454,7 +462,8 @@ var DataRepeater = module.exports = kind(
 	* @private
 	*/
 	initCollection: function (c, p) {
-		var e;
+		var e, filter, isArray = c && c instanceof Array;
+
 		if (c && c.addListener) {
 			for (e in this._handlers) {
 				c.addListener(e, this._handlers[e]);
@@ -464,12 +473,18 @@ var DataRepeater = module.exports = kind(
 		// access members of our dataset consistently, regardless
 		// of whether our data is in an array or a Collection
 		if (c && !c.at) {
-			c.at = at.bind(c);
+			Object.defineProperty(c, 'at', {value: at, enumerable: false});
 		}
 		if (p && p.removeListener) {
 			for (e in this._handlers) {
 				p.removeListener(e, this._handlers[e]);
 			}
+		}
+		if (c && this.selectionProperty) {
+			filter = isArray ? arrayFilter : modelFilter;
+			this._selection = c.filter(filter, this);
+		} else {
+			this._selection = [];
 		}
 	},
 


### PR DESCRIPTION
* Issue *
Selection handling in DataRepeater/DataList was inconsistent. Selections would not be properly tracked with DataList and selections were not reset when changing collections.

* Solution *
If a `selectionProperty` is defined, filter out selected items to initialize the internal `_selection` property.

Enyo-DCO-1.1-Signed-off-by: Roy Sutton <roy.sutton@lge.com>