### PR TITLE
ENYO-2719: Remove panel in reverse order when replacing panels

### DIFF
--- a/src/LightPanels/LightPanels.js
+++ b/src/LightPanels/LightPanels.js
@@ -531,7 +531,7 @@ module.exports = kind(
 		commonInfo = {addBefore: insertBefore};
 
 		// remove existing panels
-		for (idx = start; idx < end; idx++) {
+		for (idx = end - 1; idx >= start; idx--) {
 			this.removePanel(panels[idx]);
 		}
 


### PR DESCRIPTION
## Issue 
When replaceAt() goes through the loop to remove panels, removePanel changes the length and entries of panels array. This will skip every even numbered index of panels that needs to be removed.

## Fix 
Remove panel in reverse order.

Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>