### PR TITLE
Fixes ENYO-2368

### DIFF
--- a/lib/History.js
+++ b/lib/History.js
@@ -81,6 +81,16 @@ var EnyoHistory = module.exports = kind.singleton(
 	enabled: true,
 
 	/**
+	* When true, the browser's history will be updated when history entries are added or removed. If
+	* the platform does not support this feature, the value will always be false. The default is
+	* true if supported by the platform and false otherwise.
+	*
+	* @type {Boolean}
+	* @private
+	*/
+	updateHistory: _supports,
+
+	/**
 	* @private
 	*/
 	components: [
@@ -98,6 +108,15 @@ var EnyoHistory = module.exports = kind.singleton(
 		_pushQueued = false;
 		_processing = false;
 		this.stopJob('history.go');
+	},
+
+	/**
+	* Resets the value to false if the platform does not support the History API
+	*
+	* @private
+	*/
+	updateHistoryChanged: function () {
+		this.updateHistory = this.updateHistory && _supports;
 	},
 
 	// Public methods
@@ -300,8 +319,8 @@ var EnyoHistory = module.exports = kind.singleton(
 			// defer the actual 'back' action so pop() or drop() can be called multiple times in the
 			// same frame. Otherwise, only the first go() would be observed.
 			this.startJob('history.go', function () {
-				// If the platform supports pushState and the effective change is positive
-				if (_supports && _popQueueCount > 0) {
+				// If we are able to and supposed to update history and there are pending pops
+				if (this.updateHistory && _popQueueCount > 0) {
 					// go back that many entries
 					global.history.go(-_popQueueCount);
 				} else {
@@ -338,7 +357,7 @@ var EnyoHistory = module.exports = kind.singleton(
 		var id = entry.context && entry.context.id || 'anonymous',
 			location = entry.location || '';
 		_history.push(entry);
-		if (_supports && !silenced) {
+		if (this.updateHistory && !silenced) {
 			global.history.pushState({id: id}, '', location);
 		}
 	},
@@ -361,7 +380,7 @@ var EnyoHistory = module.exports = kind.singleton(
 	*/
 	handleKeyUp: function (sender, event) {
 		var current = this.peek();
-		if (event.keySymbol == 'back' && current && current.getShowing()) {
+		if (event.keySymbol == 'back' && current && current.context.getShowing()) {
 			this.pop();
 		}
 		return true;


### PR DESCRIPTION
add updateHistory property to enyo/History

When false, enyo/History will only maintain its internal history stack
and will not update window.history.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)