### PR TITLE
ENYO-2780: Disable user input monitoring, by default.

### DIFF
--- a/src/SystemMonitor.js
+++ b/src/SystemMonitor.js
@@ -72,6 +72,16 @@ module.exports = kind.singleton(
 	active: false,
 
 	/**
+	* When `true`, user inputs (mouse movement, keypresses) are considered to determine system idle
+	* status.
+	*
+	* @type {Boolean}
+	* @default false
+	* @private
+	*/
+	monitorUserInput: false,
+
+	/**
 	* @method
 	* @private
 	*/
@@ -88,10 +98,10 @@ module.exports = kind.singleton(
 					f = ((c - p) < d) ? f + 1 : 0;
 				}
 
-				if (f == this.frameThreshold && this.idle()) {
+				if (f == this.frameThreshold && (!this.monitorUserInput || this.idle())) {
 					this.active = false;
 					this.emit('idle');
-					if (this.listeners('idle').length === 0) {
+					if (this.monitorUserInput && this.listeners('idle').length === 0) {
 						var idx = dispatcher.features.indexOf(this._checkEvent);
 						if (idx > -1) dispatcher.features.splice(idx, 1);
 						this._checkEvent = null;
@@ -120,10 +130,12 @@ module.exports = kind.singleton(
 	* @public
 	*/
 	start: function () {
-		if (!this.lastActive) this.lastActive = perfNow(); // setting initial value for lastActive
-		if (!this._checkEvent) {
-			this._checkEvent = this.bindSafely(this.checkEvent);
-			dispatcher.features.push(this._checkEvent);
+		if (this.monitorUserInput) {
+			if (!this.lastActive) this.lastActive = perfNow(); // setting initial value for lastActive
+			if (!this._checkEvent) {
+				this._checkEvent = this.bindSafely(this.checkEvent);
+				dispatcher.features.push(this._checkEvent);
+			}
 		}
 		if (!this.active) {
 			this.active = true;


### PR DESCRIPTION
### Issue
The system idleness monitor was overly idealistic by checking user input (mouse movement, keypresses). In real-world use cases, the user will continue to move the mouse, and prevents the system from ever registering as "idle." Kinds that rely on idleness, such as the `BackgroundTaskManager`, can encounter this scenario and not be able to process tasks, for example.

### Fix
We have added an internal flag to control the monitoring of these user input signals, `monitorUserInput`. This is set to `false` by default as we want to primarily rely on the system load check for idleness determination (processing background tasks, for example, while the user is moving the mouse and/or pressing keys, is not undesired). We may want to use these user input signals down the road, but they are effectively being disabled for now.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>