### PR TITLE
ENYO-2951: Expose transitioning property via a public method.

### DIFF
--- a/src/LightPanels/LightPanels.js
+++ b/src/LightPanels/LightPanels.js
@@ -195,6 +195,11 @@ module.exports = kind(
 	/**
 	* @private
 	*/
+	transitioning: false,
+
+	/**
+	* @private
+	*/
 	tools: [
 		{kind: Control, name: 'client', classes: 'panels-container', ontransitionend: 'transitionFinished', onwebkitTransitionEnd: 'transitionFinished'}
 	],
@@ -324,6 +329,16 @@ module.exports = kind(
 	getPanels: function () {
 		/*jshint -W093 */
 		return (this._panels = this._panels || (this.controlParent || this).children);
+	},
+
+	/**
+	* Whether or not we are currently in the midst of a panel transition.
+	*
+	* @return {Boolean} If `true`, we are currently transitioning; otherwise, `false`.
+	* @public
+	*/
+	isTransitioning: function () {
+		return this.transitioning;
 	},
 
 


### PR DESCRIPTION
### Issue
There are certain circumstances where a developer will need to check whether or not `LightPanels` is currently transitioning, but the property is private. We have safeguards against performing any adverse actions while transitioning, but we can provide something for developers to check.

### Fix
We have exposed a public method to determine the transitioning state.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>