### PR TITLE
ENYO-2667: Account for queue being modified during iteration.

### DIFF
--- a/src/History.js
+++ b/src/History.js
@@ -235,14 +235,13 @@ var EnyoHistory = module.exports = kind.singleton(
 	* @private
 	*/
 	processQueue: function () {
-		var i, l = _queue.length, next,
-			i2, entries;
+		var next, i, entries;
 
 		this.silencePushEntries();
 
-		for (i = 0; i < l; i++) {
+		while (_queue.length) {
 			next = _queue.shift();
-			
+
 			if (next.type === 'push') {
 				this.pushEntry(next.entry, next.silenced);
 			} else {
@@ -251,9 +250,9 @@ var EnyoHistory = module.exports = kind.singleton(
 				// if a 'pop' was requested
 				if (next.type == 'pop') {
 					// iterate the requested number of history entries
-					for (i2 = entries.length - 1; i2 >= 0; --i2) {
+					for (i = entries.length - 1; i >= 0; --i) {
 						// and call each handler if it exists
-						this.processPopEntry(entries[i2]);
+						this.processPopEntry(entries[i]);
 					}
 				}
 				// otherwise we just drop the entries and do nothing


### PR DESCRIPTION
### Issue
There isn't a way to prevent the back key from popping the current history entry, so we are re-pushing a dropped entry in these cases. If the back key is pressed repeatedly (particularly on slow hardware), the queue can become out of sync and cause `enyo/History` to be in a state where future back key presses do nothing.

### Fix
We use a `while` loop to account for the case where the queue is modified while it is being iterated through.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>