### PR TITLE
ENYO-2514: VDR: Always refresh immediately

### DIFF
--- a/src/VirtualDataRepeater.js
+++ b/src/VirtualDataRepeater.js
@@ -70,18 +70,7 @@ module.exports = kind({
 
 		this.stabilizeExtent();
 
-		var refresh = this.bindSafely(function() {
-			this.doIt();
-		});
-
-		// refresh is used as the event handler for
-		// collection resets so checking for truthy isn't
-		// enough. it must be true.
-		if(immediate === true) {
-			refresh();
-		} else {
-			this.startJob('refreshing', refresh, 16);
-		}
+		this.doIt();
 	},
 
 	childForIndex: function(idx) {


### PR DESCRIPTION
VirtualDataRepeater has, until now, routinely made refresh() an
async operation. This behavior was inherited (via copy/paste) from
DataRepeater when VDR was first created.

It's not apparent that making refresh() async is necessary or
useful for VDR, and the async operation is causing problems in at
least one instance -- specifically, when the data underlying a
NewDataList is modified while the list is hidden, the list isn't
refreshed until the list is reshown, and at that time the "old"
list contents flash momentarily before being refreshed.

We address this issue by making refresh() synchronous for VDR and
its subkinds.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)