### PR TITLE
ENYO-2698: Reset queue and history instead of enqueueing drop when clearing history

### DIFF
--- a/src/History.js
+++ b/src/History.js
@@ -182,9 +182,9 @@ var EnyoHistory = module.exports = kind.singleton(
 	* @public
 	*/
 	clear: function () {
-		_queue.length = 0;
+		_queue.splice(0, _queue.length);
+		_history.splice(0, _history.length);
 		_popQueueCount = 0;
-		_history.length = 0;
 		_pushQueued = false;
 	},
 

--- a/src/History.js
+++ b/src/History.js
@@ -183,6 +183,9 @@ var EnyoHistory = module.exports = kind.singleton(
 	*/
 	clear: function () {
 		var len = _history.length;
+
+		if (_popQueueCount) len = len - _popQueueCount;
+
 		if (len) {
 			this.drop(len);
 		}

--- a/src/History.js
+++ b/src/History.js
@@ -175,20 +175,17 @@ var EnyoHistory = module.exports = kind.singleton(
 	},
 
 	/**
-	* Asynchronously drops all history entries without calling their respective handlers. When the
+	* Clears all history entries without calling their respective handlers. When the
 	* entries are popped, the internal history will be empty and the browser history will be
 	* reset to the state when this module started tracking the history.
 	*
 	* @public
 	*/
 	clear: function () {
-		var len = _history.length;
-
-		if (_popQueueCount) len = len - _popQueueCount;
-
-		if (len) {
-			this.drop(len);
-		}
+		_queue.length = 0;
+		_popQueueCount = 0;
+		_history.length = 0;
+		_pushQueued = false;
 	},
 
 	/**


### PR DESCRIPTION
### Issue
When `clear()` is called when one or more `drop()` is being queued, length of `_history` array does not reflect the correct number of history entities to clear and ends up dropping more than it needs to. This results in splicing the `_history` array with negative starting index when processing the enqueued pop.

### Fix
Clear function would remove all entities in `_history` as well as the `_queue`.

Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>