### PR TITLE
ENYO-3016: Fix touch-gesture platform identification for Windows 10, …

### DIFF
--- a/src/platform.js
+++ b/src/platform.js
@@ -46,7 +46,7 @@ exports = module.exports = {
 	* `true` if the platform has native double-finger [events]{@glossary event}.
 	* @public
 	*/
-	gesture: Boolean(('ongesturestart' in window) || window.navigator.msMaxTouchPoints || window.navigator.maxTouchPoints)
+	gesture: Boolean(('ongesturestart' in window) || (window.navigator.msMaxTouchPoints && window.navigator.msMaxTouchPoints > 1) || (window.navigator.maxTouchPoints && window.navigator.maxTouchPoints > 1))
 
 	/**
 	* The name of the platform that was detected or `undefined` if the platform

--- a/src/platform.js
+++ b/src/platform.js
@@ -38,9 +38,9 @@ var utils = require('./utils');
 exports = module.exports =
 	/** @lends module:enyo/platform~platform */ {
 	//* `true` if the platform has native single-finger [events]{@glossary event}.
-	touch: Boolean(('ontouchstart' in window) || window.navigator.msMaxTouchPoints),
+	touch: Boolean(('ontouchstart' in window) || window.navigator.msMaxTouchPoints || window.navigator.maxTouchPoints),
 	//* `true` if the platform has native double-finger [events]{@glossary event}.
-	gesture: Boolean(('ongesturestart' in window) || window.navigator.msMaxTouchPoints)
+	gesture: Boolean(('ongesturestart' in window) || window.navigator.msMaxTouchPoints || window.navigator.maxTouchPoints)
 };
 
 /**
@@ -49,6 +49,8 @@ exports = module.exports =
 var ua = navigator.userAgent;
 var ep = exports;
 var platforms = [
+	// Windows Phone 7 - 10
+	{platform: 'windowsPhone', regex: /Windows Phone (?:OS )?(\d+)[.\d]+/},
 	// Android 4+ using Chrome
 	{platform: 'androidChrome', regex: /Android .* Chrome\/(\d+)[.\d]+/},
 	// Android 2 - 4
@@ -60,8 +62,6 @@ var platforms = [
 	// Force version to 4
 	{platform: 'android', regex: /Silk\/2./, forceVersion: 4, extra: {silk: 2}},
 	{platform: 'android', regex: /Silk\/3./, forceVersion: 4, extra: {silk: 3}},
-	// Windows Phone 7 - 8
-	{platform: 'windowsPhone', regex: /Windows Phone (?:OS )?(\d+)[.\d]+/},
 	// IE 8 - 10
 	{platform: 'ie', regex: /MSIE (\d+)/},
 	// IE 11


### PR DESCRIPTION
…add Windows 10 Mobile

### Issue
enyo.platform reports the wrong touch/gesture information for Windows 10 and Windows 10 Mobile. Also Windows 10 Mobile is incorrectly identified as 'androidChrome'

### Fix
Enyo is using deprecated Windows pointer events (for IE 10 support - not to be confused with Windows 10) to determine touch/gesture capability. Since IE11, Microsoft has dropped support for its vendor-prefixed event "msMaxTouchPoints". I have now added support for "maxTouchPoints", while keeping the vendor-prefix version (until we decide we're completely dropping IE10 support).

I've also moved the Windows Phone platform regex match to the top - above 'androidChrome' - since Windows 10 Mobile contains a match to it, falsely being identified by enyo as 'androidChrome'.

Enyo-DCO-1.1-Signed-off-by: Jeremy Thomas <jeremy.thomas@lge.com>