### PR TITLE
ENYO-2541: Remove popOnForward.

### DIFF
--- a/src/LightPanels/LightPanels.js
+++ b/src/LightPanels/LightPanels.js
@@ -445,12 +445,10 @@ module.exports = kind(
 	* depending on the direction.
 	*
 	* @param {Number} index - Index at which to start removing panels.
-	* @param {Number} [direction] - The direction in which we are changing indices. A negative
-	*	value signifies that we are moving backwards, and want to remove panels whose indices are
-	*	greater than the current index. Conversely, a positive value signifies that we are moving
-	*	forwards, and panels whose indices are less than the current index should be removed. To
-	*	maintain backwards-compatibility with the existing API, this parameter is optional and, if
-	*	not specified, will default to the popOnBack behavior.
+	* @param {Number} direction - The direction in which we are changing indices. A negative value
+	*	signifies that we are moving backwards, and want to remove panels whose indices are greater
+	*	than the current index. Conversely, a positive value signifies that we are moving forwards,
+	*	and panels whose indices are less than the current index should be removed.
 	* @public
 	*/
 	removePanels: function (index, direction) {

--- a/src/LightPanels/LightPanels.js
+++ b/src/LightPanels/LightPanels.js
@@ -128,15 +128,6 @@ module.exports = kind(
 	popOnBack: true,
 
 	/**
-	* When `true`, previous panels are automatically popped when moving forwards.
-	*
-	* @type {Boolean}
-	* @default false
-	* @public
-	*/
-	popOnForward: false,
-
-	/**
 	* The amount of time, in milliseconds, to run the transition animation between panels.
 	*
 	* @type {Number}
@@ -450,41 +441,43 @@ module.exports = kind(
 	},
 
 	/**
-	* Destroys panels whose index is either greater than, or less than, the specified value,
+	* Removes panels whose index is either greater than, or less than, the specified value,
 	* depending on the direction.
 	*
-	* @param {Number} index - Index at which to start destroying panels.
-	* @param {Number} direction - The direction in which we want to destroy panels. A negative
-	*	number signifies popping backwards, otherwise we pop forwards.
+	* @param {Number} index - Index at which to start removing panels.
+	* @param {Number} [direction] - The direction in which we are changing indices. A negative
+	*	value signifies that we are moving backwards, and want to remove panels whose indices are
+	*	greater than the current index. Conversely, a positive value signifies that we are moving
+	*	forwards, and panels whose indices are less than the current index should be removed. To
+	*	maintain backwards-compatibility with the existing API, this parameter is optional and, if
+	*	not specified, will default to the popOnBack behavior.
 	* @public
 	*/
-	popPanels: function (index, direction) {
-		var panels = this.getPanels();
+	removePanels: function (index, direction) {
+		var panels = this.getPanels(),
+			i;
 
 		if (direction < 0) {
-			while (panels.length > index + 1 && index >= 0) {
-				this.popPanel(panels.length - 1);
+			for (i = panels.length - 1; i > index; i--) {
+				this.removePanel(panels[i]);
 			}
 		} else {
-			for (var panelIndex = index - 1; panelIndex >= 0; panelIndex--) {
-				this.popPanel(panelIndex, true);
+			for (i = 0; i < index; i++) {
+				this.removePanel(panels[i], true);
 			}
 		}
 	},
 
 	/**
-	* Destroys the specified panel.
+	* Removes the specified panel.
 	*
-	* @param {Number} index - The index of the panel to destroy.
-	* @param {Boolean} [preserve] - If {@link module:enyo/LightPanels~LightPanels#cacheViews} is `true`, this
-	*	value is used to determine whether or not to preserve the current panel's position in
-	*	the component hierarchy and on the screen, when caching.
-	* @public
+	* @param {Object} panel - The panel to remove.
+	* @param {Boolean} [preserve] - If {@link module:enyo/LightPanels~LightPanels#cacheViews} is
+	*	`true`, this value is used to determine whether or not to preserve the current panel's
+	*	position in the component hierarchy and on the screen, when caching.
+	* @private
 	*/
-	popPanel: function (index, preserve) {
-		var panels = this.getPanels(),
-			panel = panels[index];
-
+	removePanel: function (panel, preserve) {
 		if (panel) {
 			if (this.cacheViews) {
 				this.cacheView(panel, preserve);
@@ -627,8 +620,8 @@ module.exports = kind(
 			currPanel = this._currentPanel;
 
 			if ((this._indexDirection < 0 && (this.popOnBack || this.cacheViews) && this.index < this.getPanels().length - 1) ||
-				(this._indexDirection > 0 && (this.popOnForward || this.cacheViews) && this.index > 0)) {
-				this.popPanels(this.index, this._indexDirection);
+				(this._indexDirection > 0 && this.cacheViews && this.index > 0)) {
+				this.removePanels(this.index, this._indexDirection);
 			}
 
 			if (prevPanel) {


### PR DESCRIPTION
### Issue
The `popOnForward` API does not really make sense and is not a use case that has actually come up, with the use of `cacheViews`, so it should be removed to avoid confusion and tighten up our APIs.

### Fix
The property has been removed and the logic has been updated and cleaned-up to reflect this.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>