### PR TITLE
ENYO-2644: Override scrollToControl() in enyo/NewDataList

### DIFF
--- a/src/NewDataList.js
+++ b/src/NewDataList.js
@@ -73,6 +73,26 @@ module.exports = kind({
 	},
 
 	/**
+	* This method is considered private for NewDataList, although
+	* the corresponding method defined in the Scrollable mixin is
+	* public in the more general case. For NewDataList, application
+	* code should generally use `scrollToItem()` instead, because it works
+	* regardless of whether the target item is currently "virtualized,"
+	* whereas `scrollToControl()` works only on non-virtual items.
+	*
+	* NewDataList overrides this method because it can provide a
+	* more accurate, more performant implementation than the general
+	* one provided by enyo/Scrollable.
+	*
+	* @private
+	*/
+	scrollToControl: function (control, opts) {
+		if (typeof control.index === 'number' && control.parent === this.$.container) {
+			this.scrollToItem(control.index, opts);
+		}
+	},
+
+	/**
 	* @private
 	*/
 	calculateMetrics: function(opts) {

--- a/src/Scrollable/Scrollable.js
+++ b/src/Scrollable/Scrollable.js
@@ -327,13 +327,27 @@ module.exports = {
 	*
 	* @public
 	*/
-	scrollToControl: function (control, opts) {
-		var n = control.hasNode();
+	scrollToControl: kind.inherit(function (sup) {
+		return function (control, opts) {
+			var n;
 
-		if (n) {
-			this.scrollToNode(n, opts);
-		}
-	},
+			// Default implementation -- in case the Control
+			// applying the Scrollable mixin does not supply
+			// its own
+			if (sup === utils.nop) {
+				n = control.hasNode();
+
+				if (n) {
+					this.scrollToNode(n, opts);
+				}
+			}
+			// If the Control does provide an alternative
+			// implementation, we use it
+			else {
+				sup.apply(this, arguments);
+			}
+		};
+	}),
 
 	/**
 	* TODO: Document. Based on CSSOM View spec ()


### PR DESCRIPTION
enyo/Scrollable provides a `scrollToControl()` method that
has a generalized implementation for calculating a Control's
position and scrolling to it.

In the case of enyo/NewDataList, it's possible to provide an
alternative implementation that is more performant and more
accurate (more performant because it doesn't need to query the DOM
for bounds, more accurate because the generalized implementation
is influenced by current scroll position and may give slightly
different values when animating vs. not).

We tweak enyo/Scrollable to defer to an alternative method when one
is provided, and we provide an alternative method in
enyo/NewDataList.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)