### PR TITLE
ENYO-2768: Set visibility to a valid property value.

### DIFF
--- a/src/VirtualDataRepeater.js
+++ b/src/VirtualDataRepeater.js
@@ -33,7 +33,7 @@ module.exports = kind({
 			if (this._needsReset) {
 				// Now that we've done our deferred reset, we
 				// can become visible again
-				this.applyStyle('visibility', 'showing');
+				this.applyStyle('visibility', 'visible');
 				this._needsReset = false;
 			}
 		}
@@ -289,7 +289,7 @@ module.exports = kind({
 	fwd: function() {
 		this.set('first', this.first + 1);
 	},
-	
+
 	bak: function() {
 		this.set('first', this.first - 1);
 	},


### PR DESCRIPTION
### Issue
In `reset`, the value of the `visibility` property was not being set to a valid value, and so in certain cases the list remained hidden.

### Fix
We set the value to `visible` when we want the list to be shown.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>