### PR TITLE
ENYO-2557: Allow resize events to waterfall freely

### DIFF
--- a/src/UiComponent.js
+++ b/src/UiComponent.js
@@ -145,13 +145,6 @@ var UiComponent = module.exports = kind(
 	addBefore: undefined,
 
 	/**
-	* @private
-	*/
-	protectedStatics: {
-		_resizeFlags: {showingOnly: true} // don't waterfall these events into hidden controls
-	},
-
-	/**
 	* @method
 	* @private
 	*/
@@ -631,8 +624,8 @@ var UiComponent = module.exports = kind(
 	* @public
 	*/
 	resize: function () {
-		this.waterfall('onresize', UiComponent._resizeFlags);
-		this.waterfall('onpostresize', UiComponent._resizeFlags);
+		this.waterfall('onresize');
+		this.waterfall('onpostresize');
 	},
 
 	/**
@@ -677,13 +670,7 @@ var UiComponent = module.exports = kind(
 		}
 		// waterfall to my children
 		for (var i=0, cs=this.children, c; (c=cs[i]); i++) {
-			// Do not send {showingOnly: true} events to hidden controls. This flag is set for resize events
-			// which are broadcast from within the framework. This saves a *lot* of unnecessary layout.
-			// TODO: Maybe remember that we did this, and re-send those messages on setShowing(true)?
-			// No obvious problems with it as-is, though
-			if (c.showing || !(event && event.showingOnly)) {
-				c.waterfall(nom, event, sender);
-			}
+			c.waterfall(nom, event, sender);
 		}
 	},
 


### PR DESCRIPTION
Some time ago, we added some logic to prevent resize events from
waterfalling through hidden UI components. The intention was to
prevent unnecessary layout from happening.

This approach generally worked, but there were some problem cases,
as noted in a comment that went in with the original change.
Specifically, a component that is hidden and therefore never
receives a resize event has no way of "knowing" that a resize has
been requested, so won't reflow its layout when it is later shown.

We recently added some different but related logic to allow
components to defer reflows when hidden and perform them later upon
being shown. This newer mechanism has the advantage of avoiding the
problem described above.

Since the expensive part of dealing with a resize event is almost
always performing a reflow, it seems that we can safely remove the
prevent-resize-event logic and rely on the new defer-reflow logic
to address the original problem.

I did some quick tests on a range of Moonstone samples with
instrumentation in place to ensure that we weren't substantially
increasing the number of resize events flowing through the UI.
Based on these tests, it appears that the number of additional
resize events is not significant, and since virtually all of the
processing that would have been caused by the additional events is
short-circuited by the defer-reflow logic, I feel good about this
change.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)