### PR TITLE
ENYO-2565: Bullet-proof logic for constraining min threshold

### DIFF
--- a/src/NewDataList.js
+++ b/src/NewDataList.js
@@ -171,7 +171,7 @@ module.exports = kind({
 			st = Math.ceil(d / delta);
 			j = st * delta;
 			tt.max = Math.min(maxVal, tt.max + j);
-			tt.min = (tt.max == maxVal) ? maxMin : tt.max - delta;
+			tt.min = Math.min(maxMin, tt.max - delta);
 			this.set('first', (d2x * Math.ceil(this.first / d2x)) + (st * d2x));
 		}
 		else if (dir == -1 && val < tt.min) {


### PR DESCRIPTION
In `NewDataList`, the logic for constraining the minimum scroll
threshold value was susceptible to failure in the case where the
values being compared were long floating point values (we were
checking for equality, but in the failure case two values that were
"conceptually equal" for the purpose of our algorithm were actually
different in digits far to the right of the decimal). We replace
the equality operator  with a call to `Math.min()` to constrain the
threshold  value, which gives us the desired result.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)