### PR TITLE
ENYO-3030: Prevent reading disabled component

### DIFF
--- a/src/AccessibilitySupport/AccessibilitySupport.js
+++ b/src/AccessibilitySupport/AccessibilitySupport.js
@@ -11,8 +11,8 @@ var
 	utils = require('../utils');
 
 var defaultObservers = [
-	{from: 'accessibilityDisabled', method: function () {
-		this.setAriaAttribute('aria-hidden', this.accessibilityDisabled ? 'true' : null);
+	{from: ['accessibilityDisabled', 'disabled'], method: function () {
+		this.setAriaAttribute('aria-hidden', (this.disabled || this.accessibilityDisabled) ? 'true' : null);
 	}},
 	{from: 'accessibilityLive', method: function () {
 		var live = this.accessibilityLive === true && 'assertive' || this.accessibilityLive || null;
@@ -22,7 +22,7 @@ var defaultObservers = [
 		var role = this.accessibilityAlert && 'alert' || this.accessibilityRole || null;
 		this.setAriaAttribute('role', role);
 	}},
-	{path: ['content', 'accessibilityHint', 'accessibilityLabel', 'tabIndex', 'disabled'], method: function () {
+	{path: ['content', 'accessibilityHint', 'accessibilityLabel', 'tabIndex'], method: function () {
 		var focusable = this.accessibilityLabel || this.content || this.accessibilityHint || false,
 			prefix = this.accessibilityLabel || this.content || null,
 			label = this.accessibilityHint && prefix && (prefix + ' ' + this.accessibilityHint) ||
@@ -33,12 +33,12 @@ var defaultObservers = [
 		this.setAriaAttribute('aria-label', label);
 
 		// A truthy or zero tabindex will be set directly
-		if (!this.disabled && (this.tabIndex || this.tabIndex === 0)) {
+		if (this.tabIndex || this.tabIndex === 0) {
 			this.setAriaAttribute('tabindex', this.tabIndex);
 		}
 		// The webOS browser will only read nodes with a non-null tabindex so if the node has
 		// readable content, make it programmably focusable.
-		else if (!this.disabled && focusable && this.tabIndex === undefined && platform.webos) {
+		else if (focusable && this.tabIndex === undefined && platform.webos) {
 			this.setAriaAttribute('tabindex', -1);
 		}
 		// Otherwise, remove it

--- a/src/AccessibilitySupport/AccessibilitySupport.js
+++ b/src/AccessibilitySupport/AccessibilitySupport.js
@@ -22,7 +22,7 @@ var defaultObservers = [
 		var role = this.accessibilityAlert && 'alert' || this.accessibilityRole || null;
 		this.setAriaAttribute('role', role);
 	}},
-	{path: ['content', 'accessibilityHint', 'accessibilityLabel', 'tabIndex'], method: function () {
+	{path: ['content', 'accessibilityHint', 'accessibilityLabel', 'tabIndex', 'disabled'], method: function () {
 		var focusable = this.accessibilityLabel || this.content || this.accessibilityHint || false,
 			prefix = this.accessibilityLabel || this.content || null,
 			label = this.accessibilityHint && prefix && (prefix + ' ' + this.accessibilityHint) ||
@@ -33,12 +33,12 @@ var defaultObservers = [
 		this.setAriaAttribute('aria-label', label);
 
 		// A truthy or zero tabindex will be set directly
-		if (this.tabIndex || this.tabIndex === 0) {
+		if (!this.disabled && (this.tabIndex || this.tabIndex === 0)) {
 			this.setAriaAttribute('tabindex', this.tabIndex);
 		}
 		// The webOS browser will only read nodes with a non-null tabindex so if the node has
 		// readable content, make it programmably focusable.
-		else if (focusable && this.tabIndex === undefined && platform.webos) {
+		else if (!this.disabled && focusable && this.tabIndex === undefined && platform.webos) {
 			this.setAriaAttribute('tabindex', -1);
 		}
 		// Otherwise, remove it


### PR DESCRIPTION
## Issue
screen reader doesn't read disable Button's string, but it reads disabled IconButton.

## Cause
Button is created with button tag, but IconButton is div tag. If form element has disabled attribute,
screen reader doesn't read string.

## Fix
Prevent reading disabled component's string as removing tabindex.

https://jira2.lgsvl.com/browse/ENYO-3030
Enyo-DCO-1.1-Signed-off-by: Bongsub Kim <bongsub.kim@lgepartner.com>