### PR TITLE
ENYO-2638: Synchronously fire onEnd event.

### DIFF
--- a/src/Animator.js
+++ b/src/Animator.js
@@ -59,13 +59,13 @@ var
 * to [endValue]{@link module:enyo/Animator~Animator#endValue} during the animation, based on the
 * [function]{@glossary Function} referenced by the
 * [easingFunction]{@link module:enyo/Animator~Animator#easingFunction} property.
-* 
+*
 * Event handlers may be specified as functions. If specified, the handler function will
 * be used to handle the event directly, without sending the event to its
 * [owner]{@link module:enyo/Component~Component#owner} or [bubbling]{@link module:enyo/Component~Component#bubble} it.
 * The [context]{@link module:enyo/Animator~Animator#context} property may be used to call the supplied
 * event functions in a particular `this` context.
-* 
+*
 * During animation, an {@link module:enyo/jobs} priority of 5 is registered to defer low priority
 * tasks.
 *
@@ -79,14 +79,14 @@ module.exports = kind(
 	/**
 	* A context in which to run the specified {@glossary event} handlers. If this is
 	* not specified or is falsy, then the [global object]{@glossary global} is used.
-	* 
+	*
 	* @name context
 	* @type {Object}
 	* @default undefined
 	* @memberOf module:enyo/Animator~Animator.prototype
 	* @public
 	*/
-		
+
 	name: 'enyo.Animator',
 
 	/**
@@ -97,10 +97,10 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	published: 
+	published:
 		/** @lends module:enyo/Animator~Animator.prototype */ {
-		
-		/** 
+
+		/**
 		* Animation duration in milliseconds
 		*
 		* @type {Number}
@@ -109,7 +109,7 @@ module.exports = kind(
 		*/
 		duration: 350,
 
-		/** 
+		/**
 		* Value of [value]{@link module:enyo/Animator~Animator#value} property at the beginning of an animation.
 		*
 		* @type {Number}
@@ -118,7 +118,7 @@ module.exports = kind(
 		*/
 		startValue: 0,
 
-		/** 
+		/**
 		* Value of [value]{@link module:enyo/Animator~Animator#value} property at the end of an animation.
 		*
 		* @type {Number}
@@ -127,8 +127,8 @@ module.exports = kind(
 		*/
 		endValue: 1,
 
-		/** 
-		* Node that must be visible in order for the animation to continue. This reference is 
+		/**
+		* Node that must be visible in order for the animation to continue. This reference is
 		* destroyed when the animation ceases.
 		*
 		* @type {Object}
@@ -137,17 +137,17 @@ module.exports = kind(
 		*/
 		node: null,
 
-		/** 
-		* [Function]{@glossary Function} that determines how the animation progresses from 
+		/**
+		* [Function]{@glossary Function} that determines how the animation progresses from
 		* [startValue]{@link module:enyo/Animator~Animator#startValue} to [endValue]{@link module:enyo/Animator~Animator#endValue}.
-		* 
+		*
 		* @type {Function}
 		* @default module:enyo/easing~easing.cubicOut
 		* @public
 		*/
 		easingFunction: animation.easing.cubicOut
 	},
-	
+
 	/*
 	* @private
 	*/
@@ -179,7 +179,7 @@ module.exports = kind(
 		};
 	}),
 
-	/** 
+	/**
 	* Plays the animation.
 	*
 	* @param {Object} props - As a convenience, this [hash]{@glossary Object} will be mixed
@@ -203,7 +203,7 @@ module.exports = kind(
 		return this;
 	},
 
-	/** 
+	/**
 	* Stops the animation and fires the associated {@glossary event}.
 	*
 	* @fires module:enyo/Animator~Animator#onStop
@@ -235,9 +235,9 @@ module.exports = kind(
 		return this;
 	},
 
-	/** 
+	/**
 	* Reverses the direction of a running animation.
-	* 
+	*
 	* @return {this} The callee for chaining.
 	* @public
 	*/
@@ -318,9 +318,7 @@ module.exports = kind(
 			this.fraction = 1;
 			this.fire('onStep');
 			this.cancel();
-			utils.asyncMethod(this.bindSafely(function() {
-				this.fire('onEnd');
-			}));
+			this.fire('onEnd');
 		} else {
 			this.fire('onStep');
 			this.requestNext();


### PR DESCRIPTION
### Issue
We had previously made a tweak to `enyo/Animator` based on initial performance optimization investigations via this PR: https://github.com/enyojs/enyo/pull/709. There is a side effect of this change, where calls to `play` triggered by a repeated keypress can result in unexpected (partial) values when retrieving the current value from the animator. This is due to the fact that a repeated keypress results in an initial `onEnd` event firing, but because this is async, subsequent repeated animations have already begun, and the retrieved value associated with the `onEnd` do not correlate with the ending value that initially triggered the `onEnd`. I noticed that, for a repeated keypress, the initial `play` results in an `onEnd` firing, while the repeated keypress commences; this causes the consumer of the event to set the wrong current value, and affects the value used for calls to `play` from this point forward. So, the root cause is actually the disjointed series of events fired from a repeated key press, but this seems to be a very specific case tied to the keypress triggering the `play`ing of the animation.

### Fix
Because we now have `MoonAnimator` for `Panels`, we no longer need to async the firing of the `onEnd` event in `enyo/Animator`. I realize that this does not quite resolve the disjointed event firing issue mentioned above, but I see no harm in making this change, as a first step. Ideally, we would either fire an `onEnd` event for each call to `play`, or we would only fire a single `onEnd` event for a series of calls to `play`. The former would require some non-trivial modifications to `enyo/Animator` (not to mention, many events being fired, so unclear if this is actually ideal or makes the most sense), while the latter (which seems to be more reasonable), when using a job, requires the specification of a specific time delay amount (to account for the hold repeat firing) that seemed fairly brittle.

Note that we are still using this async technique in the `next` method of `MoonAnimator`, so it might be worth exploring whether or not there are still performance concerns related to the original issue, possibly as part of a separate ticket. So, maybe consider this PR more of a conversation starter as there are some outstanding issues to be discussed, which I'll detail below.

### Discussion points
- `enyo/Animator`'s disjointed event firing when tied to repeated keypresses.
- The original quirk where `onEnd` was fired while the animation was still being played, causing performance issues, especially on panels.
    - Do we need to worry about this quirk for other use cases, or can we assume that this would only provide a substantial/significant performance gain for panels?

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>