### PR TITLE
ENYO-3049: Calculate bounds when shown

### DIFF
--- a/src/Scrollable/Scrollable.js
+++ b/src/Scrollable/Scrollable.js
@@ -245,6 +245,16 @@ module.exports = {
 
 	showingChangedHandler: kind.inherit(function (sup) {
 		return function (sender, event) {
+			// Calculate boundaries when shown, just in case
+			// anything has happened (like scroller contents changing)
+			// while we were hidden. We do this unconditionally since
+			// it's cheap to do it now and we avoid a lot of extra
+			// complexity by not trying to track whether we need it.
+			// May need to revisit this decision if related issues
+			// arise.
+			if (event.showing) {
+				this.calcBoundaries();
+			}
 			sup.apply(this, arguments);
 			if (!event.showing && this._suppressing) {
 				this._resumeMouseEvents();


### PR DESCRIPTION
`enyo/Scrollable` has a `calcBoundaries()` method that it uses
internally and exposes publicly to ensure that a scrollable Control
stays up to date with respect to its own size and the size of its
contents.

In this change, we add a call to `calcBoundaries()` when the
scrollable Control is shown to ensure the boundaries are correct,
taking into account any changes that may have occurred while the
Control was hidden.

This change was prompted by ENYO-3049, in which the scroll
boundaries and position were inaccurate after hiding NewDataList,
removing items from its backing collection, and then re-showing
the list.

We chose this simple fix over more complicated alternatives,
including deferring calls to `calcBoundaries()` when the
scrollable Control was hidden and then calling it only when
necessary in `showingChangedHandler()`. In truth, there are
probably a bunch of things in Scrollable that can / should be
deferred when the Control is hidden, but we'll save that larger
effort until we know it's needed.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)