### PR TITLE
Fixes ENYO-3038

### DIFF
--- a/src/gesture/drag.js
+++ b/src/gesture/drag.js
@@ -586,7 +586,7 @@ module.exports = {
 			}
 			this._pulsing = true;
 			dispatcher.dispatch(e);
-			n = this._next = this._unsent.shift();
+			n = this._next = this._unsent && this._unsent.shift();
 		}
 	},
 


### PR DESCRIPTION
If endHold() is called during a hold event handlers, this._unsent will
be nulled which causes an exception because it is assumed to be an
array. Adding a truthy guard to ensure that the next event is only
shifted if it hasn't been cleared.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)