### PR TITLE
ENYO-2384: Use panel container wrapper for panels.

### DIFF
--- a/src/LightPanels/LightPanel.js
+++ b/src/LightPanels/LightPanel.js
@@ -41,13 +41,6 @@ module.exports = kind(
 	kind: Control,
 
 	/**
-	* @private
-	*/
-	handlers: {
-		ontransitionend: 'transitionEnd'
-	},
-
-	/**
 	* The current [state]{@link module:enyo/LightPanel~LightPanel#States}.
 	*
 	* @type {module:enyo/LightPanel~LightPanel#States}
@@ -68,18 +61,7 @@ module.exports = kind(
 	*
 	* @public
 	*/
-	postTransition: function () {
-		// TODO: this is added for backwards-compatibility and is deprecated functionality
-		if (this.state == States.ACTIVE && this.activated) this.activated();
-		else if (this.state == States.INACTIVE && this.deactivated) this.deactivated();
-	},
-
-	/**
-	* @private
-	*/
-	transitionEnd: function (sender, ev) {
-		if (ev.originator === this) this.set('state', this.state == States.ACTIVATING ? States.ACTIVE : States.INACTIVE);
-	}
+	postTransition: function () {}
 
 });
 

--- a/src/LightPanels/LightPanels.css
+++ b/src/LightPanels/LightPanels.css
@@ -7,7 +7,16 @@
 	overflow: hidden;
 }
 
-.enyo-light-panels > * {
+/* Panels container styles */
+
+.enyo-light-panels.transitioning .panels-container {
+	-webkit-transform: translateZ(0);
+	transform: translateZ(0);
+}
+
+.enyo-light-panels .panels-container > * {
+	display: inline-block;
+	vertical-align: top;
 	position: absolute;
 	top: 0;
 	left: 0;
@@ -16,22 +25,42 @@
 	box-sizing: border-box;
 }
 
-.enyo-light-panels.horizontal.forwards > * {
-	transform: translateX(100%);
-	-webkit-transform: translateX(100%);
+.enyo-light-panels.horizontal .panels-container {
+	width: 200%;
+	height: 100%;
 }
 
-.enyo-light-panels.horizontal.backwards > * {
-	transform: translateX(-100%);
-	-webkit-transform: translateX(-100%);
+.enyo-light-panels.vertical .panels-container {
+	width: 100%;
+	height: 200%;
 }
 
-.enyo-light-panels.vertical.forwards > * {
-	transform: translateY(100%);
-	-webkit-transform: translateY(100%);
+.enyo-light-panels.horizontal .panels-container > * {
+	width: 50%;
 }
 
-.enyo-light-panels.vertical.backwards > * {
-	transform: translateY(-100%);
-	-webkit-transform: translateY(-100%);
+.enyo-light-panels.vertical .panels-container > * {
+	height: 50%;
+}
+
+/* Individual panel styles */
+
+.enyo-light-panels.horizontal.forwards .panels-container > .next,
+.enyo-light-panels.horizontal.backwards .panels-container > .previous {
+	left: 50%;
+}
+
+.enyo-light-panels.horizontal.backwards .panels-container > .next,
+.enyo-light-panels.horizontal.forwards .panels-container > .previous {
+	right: 50%;
+}
+
+.enyo-light-panels.vertical.forwards .panels-container > .next,
+.enyo-light-panels.vertical.backwards .panels-container > .previous {
+	top: 50%;
+}
+
+.enyo-light-panels.vertical.backwards .panels-container > .next,
+.enyo-light-panels.vertical.forwards .panels-container > .previous {
+	bottom: 50%;
 }

--- a/src/ViewPreloadSupport.js
+++ b/src/ViewPreloadSupport.js
@@ -45,9 +45,15 @@ var ViewPreloadSupport = {
 			sup.apply(this, arguments);
 
 			if (this.cacheViews) {
+				// we don't want viewCache to be added to the client area, so we cache the original
+				// controlParent and restore it afterward
+				var cp = this.controlParent;
+				this.controlParent = null;
 				this.createChrome([
 					{name: 'viewCache', kind: Control, canGenerate: false}
 				]);
+				this.controlParent = cp;
+
 				this.removeChild(this.$.viewCache);
 				this._cachedViews = {};
 			}


### PR DESCRIPTION
### Issue
When changing panel indices, we had been transitioning the previous and current panels individually, and this caused some visual glitches on slower processors. Additionally, it seemed that the transition logic could be made more efficient if we transitioned a single element.

### Fix
We have wrapped the transitioning panels in a container and transition the container, instead. This allowed for some clean-up and simplification of the transition logic. Lastly, we have also removed the backward-compatibility calls for `activated` and `deactivated`, as those were deprecated.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>