### PR TITLE
ENYO-2257 DataList/DataRepeater does not update selection with POJOs

### DIFF
--- a/src/DataRepeater.js
+++ b/src/DataRepeater.js
@@ -630,6 +630,7 @@ var DataRepeater = module.exports = kind(
 			}
 			else {
 				model[p] = select;
+				if(c) c.syncBindings({force: true, all: true});
 			}
 		}
 		this.notifyObservers('selected');


### PR DESCRIPTION
## Issue
POJO selection not working because bindings do not update when we change the underlying selection property

## Solution
Call the `syncBindings()` method on the row when we update the selection property

Enyo-DCO-1.1-Signed-off-by: Roy Sutton <roy.sutton@lge.com>