### PR TITLE
after tearDownRender, render does not happen

### DIFF
--- a/src/HTMLStringDelegate.js
+++ b/src/HTMLStringDelegate.js
@@ -120,7 +120,7 @@ module.exports = {
 	* @private
 	*/
 	renderContent: function (control) {
-		if (control.generated) control.teardownChildren();
+		if (control.generated) this.teardownChildren(control);
 		if (control.hasNode()) control.node.innerHTML = this.generateInnerHtml(control);
 	},
 	
@@ -244,7 +244,7 @@ module.exports = {
 	* @private
 	*/
 	teardownRender: function (control, cache) {
-		if (control.generated) control.teardownChildren(cache);
+		if (control.generated) this.teardownChildren(control, cache);
 		control.node = null;
 		control.set('generated', false);
 	},


### PR DESCRIPTION
Cause
--------
after tearDownRender, render does not happen, because this and control is different

Fix
----
reverted ENYO-2744 only HTMLStringDelgate.js

Enyo-DCO-1.1-Signed-off-by: Suhyung Lee suhyung2.lee@lge.com