### PR TITLE
Fixes ENYO-3071

### DIFF
--- a/src/ViewLayout/ViewLayout.js
+++ b/src/ViewLayout/ViewLayout.js
@@ -218,6 +218,13 @@ module.exports = kind(
 	*/
 	registerTransition: function (was, is) {
 		var t = this._transitioning;
+
+		// if there is an active transition, we need to complete it so things aren't left hanging
+		// short circuiting isTransitioning to optimize and since we have intimate knowledge here as
+		// part of the transition registration API.
+		if (!t.to.complete) this.setTransitionComplete('to');
+		if (!t.from.complete) this.setTransitionComplete('from');
+
 		t.from.view = was;
 		t.from.complete = !was;
 		t.to.view = is;


### PR DESCRIPTION
There are a couple scenarios in which a transition might not complete
before another is registered possibly causing layout completion
activities to be skipped. To avoid this, mark any incomplete
transitions complete so the callback can fire to clean up before
registering the new transition.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)