### PR TITLE
ENYO-2258: Defer reflow when hidden, do it when shown

### DIFF
--- a/src/Control/Control.js
+++ b/src/Control/Control.js
@@ -882,7 +882,25 @@ var Control = module.exports = kind(
 	* @private
 	*/
 	showingChangedHandler: function (sender, event) {
+		// If we have deferred a reflow, do it now...
+		if (this.showing && this._needsReflow) {
+			this.reflow();
+		}
+
+		// Then propagate `onShowingChanged` if appropriate
 		return sender === this ? false : !this.showing;
+	},
+
+	/**
+	* Overriding reflow() so that we can take `showing` into
+	* account and defer reflowing accordingly.
+	*
+	* @private
+	*/
+	reflow: function () {
+		if (this.layout) {
+			this._needsReflow = this.showing ? this.layout.reflow() : true;
+		}
 	},
 
 	/**

--- a/src/Layout.js
+++ b/src/Layout.js
@@ -74,6 +74,12 @@ module.exports = kind(
 	/** 
 	* Called during dynamic measuring layout (i.e., during a resize).
 	*
+	* May short-circuit and return `true` if the layout needs to be
+	* redone when the associated Control is next shown. This is useful
+	* for cases where the Control itself has `showing` set to `true`
+	* but an ancestor is hidden, and the layout is therefore unable to
+	* get accurate measurements of the Control or its children.
+	*
 	* @public
 	*/
 	reflow: function () {


### PR DESCRIPTION
Reflowing a Control when it's hidden generally doesn't make sense,
since a) it's wasteful to spend cycles laying out something that
can't be seen; and b) the layout may depend on measuring the
Control's children, and they can't be accurately measured if
they're not showing.

We therefore defer reflow in the case where we're hidden, and
wait until we're shown.

In the case where we are explicitly hidden (i.e., `showing` is
`false`), we defer immediately. We can't inexpensively detect the
case where we're showing but an ancestor is hidden, so to handle
that case we rely on the layout to do its measurements and let
us know (by returning `true`) if we need to reflow again the next
time we are shown.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)