### PR TITLE
ENYO-2129 : add aria-pressed to child Button of Group

### DIFF
--- a/src/Group/Group.js
+++ b/src/Group/Group.js
@@ -6,9 +6,11 @@ require('enyo');
 */
 
 var
-	kind = require('../kind');
+	kind = require('../kind'),
+	options = require('../options');
 var
-	Control = require('../Control');
+	Control = require('../Control'),
+	Button = require('../Button');
 
 /**
 * The extended {@glossary event} [object]{@glossary Object} that is provided when the
@@ -123,6 +125,10 @@ module.exports = kind(
 			return;
 		}
 		if (this.highlander) {
+			// Accessibility
+			if (e.originator instanceof Button) {
+				e.originator.setAttribute('aria-pressed', options.accessibility ? String(false) : null);
+			}
 			// we can optionally accept an `allowHighlanderDeactivate` property in e without directly 
 			// specifying it when instatiating the group - used mainly for custom kinds requiring deactivation  
 			if (e.allowHighlanderDeactivate !== undefined && e.allowHighlanderDeactivate !== this.allowHighlanderDeactivate) {
@@ -137,12 +143,16 @@ module.exports = kind(
 				if (e.originator == this.active) {
 					if (!this.allowHighlanderDeactivate) {
 						this.active.setActive(true);
+						// Accessibility
+						this.active.set('accessibilityPressed', options.accessibility ? true : null);
 					} else {
 						this.setActive(null);
 					}
 				}
 			} else {
 				this.setActive(e.originator);
+				// Accessibility
+				e.originator.set('accessibilityPressed', options.accessibility ? true : null);
 			}
 		}
 	},


### PR DESCRIPTION
## Issue 
Accessibility: Do not read the active status of the grouped buttons

## Cause
Button wrapped using enyo Group does not have aria-pressed attribute, which is neccessary for reading own status. However, If Button is not child of Group, Button should not have aria-pressed attribute since it is used in ToggleButton for reading toggle status, so we should add only aria-pressed attribute when button is child of group. 

## Fix
Add aria-pressed attribute when button is child of Group.

Enyo-DCO-1.1-Signed-off-by: Bongsub Kim bongsub.kim@lgepartner.com