### PR TITLE
ENYO-2673: Prevent bounds of zero when restoring a cached view.

### DIFF
--- a/src/LightPanels/LightPanels.less
+++ b/src/LightPanels/LightPanels.less
@@ -94,7 +94,7 @@
 		}
 
 		> .offscreen {
-			display: none;
+			visibility: hidden;
 		}
 
 		.enyo-locale-right-to-left & > * {


### PR DESCRIPTION
### Issue
When restoring a cached view that performs bounds calculations during an initialization lifecycle method, such as `rendered`, the bounds of the component will be zero as we are using `display:none` to hide offscreen panels. In the case of `moonstone/Scroller`, the bounds of zero resulted in the paging controls not being properly updated/enabled when the view was restored.

### Fix
As we want to hide any potentially offscreen panels (i.e. in use cases where this is not being used full-screen or we don't want to clip the overflow) but want to maintain the proper bounds values, we instead use `visibility:none` for offscreen panels.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>