### PR TITLE
ENYO-896: Combine Android detection patterns.

### DIFF
--- a/src/platform.js
+++ b/src/platform.js
@@ -52,9 +52,7 @@ var platforms = [
 	// Android 4+ using Chrome
 	{platform: 'androidChrome', regex: /Android .* Chrome\/(\d+)[.\d]+/},
 	// Android 2 - 4
-	{platform: 'android', regex: /Android (\d+)/},
-	// Some android phones, e.g. ZTE and Lenovo
-	{platform: "android", regex: /Android\/(\d+)/},
+	{platform: 'android', regex: /Android(?:\s|\/)(\d+)/},
 	// Kindle Fire
 	// Force version to 2, (desktop mode does not list android version)
 	{platform: 'android', regex: /Silk\/1./, forceVersion: 2, extra: {silk: 1}},

--- a/src/platform.js
+++ b/src/platform.js
@@ -35,7 +35,7 @@ var utils = require('./utils');
 *
 * @module enyo/platform
 */
-exports = module.exports = 
+exports = module.exports =
 	/** @lends module:enyo/platform~platform */ {
 	//* `true` if the platform has native single-finger [events]{@glossary event}.
 	touch: Boolean(('ontouchstart' in window) || window.navigator.msMaxTouchPoints),
@@ -53,6 +53,8 @@ var platforms = [
 	{platform: 'androidChrome', regex: /Android .* Chrome\/(\d+)[.\d]+/},
 	// Android 2 - 4
 	{platform: 'android', regex: /Android (\d+)/},
+	// Some android phones, e.g. ZTE and Lenovo
+	{platform: "android", regex: /Android\/(\d+)/},
 	// Kindle Fire
 	// Force version to 2, (desktop mode does not list android version)
 	{platform: 'android', regex: /Silk\/1./, forceVersion: 2, extra: {silk: 1}},


### PR DESCRIPTION
### Issue
There are a subset of Android devices using the Android browser (version 2 to 4) that have the userAgent string pattern `Android/4.x.x`, which was not being detected by our current pattern (expecting `Android 4.x.x`).

### Fix
We cherry-picked @wangii's changes and combined the patterns into a single pattern for detecting Android 2-4 devices.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>