### PR TITLE
PLAT-15389: Allow for clearing of queue for pops without a corresponding history entry.

### DIFF
--- a/src/History.js
+++ b/src/History.js
@@ -227,7 +227,7 @@ var EnyoHistory = module.exports = kind.singleton(
 		_processing = true;
 		if (_queue.length) {
 			this.processQueue();
-		} else {
+		} else if (_history.length) {
 			this.processPopEntry(_history.pop());
 		}
 		_processing = false;
@@ -394,7 +394,7 @@ var EnyoHistory = module.exports = kind.singleton(
 	* @private
 	*/
 	handlePop: function (event) {
-		if (this.enabled && _history.length) {
+		if (this.enabled) {
 			this.processState(event.state);
 		}
 	},


### PR DESCRIPTION
### Issue
There are certain cases where a browser pop can be queued (such as popping the last entry on the stack, whose handler triggers a subsequent pop, and expects the browser to go back). Specifically, this occurs in the case of enyo-strawman, which relies on browser back to return from samples to the main list, but can occur in other apps that rely on browser history.

### Fix
We have relaxed the guard code in `handlePop` so that we clear the queue in this case, effectively moving this guard to `processState` as there will be no pop handler for this browser back entry.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>