### PR TITLE
Fixes ENYO-2691

### DIFF
--- a/src/TranslateScrollStrategy.js
+++ b/src/TranslateScrollStrategy.js
@@ -67,18 +67,28 @@ module.exports = kind(
 			sup.apply(this, arguments);
 			dispatcher.makeBubble(this.$.clientContainer, 'scroll');
 			if (this.translateOptimized) {
-				this.setStartPosition();
+				// on render, the start positions should be 0 for translateOptimized because the
+				// scrollNode's scrollTop/Left will always be 0 and therefore offsetting the
+				// translate to account for a non-zero scrollTop/Left isn't necessary.
+				this.setStartPosition(true);
 			}
 		};
 	}),
 
 	/**
-	* @method
+	* Sets the start position for scrolling.
+	*
+	* @param {Boolean} [reset] When true, resets the start position to 0 rather than the current
+	* 	scrollTop and scrollLeft.
 	* @private
 	*/
-	setStartPosition: function() {
-		this.startX = this.getScrollLeft();
-		this.startY = this.getScrollTop();
+	setStartPosition: function (reset) {
+		if (reset) {
+			this.startX = this.startY = 0;
+		} else {
+			this.startX = this.getScrollLeft();
+			this.startY = this.getScrollTop();
+		}
 	},
 
 	/**


### PR DESCRIPTION
When re-rendering a scrolled scroller using TranslateScrollStrategy
with translateOptimized: true, the startX/Y values would be updated to
be a non-zero value matching the prior values of scrollLeft/Top.
However, the scrollNode was also translated the same amounts. As a
result, when the user scrolled, the content would jump the amount of
startX/Y resulting in whitespace above the content.

Since the purpose of startX/Y is to offset the transform the amount of
the scrollLeft/Top of the scrollNode but those values are never
updated with translateOptimized: true, we'll reset them to 0 in
rendered() so no offsetting occurs.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)