### PR TITLE
ENYO-2913: Prevent concurrent transitions when setupTransitions is triggered via an index change or animateTo call.

### DIFF
--- a/src/LightPanels/LightPanels.js
+++ b/src/LightPanels/LightPanels.js
@@ -729,17 +729,16 @@ module.exports = kind(
 			currPanel = this._currentPanel,
 			shiftCurrent, fnInitiateTransition;
 
-		this._indexDirection = 0;
-
-		// handle the wrapping case
-		if (this.wrap) {
-			if (this.index === 0 && previousIndex == panels.length - 1) this._indexDirection = 1;
-			else if (this.index === panels.length - 1 && previousIndex === 0) this._indexDirection = -1;
-		}
-		if (this._indexDirection === 0 && previousIndex != -1) this._indexDirection = this.index - previousIndex;
-
-		if (nextPanel) {
+		if (nextPanel && !this.transitioning) {
 			this.transitioning = true;
+			this._indexDirection = 0;
+
+			// handle the wrapping case
+			if (this.wrap) {
+				if (this.index === 0 && previousIndex == panels.length - 1) this._indexDirection = 1;
+				else if (this.index === panels.length - 1 && previousIndex === 0) this._indexDirection = -1;
+			}
+			if (this._indexDirection === 0 && previousIndex != -1) this._indexDirection = this.index - previousIndex;
 
 			// prepare the panel that will be deactivated
 			if (currPanel) {


### PR DESCRIPTION
### Issue
When calling `animateTo` sequentially, we can end up in a state where the currently active panel is positioned incorrectly, as the state used to setup the transitions for the second call to `animateTo` can reflect the state before the first call to `animateTo` has completed.

### Fix
If we have initiated a transition, we prevent any subsequent transitions from being processed. This seemed like the safest fix, though any logic that leads to multiple, sequential calls to `animateTo` would need to be tweaked and/or re-examined in the app as there should be a better way to achieve the same results. This mainly came up because of an edge case scenario in the application where this sequence of events occurred (we had previously guarded `next` and `previous`, but this scenario seems to be a result of some programmatic index changing).

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>