### PR TITLE
ENYO-2313: In enyo/Image, ensure that placeholder image fits

### DIFF
--- a/lib/Image/Image.css
+++ b/lib/Image/Image.css
@@ -1,7 +1,10 @@
-.enyo-image.sized {
-	display: inline-block;
+.enyo-image {
 	background-position: center;
 	background-repeat: no-repeat;
+	background-size: cover;
+}
+.enyo-image.sized {
+	display: inline-block;
 }
 .enyo-image.contain {
 	background-size: contain;


### PR DESCRIPTION
At least in cases where the image size was not explicitly
specified and the sizing option was not being used, the placeholder
image was not properly scaled to the size of the image element.

Some simple CSS refactoring takes care of that.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)