### PR TITLE
ENYO-2416 Fix issues with VideoPlayer

### DIFF
--- a/src/Video.js
+++ b/src/Video.js
@@ -651,12 +651,13 @@ module.exports = kind(
 		oldPlaybackRateNumber = this.calcNumberValueOfPlaybackRate(this.playbackRate);
 
 		this.setPlaybackRate(1);
-		node.currentTime += parseInt(this.jumpSec, 10);
-		this._prevCommand = 'jumpForward';
 
 		if(oldPlaybackRateNumber < 0) {
-			this.node.play();
+			this.node.play();	// Play before skip so video won't restart
 		}
+
+		node.currentTime += parseInt(this.jumpSec, 10);
+		this._prevCommand = 'jumpForward';
 
 		this.doJumpForward(utils.mixin(this.createEventData(), {jumpSize: this.jumpSec}));
 	},

--- a/src/Video.js
+++ b/src/Video.js
@@ -263,7 +263,7 @@ module.exports = kind(
 		* @default {
 		*	fastForward: ['2', '4', '8', '16'],
 		*	rewind: ['-2', '-4', '-8', '-16'],
-		*	slowForward: ['1/4', '1/2', '1'],
+		*	slowForward: ['1/4', '1/2'],
 		*	slowRewind: ['-1/2', '-1']
 		* }
 		* @public
@@ -271,7 +271,7 @@ module.exports = kind(
 		playbackRateHash: {
 			fastForward: ['2', '4', '8', '16'],
 			rewind: ['-2', '-4', '-8', '-16'],
-			slowForward: ['1/4', '1/2', '1'],
+			slowForward: ['1/4', '1/2'],
 			slowRewind: ['-1/2', '-1']
 		}
 	},
@@ -508,13 +508,11 @@ module.exports = kind(
 		switch (this._prevCommand) {
 		case 'slowForward':
 			if (this._speedIndex == this._playbackRateArray.length - 1) {
-				// reached to the end of array => go to fastforward
-				this.selectPlaybackRateArray('fastForward');
-				this._speedIndex = 0;
-				this._prevCommand = 'fastForward';
+				// reached to the end of array => go to play
+				this.play();
+				return;
 			} else {
 				this._speedIndex = this.clampPlaybackRate(this._speedIndex+1);
-				this._prevCommand = 'slowForward';
 			}
 			break;
 		case 'pause':
@@ -526,14 +524,14 @@ module.exports = kind(
 			this._prevCommand = 'slowForward';
 			break;
 		case 'rewind':
-			var pbNumber = this.calcNumberValueOfPlaybackRate(this.playbackRate);
-			if (pbNumber < 0) {
-				this.selectPlaybackRateArray('slowForward');
-				this._prevCommand = 'slowForward';
-			} else {
-				this.selectPlaybackRateArray('fastForward');
-				this._prevCommand = 'fastForward';
-			}
+			node.play();
+			this.selectPlaybackRateArray('fastForward');
+			this._prevCommand = 'fastForward';
+			this._speedIndex = 0;
+			break;
+		case 'slowRewind':
+			this.selectPlaybackRateArray('slowForward');
+			this._prevCommand = 'slowForward';
 			this._speedIndex = 0;
 			break;
 		case 'fastForward':
@@ -572,8 +570,17 @@ module.exports = kind(
 				this._prevCommand = 'rewind';
 			} else {
 				this._speedIndex = this.clampPlaybackRate(this._speedIndex+1);
-				this._prevCommand = 'slowRewind';
 			}
+			break;
+		case 'fastForward':
+			this.selectPlaybackRateArray('rewind');
+			this._prevCommand = 'rewind';
+			this._speedIndex = 0;
+			break;
+		case 'slowForward':
+			this.selectPlaybackRateArray('slowRewind');
+			this._prevCommand = 'slowRewind';
+			this._speedIndex = 0;
 			break;
 		case 'pause':
 			this.selectPlaybackRateArray('slowRewind');
@@ -607,15 +614,22 @@ module.exports = kind(
 	* @public
 	*/
 	jumpBackward: function () {
-		var node = this.hasNode();
+		var node = this.hasNode(),
+			oldPlaybackRateNumber;
 
 		if (!node) {
 			return;
 		}
 
+		oldPlaybackRateNumber = this.calcNumberValueOfPlaybackRate(this.playbackRate);
+
 		this.setPlaybackRate(1);
 		node.currentTime -= this.jumpSec;
 		this._prevCommand = 'jumpBackward';
+
+		if(oldPlaybackRateNumber < 0) {
+			this.node.play();
+		}
 
 		this.doJumpBackward(utils.mixin(this.createEventData(), {jumpSize: this.jumpSec}));
 	},
@@ -627,15 +641,22 @@ module.exports = kind(
 	* @public
 	*/
 	jumpForward: function () {
-		var node = this.hasNode();
+		var node = this.hasNode(),
+			oldPlaybackRateNumber;
 
 		if (!node) {
 			return;
 		}
 
+		oldPlaybackRateNumber = this.calcNumberValueOfPlaybackRate(this.playbackRate);
+
 		this.setPlaybackRate(1);
 		node.currentTime += parseInt(this.jumpSec, 10);
 		this._prevCommand = 'jumpForward';
+
+		if(oldPlaybackRateNumber < 0) {
+			this.node.play();
+		}
 
 		this.doJumpForward(utils.mixin(this.createEventData(), {jumpSize: this.jumpSec}));
 	},
@@ -723,8 +744,7 @@ module.exports = kind(
 	*/
 	setPlaybackRate: function (rate) {
 		var node = this.hasNode(),
-			pbNumber
-		;
+			pbNumber;
 
 		if (!node) {
 			return;


### PR DESCRIPTION
## Issue
The Video component would not always successfully start playing the
video after a rewind operation.

## Solution
This problem was, at least in part, caused by the need to emulate rewind
on platforms that don't support negative `playbackRate`s.  Additionally,
a problem was discovered with handling the switch between slow and
fastForward. The slowForward playback rate array was updated to remove
the rate of '1' (normal speed) and the fastforward mechanism is updated
to move to play when reaching the end of the playback rate array
(Previously, it rotated to the fast forward array after playing the '1'
rate). There should be no change for apps that did not alter the
playback rate array. The player has also been updated so that rewinding
after a slowForward will now result in a slowRewind. The converse also
applies.