### PR TITLE
ENYO-2840: Make `accessibilityPreventScroll` work in RTL

### DIFF
--- a/src/AccessibilitySupport/AccessibilitySupport.js
+++ b/src/AccessibilitySupport/AccessibilitySupport.js
@@ -54,11 +54,14 @@ var defaultObservers = [
 *
 * @private
 */
-function preventScroll (node) {
+function preventScroll (node, rtl) {
 	if (node) {
 		dispatcher.listen(node, 'scroll', function () {
 			node.scrollTop = 0;
-			node.scrollLeft = 0;
+			// TODO: This probably won't work cross-browser, as the different
+			// browser engines appear to treat scrollLeft differently in RTL.
+			// See ENYO-2841.
+			node.scrollLeft = rtl ? node.scrollWidth : 0;
 		});
 	}
 }
@@ -293,7 +296,7 @@ var AccessibilitySupport = {
 		return function () {
 			sup.apply(this, arguments);
 			if (this.accessibilityPreventScroll) {
-				preventScroll(this.hasNode());
+				preventScroll(this.hasNode(), this.rtl);
 			}
 		};
 	})


### PR DESCRIPTION
The `accessibilityPreventScroll` feature prevents the browser
engine from doing bad auto-scrolling things when an item is focused
in one of our scrollers. It works by listening for native scroll
events and forcibly resetting native scrollTop and scrollLeft
properties as needed.

Our logic for resetting scrollLeft did not previously account for
RTL, so we fix that.

As noted inline, the current fix is specific to Blink and WebKit;
we'll need to do something clever to make this work cross-browser,
but not attempting that now because cross-browser support is not
urgent for the imminent internal release, and this is not our only
cross-browser scrolling issue. Wrote up ENYO-2841 to track future
work.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)