### PR TITLE
Fix for: ENYO-2459

### DIFF
--- a/src/UiComponent.js
+++ b/src/UiComponent.js
@@ -701,5 +701,17 @@ var UiComponent = module.exports = kind(
 				|| this.owner
 			);
 		}
+	},
+	
+	/**
+	* @method
+	* @private
+	*/
+	bubbleTargetChanged: function (was) {
+		if (was && this.cachedBubble && this.cachedBubbleTarget) {
+			for (var n in this.cachedBubbleTarget) {
+				if (this.cachedBubbleTarget[n] === was) delete this.cachedBubbleTarget[n];
+			}
+		}
 	}
 });


### PR DESCRIPTION
## Issue

Failing unit test for ViewController was due to cached bubbleTarget not being cleared when live-view swapping.

## Fix

Ensure we scrub the cached bubble targets when necessary. Note that this functionality is currently only ever used by ViewController and no implementations using this are known.

Enyo-DCO-1.1-Signed-Off-By: Cole Davis (cole.davis@lge.com)