### PR TITLE
ENYO-2744: Tweaks to allow restoration of list state on render

### DIFF
--- a/src/Control/Control.js
+++ b/src/Control/Control.js
@@ -1199,8 +1199,7 @@ var Control = module.exports = kind(
 	removeNodeFromDom: function() {
 		var node = this.hasNode();
 		if (node) {
-			if (node.remove) node.remove();
-			else if (node.parentNode) node.parentNode.removeChild(node);
+			Dom.removeNode(node);
 		}
 	},
 

--- a/src/DataList/DataList.js
+++ b/src/DataList/DataList.js
@@ -224,18 +224,24 @@ var DataList = module.exports = kind(
 	* [collection]{@link module:enyo/DataRepeater~DataRepeater#data} to scroll to the position of that
 	* index in the list.
 	*
+	* It is important to note that this scrolling operation is not guaranteed to be synchronous. If
+	* you need to perform another action upon the completion of scrolling, you should pass a callback
+	* function as a second argument to this method.
+	*
 	* @param {Number} idx - The index in the [list's]{@link module:enyo/DataList~DataList}
 	*	[collection]{@link module:enyo/DataRepeater~DataRepeater#data} to scroll to.
+	* @param {Function} callback - A function to be executed after the scroll operation is
+	*   complete.
 	* @public
 	*/
-	scrollToIndex: function (idx) {
+	scrollToIndex: function (idx, callback) {
 		var len = this.collection? this.collection.length: 0;
 		if (idx >= 0 && idx < len) {
 			if (this.get('absoluteShowing')) {
-				this.delegate.scrollToIndex(this, idx);
+				this.delegate.scrollToIndex(this, idx, callback);
 			} else {
 				this._addToShowingQueue('scrollToIndex', function () {
-					this.delegate.scrollToIndex(this, idx);
+					this.delegate.scrollToIndex(this, idx, callback);
 				});
 			}
 		}

--- a/src/HTMLStringDelegate.js
+++ b/src/HTMLStringDelegate.js
@@ -120,7 +120,7 @@ module.exports = {
 	* @private
 	*/
 	renderContent: function (control) {
-		if (control.generated) this.teardownChildren(control);
+		if (control.generated) control.teardownChildren();
 		if (control.hasNode()) control.node.innerHTML = this.generateInnerHtml(control);
 	},
 	
@@ -244,7 +244,7 @@ module.exports = {
 	* @private
 	*/
 	teardownRender: function (control, cache) {
-		if (control.generated) this.teardownChildren(control, cache);
+		if (control.generated) control.teardownChildren(cache);
 		control.node = null;
 		control.set('generated', false);
 	},

--- a/src/VerticalDelegate.js
+++ b/src/VerticalDelegate.js
@@ -338,9 +338,11 @@ module.exports = {
 	* @method
 	* @param {module:enyo/DataList~DataList} list - The [list]{@link module:enyo/DataList~DataList} to perform this action on.
 	* @param {Number} i - The index to scroll to.
+	* @param {Function} callback - A function to be executed after the scroll operation is
+	*   complete.
 	* @private
 	*/
-	scrollToIndex: function (list, i) {
+	scrollToIndex: function (list, i, callback) {
 			// first see if the child is already available to scroll to
 		var c = this.childForIndex(list, i),
 			// but we also need the page so we can find its position
@@ -353,12 +355,15 @@ module.exports = {
 		list.$.scroller.stop();
 		if (c) {
 			this.scrollToControl(list, c);
+			if (typeof callback === 'function') {
+				callback();
+			}
 		} else {
 			// we do this to ensure we trigger the paging event when necessary
 			this.resetToPosition(list, this.pagePosition(list, p));
 			// now retry the original logic until we have this right
 			list.startJob('vertical_delegate_scrollToIndex', function () {
-				list.scrollToIndex(i);
+				list.scrollToIndex(i, callback);
 			});
 		}
 	},

--- a/src/ViewPreloadSupport.js
+++ b/src/ViewPreloadSupport.js
@@ -3,6 +3,7 @@
 * @module enyo/ViewPreloadSupport
 */
 var
+	dom = require('./dom'),
 	kind = require('./kind'),
 	utils = require('./utils');
 
@@ -111,13 +112,14 @@ var ViewPreloadSupport = {
 	* @public
 	*/
 	cacheView: function (view, preserve) {
-		var id = this.getViewId(view);
+		var id = this.getViewId(view),
+			node = view.hasNode();
 
 		// The panel could have already been removed from DOM and torn down if we popped when
 		// moving forward.
-		if (view.hasNode()) {
-			view.removeNodeFromDom();
+		if (node) {
 			view.teardownRender(true);
+			dom.removeNode(node);
 		}
 
 		if (!preserve) {

--- a/src/dom.js
+++ b/src/dom.js
@@ -411,6 +411,17 @@ var dom = module.exports = {
 	},
 
 	/**
+	* Removes a node from the DOM.
+	*
+	* @param {Node} node - The [node]{@glossary Node} to remove.
+	* @public
+	*/
+	removeNode: function (node) {
+		if (node.remove) node.remove();
+		else if (node.parentNode) node.parentNode.removeChild(node);
+	},
+
+	/**
 	* Sets the `innerHTML` property of the specified `node` to `html`.
 	*
 	* @param {Node} node - The [node]{@glossary Node} to set.


### PR DESCRIPTION
We have recently started getting more aggressive about view
virtualization for performance reasons. One tactic in this area
involves tearing down the DOM representation of a Control and then
restoring it later as needed ("view caching").

In the case where the view being cached / restored contains a
DataList, the state of the view was not being preserved as expected
because DataList effectively resets upon being (re-)rendered.

The proper fix for this issue would involve rethinking the DataList
lifecycle with view-virtualization scenarios in mind, but this
would be a significant effort and the current DataList is on a
relatively short road to replacement, so for now we'll go with a
lighter-weight, Moonstone-specific solution.

That solution does, however, require a number of minor tweaks and
enhancements in Enyo:

* A minor change to the delegation interface between enyo/Control
  and enyo/HTMLStringDelegate, allowing `teardownChildren()` to be
  more easily extended or overridden.

* A new `callback` argument for `enyo/DataList.scrollToIndex()`,
  allowing for actions to be performed after this potentially
  asynchronous operation is completed.

* A change in `enyo/ViewPreloadSupport.cacheView()` to defer
  removing the view's DOM node until after its children have been
  torn down. This enables views to hook `teardownChildren()` and
  do things in preparation for being torn down that take current
  DOM state into account.

* To support the above change in enyo/ViewPreloadSupport, a minor
  refactoring of some cross-platform node-removal logic, moving it
  from enyo/Control to enyo/dom.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)