### PR TITLE
ENYO-2452-rajyavardhan-Unnecessary border around placeholder if image…

### DIFF
--- a/src/Image/Image.js
+++ b/src/Image/Image.js
@@ -182,7 +182,7 @@ module.exports = kind(
 
 	/**
 	* This image is used to handle the border around placeholder, if the original image
-	* to load
+	* fails to load
 	*
 	* @private
 	*/

--- a/src/Image/Image.js
+++ b/src/Image/Image.js
@@ -186,7 +186,16 @@ module.exports = kind(
 	*
 	* @private
 	*/
-	_transparentImg: 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==',
+	_transparentImg:
+		'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciI' +
+		'HhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iMTAwJSIgaGVp' +
+		'Z2h0PSIxMDAlIiB2aWV3Qm94PSIwIDAgIDExNzMgNTMxIiBwcmVzZXJ2ZUFzcGVjdFJhdGlvPSJ4TWl' +
+		'kWU1pZCBtZWV0IiB6b29tQW5kUGFuPSJkaXNhYmxlIiA+PHJlY3QgaWQ9InN2Z0VkaXRvckJhY2tncm' +
+		'91bmQiIHg9IjAiIHk9IjAiIHdpZHRoPSIxMTczIiBoZWlnaHQ9IjUzMSIgc3R5bGU9ImZpbGw6IG5vb' +
+		'mU7IHN0cm9rZTogbm9uZTsiLz48cmVjdCB4PSIxMjYiIHk9IjgxIiBpZD0iZTFfcmVjdGFuZ2xlIiBz' +
+		'dHlsZT0ic3Ryb2tlLXdpZHRoOiAxcHg7IHZlY3Rvci1lZmZlY3Q6IG5vbi1zY2FsaW5nLXN0cm9rZTs' +
+		'gc3Ryb2tlOiBub25lOyBmaWxsLW9wYWNpdHk6IDA7IiB3aWR0aD0iODQwIiBoZWlnaHQ9IjM3MiIgZm' +
+		'lsbD0ia2hha2kiLz48L3N2Zz4=',
 
 	/**
 	* @type {Object}
@@ -284,7 +293,11 @@ module.exports = kind(
 	*/
 	handleLoad: function () {
 		if (!this.sizing && this.placeholder) {
-			this._errorHandling? this._errorHandling = false : this.applyStyle('background-image', null);
+			if (this._errorHandling) {
+				this._errorHandling = false;
+			} else {
+				this.applyStyle('background-image', null);
+			}
 		}
 	},
 
@@ -293,7 +306,7 @@ module.exports = kind(
 	*/
 	handleError: function () {
 		if (this.placeholder) {
-			this.set('src', this._transparentImg);
+			this.set('_src', this._transparentImg);
 			this._errorHandling = true;
 		}
 	},

--- a/src/Image/Image.js
+++ b/src/Image/Image.js
@@ -181,6 +181,14 @@ module.exports = kind(
 	_src: null,
 
 	/**
+	* This image is used to handle the border around placeholder, if the original image
+	* to load
+	*
+	* @private
+	*/
+	_transparentImg: 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==',
+
+	/**
 	* @type {Object}
 	* @property {Boolean} draggable - This attribute will take one of the following
 	*	[String]{@glossary String} values: 'true', 'false' (the default), or 'auto'.
@@ -276,7 +284,7 @@ module.exports = kind(
 	*/
 	handleLoad: function () {
 		if (!this.sizing && this.placeholder) {
-			this.applyStyle('background-image', null);
+			this._errorHandling? this._errorHandling = false : this.applyStyle('background-image', null);
 		}
 	},
 
@@ -285,7 +293,8 @@ module.exports = kind(
 	*/
 	handleError: function () {
 		if (this.placeholder) {
-			this.set('_src', null);
+			this.set('src', this._transparentImg);
+			this._errorHandling = true;
 		}
 	},
 


### PR DESCRIPTION
… fails to load

Issue: The behavior is rather normal as enyo.Image makes the 'src:
null', if the image fails to load. So browser draws a border around the
size of the image when there is no 'src' attribute or 'src: null'
Fix: Instead of making the src: null when the image doesn't load, the
source is set with a transparent image.
Enyo-DCO-1.1-Signed-off-by: Rajyavardhan P <rajyavardhan.p@lge.com>