### PR TITLE
ENYO-2491: Ensure that panel transition runs.

### DIFF
--- a/src/LightPanels/LightPanels.js
+++ b/src/LightPanels/LightPanels.js
@@ -678,7 +678,7 @@ module.exports = kind(
 		var panels = this.getPanels(),
 			nextPanel = panels[this.index],
 			currPanel = this._currentPanel,
-			shiftCurrent, fnSetupClasses, fnTransition;
+			shiftCurrent, fnSetupClasses;
 
 		this._indexDirection = 0;
 
@@ -712,20 +712,12 @@ module.exports = kind(
 				nextPanel.removeClass('offscreen');
 				nextPanel.addRemoveClass('shifted', shiftCurrent);
 				if (currPanel) currPanel.addRemoveClass('shifted', !shiftCurrent);
-			});
-
-			fnTransition = this.bindSafely(function () {
 				if (animate) setTimeout(this.bindSafely('applyTransitions', nextPanel, true), 16);
 				else this.applyTransitions(nextPanel);
 			});
 
-			if (this.generated) {
-				global.requestAnimationFrame(fnSetupClasses);
-				global.requestAnimationFrame(fnTransition);
-			} else {
-				fnSetupClasses();
-				fnTransition();
-			}
+			if (this.generated) global.requestAnimationFrame(fnSetupClasses);
+			else fnSetupClasses();
 		}
 	},
 


### PR DESCRIPTION
### Issue
If the main loop is very busy, such as when we are rapidly switching panel indices, the delay between setting up the initial position of the panel container, and applying the transition to animate this panel container is small enough that the style change is batched and there is no transition. This causes a number of issues, such as lack of a visible animation, and more importantly, the `transitionFinished` handler for the `ontransitionend` event is not fired.

### Fix
We moved the class application for the initial panel container position and individual panels into a rAF callback, and also moved the call to apply the transition styles into a rAF callback as well, so that we take these calls off of the main loop. Additionally, we placed the panel container in a compositing layer if `animate` is true, to prevent unnecessary `ontransitionend` events from firing, and to prevent some subtle but unwanted element shifting that I noticed.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>