### PR TITLE
Fixes PLAT-12619

### DIFF
--- a/src/SlideViewLayout/SlideViewLayout.js
+++ b/src/SlideViewLayout/SlideViewLayout.js
@@ -114,12 +114,12 @@ module.exports = kind({
 			transform = this.container.orientation == 'horizontal' ? 'translateX' : 'translateY';
 
 		TransitionViewLayout.prototype.transition.apply(this, arguments);
-		if (was) {
+		if (was && was != this.dragView) {
 			dom.transformValue(was, transform, null);
 		}
 		if (is) {
 			this.addRemoveDirection(is, false);
-			dom.transformValue(is, transform, null);
+			if (is != this.dragView) dom.transformValue(is, transform, null);
 		}
 
 		// If the user drags the entire view off screen, it won't animate so we won't see the CSS

--- a/src/ViewLayout/ViewLayout.js
+++ b/src/ViewLayout/ViewLayout.js
@@ -70,11 +70,11 @@ module.exports = kind(
 		this._transitioning = {
 			from: {
 				view: null,
-				complete: false
+				complete: true
 			},
 			to: {
 				view: null,
-				complete: false
+				complete: true
 			}
 		};
 	},
@@ -227,7 +227,7 @@ module.exports = kind(
 		if (!this.isTransitioning()) {
 			this.completeTransition(t.from.view, t.to.view);
 			t.from.view = t.to.view = null;
-			t.from.complete = t.to.complete = false;
+			t.from.complete = t.to.complete = true;
 		}
 	},
 

--- a/src/ViewManager/ViewManager.js
+++ b/src/ViewManager/ViewManager.js
@@ -338,7 +338,13 @@ var ViewMgr = kind(
 	* @private
 	*/
 	activeChanged: function (was, is) {
-		if (was) this.emitViewEvent('deactivate', was);
+		if (was) {
+			if (this.dragging) {
+				this.set('dragging', false);
+				this.releaseDraggedView = was.retainNode();
+			}
+			this.emitViewEvent('deactivate', was);
+		}
 	},
 
 	/**
@@ -865,8 +871,10 @@ var ViewMgr = kind(
 	*/
 	teardownView: function (view) {
 		if (view.node && !view.persistent) {
-			view.node.remove();
-			view.node = null;
+			if (!this.releaseDraggedView) {
+				view.node.remove();
+				view.node = null;
+			}
 			view.set('canGenerate', false);
 			view.teardownRender(true);
 		}
@@ -978,6 +986,10 @@ var ViewMgr = kind(
 	* @private
 	*/
 	handleDragFinish: function (sender, event) {
+		if (this.releaseDraggedView) {
+			this.releaseDraggedView();
+			this.releaseDraggedView = null;
+		}
 		if (!this.dragging || !this.draggable || this.dismissed) return;
 
 		this.decorateDragEvent(event);


### PR DESCRIPTION
Prevents resetting transform on the dragView which caused a visual jump
when the view reset its position before transitioning offscreen. Resets
dragging when a view is activated and correctly retains a to be
tore down node until dragging completes.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)