### PR TITLE
ENYO-2536: Guard against initialization edge cases

### DIFF
--- a/src/LightPanels/LightPanels.js
+++ b/src/LightPanels/LightPanels.js
@@ -8,6 +8,7 @@ require('enyo');
 var
 	kind = require('../kind'),
 	dom = require('../dom'),
+	animation = require('../animation'),
 	asyncMethod = require('../utils').asyncMethod;
 
 var
@@ -179,7 +180,7 @@ module.exports = kind(
 	* @private
 	*/
 	tools: [
-		{kind: Control, name: 'client', classes: 'panels-container', ontransitionend: 'transitionFinished'}
+		{kind: Control, name: 'client', classes: 'panels-container', ontransitionend: 'transitionFinished', onwebkitTransitionEnd: 'transitionFinished'}
 	],
 
 	/**
@@ -715,12 +716,12 @@ module.exports = kind(
 				if (currPanel) currPanel.addRemoveClass('shifted', !shiftCurrent);
 
 				// timestamp will be truthy if this is triggered from a rAF
-				if (timestamp) global.requestAnimationFrame(this.bindSafely('applyTransitions', nextPanel, animate));
+				if (timestamp) animation.requestAnimationFrame(this.bindSafely('applyTransitions', nextPanel, animate));
 				else this.applyTransitions(nextPanel, animate);
 			});
 
 			if (!this.generated || !animate) fnInitiateTransition();
-			else global.requestAnimationFrame(fnInitiateTransition);
+			else animation.requestAnimationFrame(fnInitiateTransition);
 		}
 	},
 

--- a/src/LightPanels/LightPanels.js
+++ b/src/LightPanels/LightPanels.js
@@ -678,7 +678,7 @@ module.exports = kind(
 		var panels = this.getPanels(),
 			nextPanel = panels[this.index],
 			currPanel = this._currentPanel,
-			shiftCurrent, fnSetupClasses;
+			shiftCurrent, fnInitiateTransition;
 
 		this._indexDirection = 0;
 
@@ -703,21 +703,24 @@ module.exports = kind(
 			if (!nextPanel.generated) nextPanel.render();
 			if (nextPanel.preTransition) nextPanel.preTransition();
 
-			// ensure our panel container is in the correct, pre-transition position
-			this.shiftContainer(-1 * this._indexDirection);
-			shiftCurrent = this._indexDirection > 0;
+			fnInitiateTransition = this.bindSafely(function (timestamp) {
 
-			fnSetupClasses = this.bindSafely(function () {
+				// ensure our panel container is in the correct, pre-transition position
+				this.shiftContainer(-1 * this._indexDirection);
+				shiftCurrent = this._indexDirection > 0;
+
 				this.addClass('transitioning');
 				nextPanel.removeClass('offscreen');
 				nextPanel.addRemoveClass('shifted', shiftCurrent);
 				if (currPanel) currPanel.addRemoveClass('shifted', !shiftCurrent);
-				if (animate) setTimeout(this.bindSafely('applyTransitions', nextPanel, true), 16);
-				else this.applyTransitions(nextPanel);
+
+				// timestamp will be truthy if this is triggered from a rAF
+				if (timestamp) global.requestAnimationFrame(this.bindSafely('applyTransitions', nextPanel, animate));
+				else this.applyTransitions(nextPanel, animate);
 			});
 
-			if (this.generated) global.requestAnimationFrame(fnSetupClasses);
-			else fnSetupClasses();
+			if (!this.generated || !animate) fnInitiateTransition();
+			else global.requestAnimationFrame(fnInitiateTransition);
 		}
 	},
 


### PR DESCRIPTION
### Issue
When initially populating a `LightPanels` kind, if `pushPanels` is used, by default the index is set to be the index of the last panel pushed. If we attempt to set the index to a different value, immediately after this operation, the `ontransitionend` event for the must recent index change does not always fire, especially on slower hardware, as the rAF operation effectively batched both the transition setup and the transition application as the 16ms timeout is not sufficient during what is presumably some heavy load (executing the previous transition), resulting in no transition event occurring at all.

### Fix
To counter this, we separate out the two operations into different rAF requests, and kick off the transition application rAF *after* the transition setup rAF. This way there is a redraw in-between and allows for the transition to always be applied. Also, this allows us to drop the somewhat-arbitrary 16ms timeout we had been using to semi-guarantee that a redraw had occurred between these operations.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>