### PR TITLE
ENYO-2504: TouchScrollStrategy should require touch.js

### DIFF
--- a/src/TouchScrollStrategy.js
+++ b/src/TouchScrollStrategy.js
@@ -1,4 +1,5 @@
 require('enyo');
+require('./touch');
 
 /**
 * Contains the declaration for the {@link module:enyo/TouchScrollStrategy~TouchScrollStrategy} kind.


### PR DESCRIPTION
Enyo-DCO-1.1-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>