### PR TITLE
ENYO-2592: Add replaceAt method.

### DIFF
--- a/src/LightPanels/LightPanels.js
+++ b/src/LightPanels/LightPanels.js
@@ -668,8 +668,6 @@ module.exports = kind(
 				prevPanel.addClass('offscreen');
 			}
 
-			if (this.popQueue && this.popQueue.length) this.finalizePurge();
-
 			this.cleanUpPanel(prevPanel);
 			this.cleanUpPanel(currPanel);
 
@@ -802,20 +800,9 @@ module.exports = kind(
 	* @private
 	*/
 	purge: function () {
-		var panels = this.getPanels();
-		this.popQueue = panels.slice();
-		panels.length = 0;
-		this.index = -1;
-	},
-
-	/**
-	* Clean-up any panels queued for destruction.
-	*
-	* @private
-	*/
-	finalizePurge: function () {
-		var panels = this.popQueue,
+		var panels = this.getPanels(),
 			panel;
+
 		while (panels.length) {
 			panel = panels.pop();
 			if (this.cacheViews) {
@@ -825,6 +812,8 @@ module.exports = kind(
 				panel.destroy();
 			}
 		}
+
+		this.index = -1;
 	},
 
 	/**

--- a/src/LightPanels/LightPanels.js
+++ b/src/LightPanels/LightPanels.js
@@ -53,6 +53,11 @@ var Orientation = {
 *	immediately after each panel is created.
 * @property {Number} [targetIndex] - The index of the panel to display, otherwise the last panel
 *	created will be displayed.
+* @property {Boolean} [purge] - If `true`, removes and clears the existing set of panels before
+*	pushing new panels.
+* @property {Boolean} [force] - If `true`, forces an index change even if we are targetting an index
+*	that is the same as the current index. This can be useful in cases where we are purging panels
+*	and want to properly setup the positioning of the newly pushed panels.
 */
 
 /**
@@ -795,7 +800,7 @@ module.exports = kind(
 	},
 
 	/**
-	* Destroys all panels. These will be queued for destruction after the next panel has loaded.
+	* Destroys all panels.
 	*
 	* @private
 	*/


### PR DESCRIPTION
### Issue
Due to some specific use cases, there was a need to navigate to a panel that is effectively a "sibling" of the current panel, meaning that they share the same ancestor and we wish to maintain this panel hierarchy / ordering. Popping the current panel and pushing the sibling panel exposed a small time window where the ancestor panel could be momentarily spotted, but was immediately torn down as the sibling panel was pushed. As `Spotlight` was still processing events, it was attempting to utilize a null node reference in these cases.

### Fix
We have added a general `replaceAt` method to `LightPanels` that will replace panel(s) in-place and allow for changing to a "sibling" panel.

### Notes
I also added an additional commit to undefer panel purging. Let me know if it makes more sense to kick this out to another PR. The main reason for making this change is that we now have view caching, and we want to prevent any possible situation where we end up removing a panel we have just pushed (see notes in the ticket).

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>