### PR TITLE
ENYO-2604: Remove scrim upon destruction.

### DIFF
--- a/src/Popup/Popup.js
+++ b/src/Popup/Popup.js
@@ -326,6 +326,7 @@ var Popup = module.exports = kind(
 	destroy: kind.inherit(function (sup) {
 		return function() {
 			this.release();
+			if (this.showing) this.showHideScrim(false);
 			sup.apply(this, arguments);
 		};
 	}),


### PR DESCRIPTION
### Issue
When an `enyo/Popup` is showing, and something triggers its destruction (i.e. destroying and recreating client controls), if a scrim was displayed, it will remain on-screen, preventing further interaction with the app.

### Fix
Now upon destruction, we remove the scrim if the popup is showing.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>