### PR TITLE
PLAT-15150: Fix issues with destruction.

### DIFF
--- a/src/LightPanels/LightPanels.js
+++ b/src/LightPanels/LightPanels.js
@@ -488,11 +488,11 @@ module.exports = kind(
 
 		if (direction < 0) {
 			for (i = panels.length - 1; i > index; i--) {
-				this.removePanel(panels[i]);
+				this.removePanel(panels[i], this.popOnBack);
 			}
 		} else {
 			for (i = 0; i < index; i++) {
-				this.removePanel(panels[i], true);
+				this.removePanel(panels[i], !this.cacheViews, true);
 			}
 		}
 	},
@@ -501,17 +501,19 @@ module.exports = kind(
 	* Removes the specified panel.
 	*
 	* @param {Object} panel - The panel to remove.
+	* @param {Boolean} destroy - Whether or not the panel should be destroyed; if `false`, the panel
+	*	will instead be cached.
 	* @param {Boolean} [preserve] - If {@link module:enyo/LightPanels~LightPanels#cacheViews} is
 	*	`true`, this value is used to determine whether or not to preserve the current panel's
 	*	position in the component hierarchy and on the screen, when caching.
 	* @private
 	*/
-	removePanel: function (panel, preserve) {
+	removePanel: function (panel, destroy, preserve) {
 		if (panel) {
-			if (this.cacheViews) {
-				this.cacheView(panel, preserve);
-			} else {
+			if (destroy) {
 				panel.destroy();
+			} else {
+				this.cacheView(panel, preserve);
 			}
 		}
 	},
@@ -654,13 +656,7 @@ module.exports = kind(
 	cleanUpPanel: function (panel) {
 		if (panel) {
 			panel.set('state', panel === this._currentPanel ? States.ACTIVE : States.INACTIVE);
-			if (panel.postTransition) {
-				// Async'ing this as it seems to improve ending transition performance on the TV.
-				// Requires further investigation into its behavior.
-				utils.asyncMethod(this, function () {
-					panel.postTransition();
-				});
-			}
+			panel.postTransition && panel.postTransition();
 		}
 	},
 
@@ -679,11 +675,6 @@ module.exports = kind(
 			prevPanel = this._previousPanel;
 			currPanel = this._currentPanel;
 
-			if ((this._indexDirection < 0 && (this.popOnBack || this.cacheViews) && this.index < this.getPanels().length - 1) ||
-				(this._indexDirection > 0 && this.cacheViews && this.index > 0)) {
-				this.removePanels(this.index, this._indexDirection);
-			}
-
 			if (prevPanel) {
 				prevPanel.removeClass('shifted');
 				prevPanel.addClass('offscreen');
@@ -691,6 +682,11 @@ module.exports = kind(
 
 			this.cleanUpPanel(prevPanel);
 			this.cleanUpPanel(currPanel);
+
+			if ((this._indexDirection < 0 && (this.popOnBack || this.cacheViews) && this.index < this.getPanels().length - 1) ||
+				(this._indexDirection > 0 && this.cacheViews && this.index > 0)) {
+				this.removePanels(this.index, this._indexDirection);
+			}
 
 			this.removeClass('transitioning');
 			this.transitioning = false;

--- a/src/LightPanels/LightPanels.js
+++ b/src/LightPanels/LightPanels.js
@@ -485,16 +485,15 @@ module.exports = kind(
 	*/
 	replaceAt: function (start, count, info) {
 		var panels = this.getPanels(),
-			queue = this.popQueue,
-			insertBefore, commonInfo, end;
+			panelsToPop, insertBefore, commonInfo, end;
 
 		start = start < 0 ? panels.length + start : start;
 		end = start + count;
 		insertBefore = panels[end];
 		commonInfo = {addBefore: insertBefore};
-		queue = queue || [];
 
-		queue = queue.concat(panels.splice(start, end - start));
+		panelsToPop = panels.splice(start, end - start);
+		this.popQueue = (this.popQueue && this.popQueue.concat(panelsToPop)) || panelsToPop;
 
 		// add replacement panels
 		if (utils.isArray(info)) this.pushPanels(info, commonInfo, {direct: true, force: true});

--- a/src/LightPanels/LightPanels.js
+++ b/src/LightPanels/LightPanels.js
@@ -680,6 +680,8 @@ module.exports = kind(
 				prevPanel.addClass('offscreen');
 			}
 
+			if (this.popQueue && this.popQueue.length) this.finalizePurge();
+
 			this.cleanUpPanel(prevPanel);
 			this.cleanUpPanel(currPanel);
 
@@ -817,9 +819,20 @@ module.exports = kind(
 	* @private
 	*/
 	purge: function () {
-		var panels = this.getPanels(),
-			panel;
+		var panels = this.getPanels();
+		this.popQueue = panels.slice();
+		panels.length = 0;
+		this.index = -1;
+	},
 
+	/**
+	* Clean-up any panels queued for destruction.
+	*
+	* @private
+	*/
+	finalizePurge: function () {
+		var panels = this.popQueue,
+			panel;
 		while (panels.length) {
 			panel = panels.pop();
 			if (this.cacheViews) {
@@ -829,8 +842,6 @@ module.exports = kind(
 				panel.destroy();
 			}
 		}
-
-		this.index = -1;
 	},
 
 	/**

--- a/src/LightPanels/LightPanels.js
+++ b/src/LightPanels/LightPanels.js
@@ -680,13 +680,14 @@ module.exports = kind(
 				prevPanel.addClass('offscreen');
 			}
 
-			if (this.popQueue && this.popQueue.length) this.finalizePurge();
-
 			this.cleanUpPanel(prevPanel);
 			this.cleanUpPanel(currPanel);
 
-			if ((this._indexDirection < 0 && (this.popOnBack || this.cacheViews) && this.index < this.getPanels().length - 1) ||
-				(this._indexDirection > 0 && this.cacheViews && this.index > 0)) {
+			if (this.popQueue && this.popQueue.length) {
+				this.finalizePurge();
+			} else if ((this._indexDirection < 0 && (this.popOnBack || this.cacheViews)
+				&& this.index < this.getPanels().length - 1)
+				|| (this._indexDirection > 0 && this.cacheViews && this.index > 0)) {
 				this.removePanels(this.index, this._indexDirection);
 			}
 

--- a/src/LightPanels/LightPanels.js
+++ b/src/LightPanels/LightPanels.js
@@ -134,13 +134,13 @@ module.exports = kind(
 	wrap: false,
 
 	/**
-	* When `true`, previous panels are automatically popped when moving backwards.
+	* When `true`, previous panels are destroyed when moving backwards.
 	*
 	* @type {Boolean}
-	* @default true
+	* @default false
 	* @public
 	*/
-	popOnBack: true,
+	popOnBack: false,
 
 	/**
 	* The amount of time, in milliseconds, to run the transition animation between panels.
@@ -472,53 +472,6 @@ module.exports = kind(
 	},
 
 	/**
-	* Removes panels whose index is either greater than, or less than, the specified value,
-	* depending on the direction.
-	*
-	* @param {Number} index - Index at which to start removing panels.
-	* @param {Number} direction - The direction in which we are changing indices. A negative value
-	*	signifies that we are moving backwards, and want to remove panels whose indices are greater
-	*	than the current index. Conversely, a positive value signifies that we are moving forwards,
-	*	and panels whose indices are less than the current index should be removed.
-	* @public
-	*/
-	removePanels: function (index, direction) {
-		var panels = this.getPanels(),
-			i;
-
-		if (direction < 0) {
-			for (i = panels.length - 1; i > index; i--) {
-				this.removePanel(panels[i], this.popOnBack);
-			}
-		} else {
-			for (i = 0; i < index; i++) {
-				this.removePanel(panels[i], !this.cacheViews, true);
-			}
-		}
-	},
-
-	/**
-	* Removes the specified panel.
-	*
-	* @param {Object} panel - The panel to remove.
-	* @param {Boolean} destroy - Whether or not the panel should be destroyed; if `false`, the panel
-	*	will instead be cached.
-	* @param {Boolean} [preserve] - If {@link module:enyo/LightPanels~LightPanels#cacheViews} is
-	*	`true`, this value is used to determine whether or not to preserve the current panel's
-	*	position in the component hierarchy and on the screen, when caching.
-	* @private
-	*/
-	removePanel: function (panel, destroy, preserve) {
-		if (panel) {
-			if (destroy) {
-				panel.destroy();
-			} else {
-				this.cacheView(panel, preserve);
-			}
-		}
-	},
-
-	/**
 	* Replaces the panel(s) at the specified index with panels that will be created via provided
 	* component definition(s).
 	*
@@ -532,17 +485,16 @@ module.exports = kind(
 	*/
 	replaceAt: function (start, count, info) {
 		var panels = this.getPanels(),
-			insertBefore, commonInfo, end, idx;
+			queue = this.popQueue,
+			insertBefore, commonInfo, end;
 
 		start = start < 0 ? panels.length + start : start;
 		end = start + count;
 		insertBefore = panels[end];
 		commonInfo = {addBefore: insertBefore};
+		queue = queue || [];
 
-		// remove existing panels
-		for (idx = end - 1; idx >= start; idx--) {
-			this.removePanel(panels[idx]);
-		}
+		queue = queue.concat(panels.splice(start, end - start));
 
 		// add replacement panels
 		if (utils.isArray(info)) this.pushPanels(info, commonInfo, {direct: true, force: true});
@@ -680,19 +632,21 @@ module.exports = kind(
 				prevPanel.addClass('offscreen');
 			}
 
-			this.cleanUpPanel(prevPanel);
-			this.cleanUpPanel(currPanel);
-
-			if (this.popQueue && this.popQueue.length) {
-				this.finalizePurge();
-			} else if ((this._indexDirection < 0 && (this.popOnBack || this.cacheViews)
-				&& this.index < this.getPanels().length - 1)
-				|| (this._indexDirection > 0 && this.cacheViews && this.index > 0)) {
-				this.removePanels(this.index, this._indexDirection);
-			}
-
 			this.removeClass('transitioning');
 			this.transitioning = false;
+
+			utils.asyncMethod(this, function () {
+				this.cleanUpPanel(prevPanel);
+				this.cleanUpPanel(currPanel);
+
+				if (this.popQueue && this.popQueue.length) {
+					this.finalizePurge();
+				} else if ((this._indexDirection < 0 && (this.popOnBack || this.cacheViews)
+					&& this.index < this.getPanels().length - 1)
+					|| (this._indexDirection > 0 && this.cacheViews && this.index > 0)) {
+					this.removePanels(this.index, this._indexDirection);
+				}
+			});
 		}
 	},
 
@@ -812,6 +766,56 @@ module.exports = kind(
 		container.applyStyle('transition', animate ? trans: null);
 
 		dom.transformValue(container, 'translate' + this.orientation, value + '%');
+	},
+
+	/**
+	* Removes panels whose index is either greater than, or less than, the specified value,
+	* depending on the direction.
+	*
+	* @param {Number} index - Index at which to start removing panels.
+	* @param {Number} direction - The direction in which we are changing indices. A negative value
+	*	signifies that we are moving backwards, and want to remove panels whose indices are greater
+	*	than the current index. Conversely, a positive value signifies that we are moving forwards,
+	*	and panels whose indices are less than the current index should be removed.
+	* @private
+	*/
+	removePanels: function (index, direction) {
+		var panels = this.getPanels(),
+			i;
+
+		if (direction < 0) {
+			for (i = panels.length - 1; i > index; i--) {
+				this.removePanel(panels[i], this.cacheViews && !this.popOnBack);
+			}
+		} else {
+			for (i = 0; i < index; i++) {
+				this.removePanel(panels[i], this.cacheViews, true);
+			}
+		}
+	},
+
+	/**
+	* Removes the specified panel.
+	*
+	* @param {Object} panel - The panel to remove.
+	* @param {Boolean} cache - Whether or not the panel should be cached; if `false` or not
+	*	specified, the panel will instead be destroyed (this is the default behavior).
+	* @param {Boolean} [preserve] - If {@link module:enyo/LightPanels~LightPanels#cacheViews} is
+	*	`true`, this value is used to determine whether or not to preserve the current panel's
+	*	position in the component hierarchy and on the screen, when caching.
+	* @private
+	*/
+	removePanel: function (panel, cache, preserve) {
+		if (panel) {
+			if (cache) {
+				this.cacheView(panel, preserve);
+			} else {
+				if (this.cacheViews) {
+					this.popView(this.getViewId(panel));
+				}
+				panel.destroy();
+			}
+		}
 	},
 
 	/**

--- a/src/ViewPreloadSupport.js
+++ b/src/ViewPreloadSupport.js
@@ -142,13 +142,27 @@ var ViewPreloadSupport = {
 	* @public
 	*/
 	restoreView: function (id) {
+		var view = this.popView(id);
+
+		if (view) {
+			this.addControl(view);
+		}
+
+		return view;
+	},
+
+	/**
+	* Pops the specified view that was previously cached.
+	*
+	* @param {String} id - The unique identifier for the cached view that is being popped.
+	* @public
+	*/
+	popView: function (id) {
 		var cp = this._cachedViews,
 			view = cp[id];
 
 		if (view) {
 			this.$.viewCache.removeControl(view);
-			this.addControl(view);
-
 			this._cachedViews[id] = null;
 		}
 

--- a/src/ViewPreloadSupport.js
+++ b/src/ViewPreloadSupport.js
@@ -155,6 +155,7 @@ var ViewPreloadSupport = {
 	* Pops the specified view that was previously cached.
 	*
 	* @param {String} id - The unique identifier for the cached view that is being popped.
+	* @return {Object} The popped view.
 	* @public
 	*/
 	popView: function (id) {


### PR DESCRIPTION
### Issue
There were a few issues when disabling `cacheViews`, namely related to the panel lifecycle methods that assumed that certain components were still instantiated (primarily in the `moonstone/LightPanels` case), which caused null reference errors as the panel had already been destroyed.

### Fix
There were a number of tweaks that had to be made to support destruction of panels, as this was not a primary use case and the related logic for this mode had gotten out of sync.
- The post-transition logic has been adjusted:
  - Instead of only executing the `postTransition` method of a panel asynchronously, we are now asynchronously executing the entirety of the post-transition work, including `postTransition` and panel removal. Unfortunately, there is still a performance issue if `postTransition` is not made asynchronous, and as a result, we cannot destroy the panel (in a non-caching mode) before `postTransition` is executed. This also necessitated making a tweak to how we are replacing panels, as a similar logical fallacy would occur if we did not defer the actual destruction of the replaced panels.
  - Deferred purging of panels has been re-introduced. This was originally a speculative fix for some hard-to-reproduce issues that still appeared after this fix went in, and were seemingly related to `enyo/History` + the back key, instead. This allows us to purge, and thus destroy, panels after the lifecycle methods have been executed.
- The `popOnBack` property now takes precedence over `cacheViews`. We wanted to support the case of destroying panels we were returning from, while caching panels we had visited when moving forward (i.e. destroying panels we likely would not revisit, and caching panels we would have a high-likelihood of revisiting). As a result, the default value of this property has been changed to `false` to preserve existing behavior.
- We have introduced a `popView` method to `enyo/ViewPreloadSupport`, that can be called directly and is also used by `restoreView`. This allows for clean-up of views (and references to them) that had been previously cached and were explicitly destroyed, such as when `popOnBack` is enabled.
- The `removePanels` method has been correctly marked as `private` as it is not useful for public consumption, due to intrinsic knowledge of whether to destroy or cache a panel, based on the navigation direction.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>