### PR TITLE
ENYO-2258-Scroller in list action is not showed

### DIFF
--- a/lib/Control.js
+++ b/lib/Control.js
@@ -802,7 +802,7 @@ var Control = module.exports = kind(
 
 			// If any layout was reflowed while it's not showing, it is reflowed
 			// again while showing 
-			if (this.layout && this._hideReflow) {
+			if (this.layout && this._hiddenReflow) {
 				this.reflow();
 			}
 

--- a/lib/Control.js
+++ b/lib/Control.js
@@ -799,7 +799,13 @@ var Control = module.exports = kind(
 				this.set('canGenerate', true);
 				this.render();
 			}
-			
+
+			// If any layout was reflowed while it's not showing, it is reflowed
+			// again while showing 
+			if (this.layout && this._hideReflow) {
+				this.reflow();
+			}
+
 			this.sendShowingChangedEvent(was);
 		}
 

--- a/lib/UiComponent.js
+++ b/lib/UiComponent.js
@@ -619,7 +619,7 @@ var UiComponent = module.exports = kind(
 	reflow: function () {
 		if (this.layout) {
 			this.layout.reflow();
-			this._hideReflow = this.showing? false: true;
+			this._hiddenReflow = this.showing ? false : true;
 		}
 	},
 

--- a/lib/UiComponent.js
+++ b/lib/UiComponent.js
@@ -619,6 +619,7 @@ var UiComponent = module.exports = kind(
 	reflow: function () {
 		if (this.layout) {
 			this.layout.reflow();
+			this._hideReflow = this.showing? false: true;
 		}
 	},
 


### PR DESCRIPTION
Issue: Scroller is '0' height as its parent is reflowed while its in
hidden state
Fix: While reflowing, the particular state is remembered and while its
showing based on the state the control is reflowed again.
Enyo-DCO-1.1-Signed-off-by: Rajyavardhan P <rajyavardhan.p@lge.com>