### PR TITLE
ENYO-2409: Fix Windows 10 app deployment/innerHTML issue

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -576,7 +576,7 @@ var dom = module.exports = {
 };
 
 // override setInnerHtml for Windows 8 HTML applications
-if (typeof global.MSApp !== 'undefined') {
+if (typeof global.MSApp !== 'undefined' && typeof global.MSApp.execUnsafeLocalFunction !== 'undefined') {
 	dom.setInnerHtml = function(node, html) {
 		global.MSApp.execUnsafeLocalFunction(function() {
 			node.innerHTML = html;


### PR DESCRIPTION
### Issue
Visual Studio outputs an error when packaging a Windows 10 enyo application.

### Fix
Validate that a method exists before firing, as Windows 10 removes the Windows 8 method and requirement of using `MSApp.execUnsafeLocalFunction` to set innerHTML content.

Enyo-DCO-1.1-Signed-off-by: Jeremy Thomas <jeremy.thomas@lge.com>