### PR TITLE
PLAT-8119: Add or modify transition related functions for safari browser

### DIFF
--- a/src/Control/Control.js
+++ b/src/Control/Control.js
@@ -241,7 +241,7 @@ var Control = module.exports = kind(
 	* @public
 	*/
 	renderOnShow: false,
-	
+
 	/**
 	* @todo Find out how to document "handlers".
 	* @public
@@ -792,7 +792,7 @@ var Control = module.exports = kind(
 		// our last known value for display was or use the default
 		if (!was && this.showing) {
 			this.applyStyle('display', this._display || '');
-			
+
 			// note the check for generated and canGenerate as changes to canGenerate will force
 			// us to ignore the renderOnShow value so we don't undo whatever the developer was
 			// intending
@@ -802,7 +802,7 @@ var Control = module.exports = kind(
 				this.set('canGenerate', true);
 				this.render();
 			}
-			
+
 			this.sendShowingChangedEvent(was);
 		}
 
@@ -829,7 +829,7 @@ var Control = module.exports = kind(
 		// the state of renderOnShow
 		this.canGenerate = (this.canGenerate && !this.renderOnShow);
 	},
-	
+
 	/**
 	* @private
 	*/
@@ -1197,8 +1197,10 @@ var Control = module.exports = kind(
 	* @private
 	*/
 	removeNodeFromDom: function() {
-		if (this.hasNode() && this.node.parentNode) {
-			this.node.parentNode.removeChild(this.node);
+		var node = this.hasNode();
+		if (node) {
+			if (node.remove) node.remove();
+			else if (node.parentNode) node.parentNode.removeChild(node);
 		}
 	},
 

--- a/src/LightPanels/LightPanels.js
+++ b/src/LightPanels/LightPanels.js
@@ -8,6 +8,7 @@ require('enyo');
 var
 	kind = require('../kind'),
 	dom = require('../dom'),
+	animation = require('../animation'),
 	asyncMethod = require('../utils').asyncMethod;
 
 var
@@ -179,7 +180,7 @@ module.exports = kind(
 	* @private
 	*/
 	tools: [
-		{kind: Control, name: 'client', classes: 'panels-container', ontransitionend: 'transitionFinished'}
+		{kind: Control, name: 'client', classes: 'panels-container', ontransitionend: 'transitionFinished', onwebkitTransitionEnd: 'transitionFinished'}
 	],
 
 	/**
@@ -716,7 +717,7 @@ module.exports = kind(
 				else this.applyTransitions(nextPanel);
 			});
 
-			if (this.generated) global.requestAnimationFrame(fnSetupClasses);
+			if (this.generated) animation.requestAnimationFrame(fnSetupClasses);
 			else fnSetupClasses();
 		}
 	},

--- a/src/LightPanels/LightPanels.less
+++ b/src/LightPanels/LightPanels.less
@@ -12,19 +12,23 @@
 			> .panels-container {
 				> .shifted {
 					transform: translateX(100%);
+					-webkit-transform: translateX(100%);
 				}
 			}
 		}
 		&.backwards {
 			> .panels-container {
 				transform: translateX(-50%);
+				-webkit-transform: translateX(-50%);
 
 				> * {
 					transform: translateX(100%);
+					-webkit-transform: translateX(100%);
 				}
 
 				> .shifted {
 					transform: translateX(0%);
+					-webkit-transform: translateX(0%);
 				}
 			}
 		}
@@ -44,19 +48,23 @@
 			> .panels-container {
 				> .shifted {
 					transform: translateY(100%);
+					-webkit-transform: translateY(100%);
 				}
 			}
 		}
 		&.backwards {
 			> .panels-container {
 				transform: translateY(-50%);
+				-webkit-transform: translateY(-50%);
 
 				> * {
 					transform: translateY(100%);
+					-webkit-transform: translateY(100%);
 				}
 
 				> .shifted {
 					transform: translateY(0%);
+					-webkit-transform: translateY(0%);
 				}
 			}
 		}

--- a/src/Popup/Popup.js
+++ b/src/Popup/Popup.js
@@ -313,10 +313,7 @@ var Popup = module.exports = kind(
 		return function () {
 			// if this is a rendered floating popup, remove the node from the
 			// floating layer because it won't be removed otherwise
-			var node = this.hasNode();
-			if(this.floating && node) {
-				this.node.remove();
-			}
+			if (this.floating) this.removeNodeFromDom();
 
 			sup.apply(this, arguments);
 		};

--- a/src/ViewPreloadSupport.js
+++ b/src/ViewPreloadSupport.js
@@ -118,7 +118,11 @@ var ViewPreloadSupport = {
 		// The panel could have already been removed from DOM and torn down if we popped when
 		// moving forward.
 		if (view.node) {
-			view.node.remove();
+			if (!view.node.remove) { // Polyfill remove for safari browser
+				view.parent.node.removeChild(view.node);
+			} else {
+				view.node.remove();
+			}
 			view.teardownRender(true);
 		}
 

--- a/src/ViewPreloadSupport.js
+++ b/src/ViewPreloadSupport.js
@@ -117,12 +117,8 @@ var ViewPreloadSupport = {
 
 		// The panel could have already been removed from DOM and torn down if we popped when
 		// moving forward.
-		if (view.node) {
-			if (!view.node.remove) { // Polyfill remove for safari browser
-				view.parent.node.removeChild(view.node);
-			} else {
-				view.node.remove();
-			}
+		if (view.hasNode()) {
+			view.removeNodeFromDom();
 			view.teardownRender(true);
 		}
 


### PR DESCRIPTION
## Issue 
1) enyo LightPanelsSample is not displayed on safari browser. Below error is occured.
Error: TypeError: 'undefined' is not a function (evaluating 'global.requestAnimationFrame(fnSetupClasses)')
2) When animate is true, LightPanelsSample does not animation work on safari browser.
3) When cache is true, LightPanelsSample does not work on safari browser. Below error is occured.
TypeError: 'undefined' is not a function (evaluating 'view.node.remove()')
4) ontransition event callback is not called on safari browser. 

## Cause
1) window.requestAnimationFrame function does not exist on safari browser
2) In LightPanels.less, safari does not support transform property
3) safari does not support dom node's remove() function.
4) safari does not support ontransition event. 

## Fix
1) enyo animation module provides requestAnimationFrame supporting other platforms, so replace requestAnimationFrame to animation module's requestAnimationFrame. 
2) Add -webkit-tranform perperty.
3) Add removeChild as polyfill remove.
4) Add onwebkitTransitionEnd event.

Enyo-DCO-1.1-Signed-off-by: Bongsub Kim bongsub.kim@lgepartner.com
