### PR TITLE
ENYO-2788: Provide an explicit `beforeTeardown()` hook for Control

### DIFF
--- a/src/Control/Control.js
+++ b/src/Control/Control.js
@@ -1132,6 +1132,16 @@ var Control = module.exports = kind(
 	},
 
 	/**
+	* If a Control needs to do something before it and its children's DOM nodes
+	* are torn down, it can implement this lifecycle method, which is called automatically
+	* by the framework and takes no arguments.
+	*
+	* @type {Function}
+	* @protected
+	*/
+	beforeTeardown: null,
+
+	/**
 	* @param {Boolean} [cache] - Whether or not we are tearing down as part of a destroy
 	*	operation, or if we are just caching. If `true`, the `showing` and `canGenerate`
 	*	properties of the control will not be reset.

--- a/src/HTMLStringDelegate.js
+++ b/src/HTMLStringDelegate.js
@@ -120,7 +120,7 @@ module.exports = {
 	* @private
 	*/
 	renderContent: function (control) {
-		if (control.generated) control.teardownChildren();
+		if (control.generated) this.teardownChildren(control);
 		if (control.hasNode()) control.node.innerHTML = this.generateInnerHtml(control);
 	},
 	
@@ -244,7 +244,13 @@ module.exports = {
 	* @private
 	*/
 	teardownRender: function (control, cache) {
-		if (control.generated) control.teardownChildren(cache);
+		if (control.generated) {
+			if (typeof control.beforeTeardown === 'function') {
+				control.beforeTeardown();
+			}
+			this.teardownChildren(control, cache);
+		}
+			
 		control.node = null;
 		control.set('generated', false);
 	},
@@ -255,7 +261,7 @@ module.exports = {
 	teardownChildren: function (control, cache) {
 		var child,
 			i = 0;
-			
+
 		for (; (child = control.children[i]); ++i) {
 			child.teardownRender(cache);
 		}


### PR DESCRIPTION
Changes from https://github.com/enyojs/enyo/pull/1326.