### PR TITLE
ENYO-2783: Refactoring in enyo/Scrollable to allow customization

### DIFF
--- a/src/DataRepeater.js
+++ b/src/DataRepeater.js
@@ -578,6 +578,22 @@ var DataRepeater = module.exports = kind(
 	},
 
 	/**
+	* Returns the index of a child control. This is useful primarily when you have a reference to a Control
+	* that is not (or may not be) an immediate child of the repeater, but is instead a sub-child of one of the
+	* repeater's immediate children.
+	*
+	* @param {Control} child - The child (or sub-child) whose index you want to retrieve.
+	* @returns {Number} The index of the child, or -1 if the Control is not a child of the repeater.
+	* @public
+	*/
+	indexForChild: function (child) {
+		while (child && child.repeater !== this) {
+			child = child.parent;
+		}
+		return child ? child.index : -1;
+	},
+
+	/**
 	* Retrieves the data associated with the [repeater]{@link module:enyo/DataRepeater~DataRepeater}.
 	*
 	* @returns {module:enyo/Collection~Collection} The {@link module:enyo/Collection~Collection} that comprises the data.

--- a/src/NewDataList.js
+++ b/src/NewDataList.js
@@ -73,6 +73,26 @@ module.exports = kind({
 	},
 
 	/**
+	* This method is considered private for NewDataList, although
+	* the corresponding method defined in the Scrollable mixin is
+	* public in the more general case. For NewDataList, application
+	* code should generally use `scrollToItem()` instead, because it works
+	* regardless of whether the target item is currently "virtualized,"
+	* whereas `scrollToControl()` works only on non-virtual items.
+	*
+	* NewDataList overrides this method because it can provide a
+	* more accurate, more performant implementation than the general
+	* one provided by enyo/Scrollable.
+	*
+	* @private
+	*/
+	scrollToControl: function (control, opts) {
+		if (typeof control.index === 'number' && control.parent === this.$.container) {
+			this.scrollToItem(control.index, opts);
+		}
+	},
+
+	/**
 	* @private
 	*/
 	calculateMetrics: function(opts) {

--- a/src/NewDataList.js
+++ b/src/NewDataList.js
@@ -73,26 +73,6 @@ module.exports = kind({
 	},
 
 	/**
-	* This method is considered private for NewDataList, although
-	* the corresponding method defined in the Scrollable mixin is
-	* public in the more general case. For NewDataList, application
-	* code should generally use `scrollToItem()` instead, because it works
-	* regardless of whether the target item is currently "virtualized,"
-	* whereas `scrollToControl()` works only on non-virtual items.
-	*
-	* NewDataList overrides this method because it can provide a
-	* more accurate, more performant implementation than the general
-	* one provided by enyo/Scrollable.
-	*
-	* @private
-	*/
-	scrollToControl: function (control, opts) {
-		if (typeof control.index === 'number' && control.parent === this.$.container) {
-			this.scrollToItem(control.index, opts);
-		}
-	},
-
-	/**
 	* @private
 	*/
 	calculateMetrics: function(opts) {

--- a/src/NewDataList.js
+++ b/src/NewDataList.js
@@ -62,14 +62,14 @@ module.exports = kind({
 
 		// If the item is near the horizontal or vertical
 		// origin, scroll all the way there
-		if (b.x <= this.spacing) {
-			b.x = 0;
+		if (b.left <= this.spacing) {
+			b.left = 0;
 		}
-		if (b.y <= this.spacing) {
-			b.y = 0;
+		if (b.top <= this.spacing) {
+			b.top = 0;
 		}
 
-		this.scrollTo(b.x, b.y, opts);
+		this.scrollTo(b.left, b.top, opts);
 	},
 
 	/**
@@ -274,9 +274,29 @@ module.exports = kind({
 		p2 = sp + (g2 * this.delta2);
 
 		return (this.direction == 'vertical')
-			? { x: p2, y: p, w: is2, h: is }
-			: { x: p, y: p2, w: is, h: is2 }
+			? { left: p2, top: p, width: is2, height: is }
+			: { left: p, top: p2, width: is, height: is2 }
 		;
+	},
+
+	/**
+	* Providing a NewDataList-specific implementation of the
+	* `getChildOffsets()` interface defined by enyo/Scrollable. This
+	* implemenation is less expensive than the general implementation
+	* provided by Scrollable, and properly accounts for item spacing.
+	*
+	* @private
+	*/
+	getChildOffsets: function (child, scrollBounds) {
+		var index = this.indexForChild(child),
+			offsets = this.getItemBounds(index),
+			margin = this.spacing;
+
+		offsets.getMargin = function (side) {
+			return margin;
+		};
+
+		return offsets;
 	},
 
 	/**

--- a/src/ScrollMath.js
+++ b/src/ScrollMath.js
@@ -158,30 +158,6 @@ module.exports = kind(
 	* @private
 	*/
 	kFrictionEpsilon: platform.webos >= 4 ? 1e-1 : 1e-2,
-
-	/**
-	* TODO: Document
-	* Experimental
-	*
-	* @private
-	*/
-	xSnapIncrement: 0,
-
-	/**
-	* TODO: Document
-	* Experimental
-	*
-	* @private
-	*/
-	ySnapIncrement: 0,
-
-	/**
-	* TODO: Document
-	* Experimental
-	*
-	* @private
-	*/
-	boundarySnapThreshold: 0,
 	
 	/** 
 	* Top snap boundary, generally `0`.
@@ -707,34 +683,16 @@ module.exports = kind(
 		var animate = !opts || opts.behavior !== 'instant',
 			xSnap = this.xSnapIncrement,
 			ySnap = this.ySnapIncrement,
-			bSnap = this.boundarySnapThreshold,
 			allowOverScroll = opts && opts.allowOverScroll,
 			maxX = Math.abs(Math.min(0, this.rightBoundary)),
 			maxY = Math.abs(Math.min(0, this.bottomBoundary));
 
-
-		if (xSnap) {
+		if (typeof xSnap === 'number') {
 			x = xSnap * Math.round(x / xSnap);
 		}
 
-		if (ySnap) {
+		if (typeof ySnap === 'number') {
 			y = ySnap * Math.round(y / ySnap);
-		}
-
-		if (bSnap) {
-			if (x > -this.x && maxX > x && maxX - x < bSnap) {
-				x = maxX;
-			}
-			else if (x < -this.x && x > 0 && x < bSnap) {
-				x = 0;
-			}
-
-			if (y > -this.y && maxY > y && maxY - y < bSnap) {
-				y = maxY;
-			}
-			else if (y < -this.y && y > 0 && y < bSnap) {
-				y = 0;
-			}
 		}
 
 		if (!animate || !allowOverScroll) {

--- a/src/Scrollable/Scrollable.js
+++ b/src/Scrollable/Scrollable.js
@@ -327,27 +327,13 @@ module.exports = {
 	*
 	* @public
 	*/
-	scrollToControl: kind.inherit(function (sup) {
-		return function (control, opts) {
-			var n;
+	scrollToControl: function (control, opts) {
+		var n = control.hasNode();
 
-			// Default implementation -- in case the Control
-			// applying the Scrollable mixin does not supply
-			// its own
-			if (sup === utils.nop) {
-				n = control.hasNode();
-
-				if (n) {
-					this.scrollToNode(n, opts);
-				}
-			}
-			// If the Control does provide an alternative
-			// implementation, we use it
-			else {
-				sup.apply(this, arguments);
-			}
-		};
-	}),
+		if (n) {
+			this.scrollToNode(n, opts);
+		}
+	},
 
 	/**
 	* TODO: Document. Based on CSSOM View spec ()

--- a/src/Scrollable/Scrollable.js
+++ b/src/Scrollable/Scrollable.js
@@ -327,13 +327,27 @@ module.exports = {
 	*
 	* @public
 	*/
-	scrollToControl: function (control, opts) {
-		var n = control.hasNode();
+	scrollToControl: kind.inherit(function (sup) {
+		return function (control, opts) {
+			var n;
 
-		if (n) {
-			this.scrollToNode(n, opts);
-		}
-	},
+			// Default implementation -- in case the Control
+			// applying the Scrollable mixin does not supply
+			// its own
+			if (sup === utils.nop) {
+				n = control.hasNode();
+
+				if (n) {
+					this.scrollToNode(n, opts);
+				}
+			}
+			// If the Control does provide an alternative
+			// implementation, we use it
+			else {
+				sup.apply(this, arguments);
+			}
+		};
+	}),
 
 	/**
 	* TODO: Document. Based on CSSOM View spec ()


### PR DESCRIPTION
The logic for scrolling to a child of Scrollable has until now
been essentially monolithic, but we now refactor it to allow parts
of the logic to be selectively overridden.

Specifically, there are now separate methods for getting the
offset coordinates of the child (`getChildOffsets()`), calculating
the target scroll coordinates (`getTargetCoordinates()`), and
actually effecting the scroll (`scrollToTarget()`).

The immediate use case is to provide a custom implementation of
`getChildOffsets()` for NewDataList, since NewDataList can get
child offsets more efficiently than the default implemenation does,
and can also properly account for the spacing of list items in its
own implementation. (Not properly accounting for spacing was the
actual root cause of ENYO-2644 and ENYO-2783, the issues that led
to this work. As part of this pull request, we are also reverting
earlier, flawed solutions to the problem described in ENYO-2644).

Note that we also have a use case for overriding `scrollToTarget()`
(see ENYO-2710 and ENYO-2729), but that work is not required to fix
ENYO-2783 so we aren't doing it now.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)