### PR TITLE
ENYO-1981: Call activated/deactivated lifecycle methods, for now.

### DIFF
--- a/lib/LightPanels/LightPanel.js
+++ b/lib/LightPanels/LightPanel.js
@@ -68,7 +68,11 @@ module.exports = kind(
 	*
 	* @public
 	*/
-	postTransition: function () {},
+	postTransition: function () {
+		// TODO: this is added for backwards-compatibility and is deprecated functionality
+		if (this.state == States.ACTIVE && this.activated) this.activated();
+		else if (this.state == States.INACTIVE && this.deactivated) this.deactivated();
+	},
 
 	/**
 	* @private


### PR DESCRIPTION
### Issue
To further decouple updating the app from updating the framework, with regard to `LightPanels`, we need to support the existing lifecycle API being used by the app.

### Fix
We add some backwards-compatibility code to execute the `activated` and `deactivated` lifecycle methods.

This change is related to https://github.com/enyojs/moonstone/pull/2393.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>