### PR TITLE
ENYO-2625: Prevent overriding of panel content directionality.

### DIFF
--- a/src/LightPanels/LightPanels.less
+++ b/src/LightPanels/LightPanels.less
@@ -96,5 +96,9 @@
 		> .offscreen {
 			display: none;
 		}
+
+		.enyo-locale-right-to-left & > * {
+			direction: rtl;
+		}
 	}
 }


### PR DESCRIPTION
### Issue
We had originally set `direction:ltr` for the `enyo-light-panels` class in order to preserve the position of the of the container when in an RTL locale, so that we did not need to recompute transition percentages. This had a side effect of incorrectly setting the directionality to `ltr` for panel contents, when in an RTL locale.

### Fix
We have added an additional rule to explicitly set `direction:rtl` for panel contents when in an RTL locale.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>