### PR TITLE
ENYO-2820: update escape function to use toLocaleString() 

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -50,6 +50,7 @@ var dom = module.exports = {
 	* @public
 	*/
 	escape: function(text) {
+		if (typeof text == 'array') text = text.toLocaleString();
 		return text !== null ? String(text).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;') : '';
 	},
 


### PR DESCRIPTION
# Issue
If content is array, converting from array to string needs to translate comma "," to locale character

# Fix
Call array's "toLocaleString()" before escape the string.
(So far, ilib doesn't support toLocaleString properly. But think they'll support it)

Enyo-DCO-1.1-Signed-off-by: Sungbae Cho (sb.cho@lge.com)