### PR TITLE
Fixes ENYO-2990 (This is for testing, Do Not Merge)

### DIFF
--- a/src/Collection.js
+++ b/src/Collection.js
@@ -157,7 +157,7 @@ var BaseCollection = kind({
 * {@link module:enyo/Collection~Collection#options}. Note that some properties have different
 * meanings in different contexts. Please review the descriptions below to see
 * how each property is used in this context.
-* 
+*
 * @typedef {module:enyo/Collection~Options} module:enyo/Collection~AddOptions
 * @property {Boolean} merge - Update existing [models]{@link module:enyo/Model~Model} when found.
 * @property {Boolean} purge - Remove existing models not in the new dataset.
@@ -186,7 +186,7 @@ var BaseCollection = kind({
 * {@link module:enyo/Collection~Options}. Note that some properties have different
 * meanings in different contexts. Please review the descriptions below to see
 * how each property is used in this context.
-* 
+*
 * @typedef {module:enyo/Collection~Options} module:enyo/Collection~RemoveOptions
 * @property {Boolean} silent - Emit [events]{@glossary event} and notifications.
 * @property {Boolean} commit - [Commit]{@link module:enyo/Collection~Collection#commit} changes to the
@@ -250,7 +250,7 @@ var BaseCollection = kind({
 
 /**
 * An array-like structure designed to store instances of {@link module:enyo/Model~Model}.
-* 
+*
 * @class Collection
 * @extends module:enyo/Component~Component
 * @mixes module:enyo/StateSupport~StateSupport
@@ -259,19 +259,19 @@ var BaseCollection = kind({
 */
 exports = module.exports = kind(
 	/** @lends module:enyo/Collection~Collection.prototype */ {
-	
+
 	name: 'enyo.Collection',
-	
+
 	/**
 	* @private
 	*/
 	kind: BaseCollection,
-	
+
 	/**
 	* @private
 	*/
 
-	
+
 	/**
 	* Used by various [sources]{@link module:enyo/Collection~Collection#source} as part of the
 	* [URI]{@glossary URI} from which they may be [fetched]{@link module:enyo/Collection~Collection#fetch},
@@ -287,7 +287,7 @@ exports = module.exports = kind(
 	* @public
 	*/
 	url: '',
-	
+
 	/**
 	* Implement this method to be used by [sources]{@link module:enyo/Model~Model#source} to
 	* dynamically derive the [URI]{@glossary URI} from which they may be
@@ -307,19 +307,19 @@ exports = module.exports = kind(
 	* @public
 	*/
 	getUrl: null,
-	
+
 	/**
 	* The [kind]{@glossary kind) of {@link module:enyo/Model~Model} that this
 	* [collection]{@link module:enyo/Collection~Collection} will contain. This is important to set properly so
 	* that when [fetching]{@link module:enyo/Collection~Collection#fetch}, the returned data will be instanced
 	* as the correct model [subkind]{@glossary subkind}.
-	* 
+	*
 	* @type {(module:enyo/Model~Model|String)}
 	* @default module:enyo/Model~Model
 	* @public
 	*/
 	model: Model,
-	
+
 	/**
 	* A special type of [array]{@glossary Array} used internally by
 	* {@link module:enyo/Collection~Collection}. The array should not be modified directly, nor
@@ -335,7 +335,7 @@ exports = module.exports = kind(
 	* @protected
 	*/
 	models: null,
-	
+
 	/**
 	* The current [state]{@link module:enyo/States} of the [collection]{@link module:enyo/Collection~Collection}.
 	* This value changes automatically and may be observed for more complex state
@@ -348,14 +348,14 @@ exports = module.exports = kind(
 	* @see module:enyo/StateSupport
 	*/
 	status: States.READY,
-	
+
 	/**
 	* The configurable default [options]{@link module:enyo/Collection~Options}. These values will be
 	* used to modify the behavior of the [collection]{@link module:enyo/Collection~Collection} unless additional
 	* options are passed into the methods that use them. When modifying these values in a
 	* [subkind]{@glossary subkind} of {@link module:enyo/Collection~Collection}, they will be merged with
 	* existing values.
-	* 
+	*
 	* @type {module:enyo/Collection~Options}
 	* @public
 	*/
@@ -373,7 +373,7 @@ exports = module.exports = kind(
 		fetch: false,
 		modelEvents: true
 	},
-	
+
 	/**
 	* Modifies the structure of data so that it can be used by the
 	* [add()]{@link module:enyo/Collection~Collection#add} method. This method will only be used
@@ -383,7 +383,7 @@ exports = module.exports = kind(
 	* data coming from a [source]{@link module:enyo/Collection~Collection#source} that requires
 	* modification before it can be added to the [collection]{@link module:enyo/Collection~Collection}.
 	* This is a virtual method and must be implemented.
-	* 
+	*
 	* @param {*} data - The incoming data passed to the
 	*	[constructor]{@link module:enyo/Collection~Collection#constructor} or returned by a successful
 	*	[fetch]{@link module:enyo/Collection~Collection#fetch}.
@@ -395,7 +395,7 @@ exports = module.exports = kind(
 	parse: function (data) {
 		return data;
 	},
-	
+
 	/**
 	* Adds data to the [collection]{@link module:enyo/Collection~Collection}. This method can add an
 	* individual [model]{@link module:enyo/Model~Model} or an [array]{@glossary Array} of models.
@@ -406,7 +406,7 @@ exports = module.exports = kind(
 	* optimized for batch operations on arrays of models. For better performance,
 	* ensure that loops do not consecutively call this method but instead
 	* build an array to pass as the first parameter.
-	* 
+	*
 	* @fires module:enyo/Collection~Collection#add
 	* @param {(Object|Object[]|module:enyo/Model~Model|module:enyo/Model~Model[])} models The data to add to the
 	*	{@link module:enyo/Collection~Collection} that can be a [hash]{@glossary Object}, an array of
@@ -428,16 +428,16 @@ exports = module.exports = kind(
 			, idx = len
 			, removedBeforeIdx = 0
 			, added, keep, removed, model, attrs, found, id;
-			
+
 		// for backwards compatibility with earlier api standards we allow the
 		// second paramter to be the index and third param options when
 		// necessary
 		!isNaN(opts) && (idx = opts);
 		arguments.length > 2 && (opts = arguments[2]);
-		
+
 		// normalize options so we have values
 		opts = opts? utils.mixin({}, [options, opts]): options;
-		
+
 		// our flags
 		var merge = opts.merge
 			, purge = opts.purge
@@ -449,50 +449,50 @@ exports = module.exports = kind(
 			, create = opts.create !== false
 			, modelOpts = opts.modelOptions
 			, index = opts.index;
-			
+
 		idx = !isNaN(index) ? Math.max(0, Math.min(len, index)) : idx;
 
 		/*jshint -W018 */
 		sort && !(typeof sort == 'function') && (sort = this.comparator);
 		/*jshint +W018 */
-		
+
 		// for a special case purge to remove records that aren't in the current
 		// set being added
-		
+
 		if (parse) models = this.parse(models);
-			
+
 		// we treat all additions as an array of additions
 		!(models instanceof Array) && (models = [models]);
-		
+
 		for (var i=0, end=models.length; i<end; ++i) {
 			model = models[i];
 			attrs = null;
-			
+
 			if (!model && isNaN(model)) continue;
-			
+
 			// first determine if the model is an instance of model since
 			// everything else hinges on this
 			if (!(model instanceof Model)) {
 				// we need to determine how to handle this
 				attrs = model;
 			}
-			
+
 			if (typeof attrs == 'string' || typeof attrs == 'number') {
 				id = attrs;
 				attrs = {};
 				attrs[pkey] = id;
 			} else id = attrs? attrs[pkey]: model;
-				
-			
+
+
 			// see if we have an existing entry for this model/hash
 			if (find) found = loc.has(id);
-			
+
 			// if it already existed...
 			if (found) {
-				
+
 				// we need to ensure we've resolved the model (if necessary)
 				found = loc.resolve(id);
-				
+
 				if (merge) {
 					attrs || (attrs = model.attributes);
 					found.set(attrs, opts);
@@ -524,7 +524,7 @@ exports = module.exports = kind(
 				model = this.prepareModel(attrs || model, modelOpts);
 				added || (added = []);
 				added.push(model);
-				
+
 				// with the purge flag we endeavor on the expensive track of removing
 				// those models currently in the collection that aren't in the incoming
 				// dataset and aren't being created
@@ -535,7 +535,7 @@ exports = module.exports = kind(
 				}
 			}
 		}
-		
+
 		// here we process those models to be removed if purge was true
 		// the other guard is just in case we actually get to keep everything
 		// so we don't do this unnecessary pass
@@ -547,23 +547,23 @@ exports = module.exports = kind(
 					removed.push(model);
 					if (i < idx) removedBeforeIdx++;
 				}
-			} 
+			}
 			// if we removed any we process that now
 			removed.length && this.remove(removed, opts);
 			idx = idx - removedBeforeIdx;
 		}
-		
+
 		// added && loc.stopNotifications().add(added, idx).startNotifications();
 		if (added) {
 			loc.add(added, idx);
 			sort && this.sort(sort, {silent: true});
-			
+
 			// we batch this operation to make use of its ~efficient array operations
-			this.store.add(added); 
+			this.store.add(added);
 		}
 		this.length = loc.length;
-		
-		
+
+
 		if (!silent) {
 			// notify observers of the length change
 			len != this.length && this.notify('length', len, this.length);
@@ -572,14 +572,14 @@ exports = module.exports = kind(
 				this.emit('add', {models: added, collection: this, index: idx});
 			}
 		}
-		
+
 		// note that if commit is set but this was called from a successful fetch this will be
 		// a nop (as intended)
 		commit && added && this.commit(opts);
-		
+
 		return added || [];
 	},
-	
+
 	/**
 	* Removes data from the [collection]{@link module:enyo/Collection~Collection}. It can take a
 	* [model]{@link module:enyo/Model~Model} or an [array]{@glossary Array} of models.
@@ -587,7 +587,7 @@ exports = module.exports = kind(
 	* removed in the order in which they are encountered. Emits the
 	* [remove]{@link module:enyo/Collection~Collection#remove} event if any models were found and
 	* removed from the collection (and the `silent` option is not `true`).
-	* 
+	*
 	* @fires module:enyo/Collection~Collection#remove
 	* @param {(module:enyo/Model~Model|module:enyo/Model~Model[])} models The [models]{@link module:enyo/Model~Model} to remove
 	*	if they exist in the [collection]{@link module:enyo/Collection~Collection}.
@@ -601,59 +601,59 @@ exports = module.exports = kind(
 			, len = loc.length
 			, options = this.options
 			, removed, model;
-		
+
 		// normalize options so we have values
 		opts = opts? utils.mixin({}, [options, opts]): options;
-		
+
 		// our flags
 		var silent = opts.silent
 			, destroy = opts.destroy
 			, complete = opts.complete
 			, commit = opts.commit;
-		
+
 		// we treat all additions as an array of additions
 		!(models instanceof Array) && (models = [models]);
-		
+
 		removed = loc.remove(models);
-		
+
 		if (removed.length) {
-			
+
 			// ensure that we can batch remove from the store
 			opts.batching = true;
-			
+
 			for (var i=0, end=removed.length; i<end; ++i) {
 				model = removed[i];
-				
+
 				// it is possible but highly, highly unlikely that this would have been set
 				// to false by default and true at runtime...so we take our chances for the
 				// small performance gain in those situations where it was defaulted to false
 				if (options.modelEvents) model.off('*', this._modelEvent, this);
 				if (destroy) model.destroy(opts);
 			}
-			
+
 			// if complete or destroy was set we remove them from the store (batched op)
 			if (complete || destroy) this.store.remove(removed);
 		}
-		
+
 		this.length = loc.length;
-		
+
 		if (!silent) {
 			len != this.length && this.notify('length', len, this.length);
 			if (removed.length) {
 				this.emit('remove', {models: removed, collection: this});
 			}
 		}
-		
-		// if this is called from an overloaded method (such as fetch or commit) or some 
+
+		// if this is called from an overloaded method (such as fetch or commit) or some
 		// success callback this will be a nop (as intended)
 		commit && removed.length && this.commit();
-		
+
 		return removed;
 	},
-	
+
 	/**
 	* Retrieves a [model]{@link module:enyo/Model~Model} for the provided index.
-	* 
+	*
 	* @param {Number} idx - The index to return from the [collection]{@link module:enyo/Collection~Collection}.
 	* @returns {(module:enyo/Model~Model|undefined)} The [model]{@link module:enyo/Model~Model} at the given index or
 	*	`undefined` if it cannot be found.
@@ -662,7 +662,7 @@ exports = module.exports = kind(
 	at: function (idx) {
 		return this.models[idx];
 	},
-	
+
 	/**
 	* Returns the JSON serializable [array]{@glossary Array} of [models]{@link module:enyo/Model~Model}
 	* according to their own [raw()]{@link module:enyo/Model~Model#raw} output.
@@ -676,7 +676,7 @@ exports = module.exports = kind(
 			return model.raw();
 		});
 	},
-	
+
 	/**
 	* Determines if the specified [model]{@link module:enyo/Model~Model} is contained by this
 	* [collection]{@link module:enyo/Collection~Collection}.
@@ -689,67 +689,67 @@ exports = module.exports = kind(
 	has: function (model) {
 		return this.models.has(model);
 	},
-	
+
 	/**
 	* @see {@glossary Array.forEach}
 	* @public
 	*/
 	forEach: function (fn, ctx) {
-		
+
 		// ensure that this is an immutable reference to the models such that changes will
 		// not affect the entire loop - e.g. calling destroy on models won't keep this from
 		// completing
 		return this.models.slice().forEach(fn, ctx || this);
 	},
-	
+
 	/**
 	* @see {@glossary Array.filter}
 	* @public
 	*/
 	filter: function (fn, ctx) {
-		
+
 		// ensure that this is an immutable reference to the models such that changes will
 		// not affect the entire loop - e.g. calling destroy on models won't keep this from
 		// completing
 		return this.models.slice().filter(fn, ctx || this);
 	},
-	
+
 	/**
 	* @see {@glossary Array.find}
 	* @public
 	*/
 	find: function (fn, ctx) {
-		
+
 		// ensure that this is an immutable reference to the models such that changes will
 		// not affect the entire loop - e.g. calling destroy on models won't keep this from
 		// completing
 		return this.models.slice().find(fn, ctx || this);
 	},
-	
+
 	/**
 	* @see {@glossary Array.findIndex}
 	* @public
 	*/
 	findIndex: function (fn, ctx) {
-		
+
 		// ensure that this is an immutable reference to the models such that changes will
 		// not affect the entire loop - e.g. calling destroy on models won't keep this from
 		// completing
 		return this.models.slice().findIndex(fn, ctx || this);
 	},
-	
+
 	/**
 	* @see {@glossary Array.map}
 	* @public
 	*/
 	map: function (fn, ctx) {
-		
+
 		// ensure that this is an immutable reference to the models such that changes will
 		// not affect the entire loop - e.g. calling destroy on models won't keep this from
 		// completing
 		return this.models.slice().map(fn, ctx || this);
 	},
-	
+
 	/**
 	* @see {@glossary Array.indexOf}
 	* @public
@@ -757,14 +757,14 @@ exports = module.exports = kind(
 	indexOf: function (model, offset) {
 		return this.models.indexOf(model, offset);
 	},
-	
+
 	/**
 	* Removes all [models]{@link module:enyo/Model~Model} from the [collection]{@link module:enyo/Collection~Collection}.
 	* Optionally, a model (or models) may be provided to replace the removed models.
 	* If this operation is not `silent`, it will emit a `reset` event. Returns the
 	* removed models, but be aware that, if the `destroy` configuration option is set,
 	* the returned models will have limited usefulness.
-	* 
+	*
 	* @param {(module:enyo/Model~Model|module:enyo/Model~Model[])} [models] The [model or models]{@link module:enyo/Model~Model}
 	*	to use as a replacement for the current set of models in the
 	*	{@link module:enyo/Collection~Collection}.
@@ -777,35 +777,35 @@ exports = module.exports = kind(
 		var silent,
 			removed,
 			len = this.length;
-		
+
 		if (models && !(models instanceof Array || models instanceof Model)) {
 			// there were no models but instead some options only
 			opts = models;
 			models = null;
 		}
-		
+
 		opts = opts || {};
-		
+
 		// just in case the entire thing was supposed to be silent
 		silent = opts.silent;
 		opts.silent = true;
-		
+
 		removed = this.remove(this.models, opts);
-		
+
 		// if there are models we are going to propagate the remove quietly and instead issue
 		// a single reset with the new content
 		if (models) this.add(models, opts);
-		
+
 		// now if the entire thing wasn't supposed to have been done silently we issue
 		// a reset
 		if (!silent) {
 			if (len != this.length) this.notify('length', len, this.length);
 			this.emit('reset', {models: this.models.copy(), collection: this});
 		}
-		
+
 		return removed;
 	},
-	
+
 	/**
 	* Returns the [JSON]{@glossary JSON} serializable [raw()]{@link module:enyo/Collection~Collection#raw}
 	* output of the [collection]{@link module:enyo/Collection~Collection}. Will automatically be executed by
@@ -818,7 +818,7 @@ exports = module.exports = kind(
 	toJSON: function () {
 		return this.raw();
 	},
-	
+
 	/**
 	* The default behavior of this method is the same as {@glossary Array.sort}. If the
 	* [function]{@glossary Function} parameter is omitted, it will attempt to use the
@@ -839,7 +839,7 @@ exports = module.exports = kind(
 	sort: function (fn, opts) {
 		if (fn || this.comparator) {
 			var options = {silent: false}, silent;
-		
+
 			opts = opts? utils.mixin({}, [options, opts]): options;
 			silent = opts.silent;
 			this.models.sort(fn || this.comparator);
@@ -851,7 +851,7 @@ exports = module.exports = kind(
 		}
 		return this;
 	},
-	
+
 	/**
 	* Commits the [collection]{@link module:enyo/Collection~Collection} to a
 	* [source]{@link module:enyo/Collection~Collection#source} or sources. An {@link module:enyo/Collection~Collection}
@@ -872,38 +872,38 @@ exports = module.exports = kind(
 		var options,
 			source,
 			it = this;
-		
+
 		// if the current status is not one of the error states we can continue
 		if (!(this.status & (States.ERROR | States.BUSY))) {
-			
+
 			// if there were options passed in we copy them quickly so that we can hijack
 			// the success and error methods while preserving the originals to use later
 			options = opts ? utils.clone(opts, true) : {};
-			
+
 			// make sure we keep track of how many sources we're requesting
 			source = options.source || this.source;
 			if (source && ((source instanceof Array) || source === true)) {
 				this._waiting = source.length ? source.slice() : Object.keys(Source.sources);
 			}
-				
+
 			options.success = function (source, res) {
 				it.committed(opts, res, source);
 			};
-			
+
 			options.error = function (source, res) {
 				it.errored('COMMITTING', opts, res, source);
 			};
-			
+
 			// set the state
 			this.set('status', (this.status | States.COMMITTING) & ~States.READY);
-			
+
 			// now pass this on to the source to execute as it sees fit
 			Source.execute('commit', this, options);
 		} else if (this.status & States.ERROR) this.errored(this.status, opts);
-		
+
 		return this;
 	},
-	
+
 	/**
 	* Fetches the [collection]{@link module:enyo/Collection~Collection} from a
 	* [source]{@link module:enyo/Collection~Collection#source} or sources. An {@link module:enyo/Collection~Collection}
@@ -924,38 +924,38 @@ exports = module.exports = kind(
 		var options,
 			source,
 			it = this;
-			
+
 		// if the current status is not one of the error states we can continue
 		if (!(this.status & (States.ERROR | States.BUSY))) {
-			
+
 			// if there were options passed in we copy them quickly so that we can hijack
 			// the success and error methods while preserving the originals to use later
 			options = opts ? utils.clone(opts, true) : {};
-			
+
 			// make sure we keep track of how many sources we're requesting
 			source = options.source || this.source;
 			if (source && ((source instanceof Array) || source === true)) {
 				this._waiting = source.length ? source.slice() : Object.keys(Source.sources);
 			}
-			
+
 			options.success = function (source, res) {
 				it.fetched(opts, res, source);
 			};
-			
+
 			options.error = function (source, res) {
 				it.errored('FETCHING', opts, res, source);
 			};
-			
+
 			// set the state
 			this.set('status', (this.status | States.FETCHING) & ~States.READY);
-			
+
 			// now pass this on to the source to execute as it sees fit
 			Source.execute('fetch', this, options);
 		} else if (this.status & States.ERROR) this.errored(this.status, opts);
-		
+
 		return this;
 	},
-	
+
 	/**
 	* Destroys the [collection]{@link module:enyo/Collection~Collection}. By default, the
 	* collection will only be [destroyed]{@glossary destroy} in the client. To
@@ -981,21 +981,21 @@ exports = module.exports = kind(
 			var options = opts ? utils.mixin({}, [this.options, opts]) : this.options,
 				it = this,
 				idx;
-						
+
 			// this becomes an (potentially) async operation if we are committing this destroy
 			// to a source and its kind of tricky to figure out because there are several ways
 			// it could be flagged to do this
-						
+
 			if (options.commit || options.source) {
-				
+
 				// if the current status is not one of the error states we can continue
 				if (!(this.status & (States.ERROR | States.BUSY))) {
-				
+
 					// remap to the originals
 					options = opts ? utils.clone(opts, true) : {};
-				
+
 					options.success = function (source, res) {
-				
+
 						if (it._waiting) {
 							idx = it._waiting.findIndex(function (ln) {
 								return (ln instanceof Source ? ln.name : ln) == source;
@@ -1003,7 +1003,7 @@ exports = module.exports = kind(
 							if (idx > -1) it._waiting.splice(idx, 1);
 							if (!it._waiting.length) it._waiting = null;
 						}
-				
+
 						// continue the operation this time with commit false explicitly
 						if (!it._waiting) {
 							options.commit = options.source = null;
@@ -1011,9 +1011,9 @@ exports = module.exports = kind(
 						}
 						if (opts && opts.success) opts.success(this, opts, res, source);
 					};
-			
+
 					options.error = function (source, res) {
-				
+
 						if (it._waiting) {
 							idx = it._waiting.findIndex(function (ln) {
 								return (ln instanceof Source ? ln.name : ln) == source;
@@ -1021,38 +1021,39 @@ exports = module.exports = kind(
 							if (idx > -1) it._waiting.splice(idx, 1);
 							if (!it._waiting.length) it._waiting = null;
 						}
-				
+
 						// continue the operation this time with commit false explicitly
 						if (!it._waiting) {
 							options.commit = options.source = null;
 							it.destroy(options);
 						}
-				
-						// we don't bother setting the error state if we aren't waiting because 
+
+						// we don't bother setting the error state if we aren't waiting because
 						// it will be cleared to DESTROYED and it would be pointless
 						else this.errored('DESTROYING', opts, res, source);
 					};
-				
+
 					this.set('status', (this.status | States.DESTROYING) & ~States.READY);
-			
+
 					Source.execute('destroy', this, options);
 				} else if (this.status & States.ERROR) this.errored(this.status, opts);
-				
+
 				// we don't allow the destroy to take place and we don't forcibly break-down
 				// the collection errantly so there is an opportuniy to resolve the issue
 				// before we lose access to the collection's content!
 				return this;
 			}
-			
-			if (this.length && options.destroy) this.empty(options);
-			
+
+			// remove the models from the collection which will also remove the its event listeners
+			if (this.length) this.empty(options);
+
 			// set the final resting state of this collection
 			this.set('status', States.DESTROYED);
-			
+
 			sup.apply(this, arguments);
 		};
 	}),
-	
+
 	/**
 	* This is a virtual method that, when provided, will be used for sorting during
 	* [add()]{@link module:enyo/Collection~Collection#add} when the `sort` flag is `true` or when the
@@ -1067,7 +1068,7 @@ exports = module.exports = kind(
 	* @public
 	*/
 	comparator: null,
-	
+
 	/**
 	* Used during [add()]{@link module:enyo/Collection~Collection#add} when `create` is `true` and
 	* the data is a [hash]{@glossary Object}.
@@ -1078,19 +1079,19 @@ exports = module.exports = kind(
 		var Ctor = this.model
 			, options = this.options
 			, model;
-		
+
 		attrs instanceof Ctor && (model = attrs);
 		if (!model) {
 			opts = opts || {};
 			opts.noAdd = true;
 			model = new Ctor(attrs, null, opts);
 		}
-		
+
 		if (options.modelEvents) model.on('*', this._modelEvent, this);
-		
+
 		return model;
 	},
-	
+
 	/**
 	* When a [commit]{@link module:enyo/Collection~Collection#commit} has completed successfully, it is returned
 	* to this method. This method handles special and important behavior; it should not be
@@ -1111,7 +1112,7 @@ exports = module.exports = kind(
 	*/
 	committed: function (opts, res, source) {
 		var idx;
-		
+
 		if (this._waiting) {
 			idx = this._waiting.findIndex(function (ln) {
 				return (ln instanceof Source ? ln.name : ln) == source;
@@ -1119,15 +1120,15 @@ exports = module.exports = kind(
 			if (idx > -1) this._waiting.splice(idx, 1);
 			if (!this._waiting.length) this._waiting = null;
 		}
-		
+
 		if (opts && opts.success) opts.success(this, opts, res, source);
-		
+
 		// clear the state
 		if (!this._waiting) {
 			this.set('status', (this.status | States.READY) & ~States.COMMITTING);
 		}
 	},
-	
+
 	/**
 	* When a [fetch]{@link module:enyo/Collection~Collection#fetch} has completed successfully, it is returned
 	* to this method. This method handles special and important behavior; it should not be
@@ -1148,7 +1149,7 @@ exports = module.exports = kind(
 	*/
 	fetched: function (opts, res, source) {
 		var idx;
-		
+
 		if (this._waiting) {
 			idx = this._waiting.findIndex(function (ln) {
 				return (ln instanceof Source ? ln.name : ln) == source;
@@ -1156,22 +1157,22 @@ exports = module.exports = kind(
 			if (idx > -1) this._waiting.splice(idx, 1);
 			if (!this._waiting.length) this._waiting = null;
 		}
-		
+
 		// if there is a result we add it to the collection passing it any per-fetch options
 		// that will override the defaults (e.g. parse) we don't do that here as it will
 		// be done in the add method -- also note we reassign the result to whatever was
 		// actually added and pass that to any other success callback if there is one
 		if (res) res = this.add(res, opts);
-		
+
 		// now look for an additional success callback
 		if (opts && opts.success) opts.success(this, opts, res, source);
-		
+
 		// clear the state
 		if (!this._waiting) {
 			this.set('status', (this.status | States.READY) & ~States.FETCHING);
 		}
 	},
-	
+
 	/**
 	* If an error is encountered while [fetching]{@link module:enyo/Collection~Collection#fetch},
 	* [committing]{@link module:enyo/Collection~Collection#commit}, or [destroying]{@link module:enyo/Collection~Collection#destroy}
@@ -1180,7 +1181,7 @@ exports = module.exports = kind(
 	* property and then checks to see if there is a provided
 	* [error handler]{@link module:enyo/Collection~Collection~Error}. If the error handler
 	* exists, it will be called.
-	* 
+	*
 	* @param {String} action - The name of the action that failed,
 	* one of `'FETCHING'` or `'COMMITTING'`.
 	* @param {module:enyo/Collection~Collection~ActionOptions} opts - The options hash originally
@@ -1192,25 +1193,25 @@ exports = module.exports = kind(
 	*/
 	errored: function (action, opts, res, source) {
 		var stat;
-		
+
 		// if the error action is a status number then we don't need to update it otherwise
 		// we set it to the known state value
 		if (typeof action == 'string') {
-			
+
 			// all built-in errors will pass this as their values are > 0 but we go ahead and
 			// ensure that no developer used the 0x00 for an error code
 			stat = States['ERROR_' + action];
 		} else stat = action;
-		
+
 		if (isNaN(stat) || !(stat & States.ERROR)) stat = States.ERROR_UNKNOWN;
-		
+
 		// if it has changed give observers the opportunity to respond
 		this.set('status', (this.status | stat) & ~States.READY);
-		
+
 		// we need to check to see if there is an options handler for this error
 		if (opts && opts.error) opts.error(this, action, opts, res, source);
 	},
-	
+
 	/**
 	* Overloaded version of the method to call [set()]{@link module:enyo/Collection~Collection#set}
 	* instead of simply assigning the value. This allows it to
@@ -1223,7 +1224,7 @@ exports = module.exports = kind(
 	clearError: function () {
 		return this.set('status', States.READY);
 	},
-	
+
 	/**
 	* @private
 	*/
@@ -1237,7 +1238,7 @@ exports = module.exports = kind(
 			break;
 		}
 	},
-	
+
 	/**
 	* Responds to changes to the [models]{@link module:enyo/Collection~Collection#models} property.
 	*
@@ -1249,12 +1250,12 @@ exports = module.exports = kind(
 	modelsChanged: function (was, is, prop) {
 		var models = this.models.copy(),
 			len = models.length;
-		
+
 		if (len != this.length) this.set('length', len);
-		
+
 		this.emit('reset', {models: models, collection: this});
 	},
-	
+
 	/**
 	* Initializes the [collection]{@link module:enyo/Collection~Collection}.
 	*
@@ -1271,48 +1272,51 @@ exports = module.exports = kind(
 	constructor: kind.inherit(function (sup) {
 		return function (recs, props, opts) {
 			// opts = opts? (this.options = enyo.mixin({}, [this.options, opts])): this.options;
-			
+
 			// if properties were passed in but not a records array
 			props = recs && !(recs instanceof Array)? recs: props;
 			if (props === recs) recs = null;
 			// initialize our core records
 			// this.models = this.models || new ModelList();
 			!this.models && (this.set('models', new ModelList()));
-			
+
 			// this is backwards compatibility
 			if (props && props.records) {
 				recs = recs? recs.concat(props.records): props.records.slice();
 				delete props.records;
 			}
-			
+
 			if (props && props.models) {
 				recs = recs? recs.concat(props.models): props.models.slice();
 				delete props.models;
 			}
-			
+
 			if (props && props.options) {
 				this.options = utils.mixin({}, [this.options, props.options]);
 				delete props.options;
+			} else {
+				// ensure we have our own copy of options
+				this.options = utils.clone(this.options);
 			}
-			
+
 			opts = opts? utils.mixin({}, [this.options, opts]): this.options;
-			
+
 			// @TODO: For now, while there is only one property we manually check for it
 			// if more options arrise that should be configurable this way it may need to
 			// be modified
 			opts.fetch && (this.options.fetch = opts.fetch);
-			
+
 			this.length = this.models.length;
 			this.euid = utils.uid('c');
-			
+
 			sup.call(this, props);
-			
+
 			typeof this.model == 'string' && (this.model = kind.constructorForKind(this.model));
 			this.store = this.store || Store;
 			recs && recs.length && this.add(recs, opts);
 		};
 	}),
-	
+
 	/**
 	* @method
 	* @private
@@ -1320,12 +1324,12 @@ exports = module.exports = kind(
 	constructed: kind.inherit(function (sup) {
 		return function () {
 			sup.apply(this, arguments);
-			
+
 			// automatically attempt a fetch after initialization is complete
 			if (this.options.fetch) this.fetch();
 		};
 	})
-	
+
 });
 
 /**
@@ -1335,7 +1339,7 @@ exports = module.exports = kind(
 */
 exports.concat = function (ctor, props) {
 	var proto = ctor.prototype || ctor;
-	
+
 	if (props.options) {
 		proto.options = utils.mixin({}, [proto.options, props.options]);
 		delete props.options;

--- a/src/EventEmitter.js
+++ b/src/EventEmitter.js
@@ -6,6 +6,7 @@
 require('enyo');
 
 var
+	kind = require('./kind'),
 	utils = require('./utils');
 
 var
@@ -200,7 +201,7 @@ var EventEmitter = {
 					return ln.event != e;
 				});
 			} else {
-				eventTable[euid] = null;
+				delete eventTable[euid];
 			}
 		}
 
@@ -245,7 +246,17 @@ var EventEmitter = {
 	*/
 	emit: function () {
 		return !this._silenced? emit(this, arguments): false;
-	}
+	},
+
+	/**
+	* @private
+	*/
+	destroy: kind.inherit(function (sup) {
+		return function () {
+			sup.apply(this, arguments);
+			this.removeAllListeners();
+		};
+	})
 };
 
 module.exports = EventEmitter;

--- a/src/ObserverSupport.js
+++ b/src/ObserverSupport.js
@@ -12,7 +12,7 @@ var
 	ObserverChain = require('./ObserverChain');
 
 var observerTable = {};
-	
+
 kind.concatenated.push("observers");
 
 /**
@@ -33,30 +33,30 @@ kind.concatenated.push("observers");
 */
 
 function addObserver (path, fn, ctx, opts) {
-	
+
 	var observers = this.getObservers(),
 		chains = this.getChains(),
 		parts = path.split('.'),
 		prio = opts && opts.priority,
 		entries,
 		noChain;
-		
+
 	noChain = (opts && opts.noChain) ||
 			chains[path] ||
 			parts.length < 2 ||
 			(parts.length === 2 && path[0] == '$');
-	
+
 	if (observers[path] && !observers.hasOwnProperty(path)) {
 		observers[path] = observers[path].slice();
 	}
-	
+
 	entries = observers[path] || (observers[path] = []);
 	entries[prio ? 'unshift' : 'push']({method: fn, ctx: ctx || this});
-	
+
 	if (!noChain) {
 		this.getChains()[path] = new ObserverChain(path, this);
 	}
-	
+
 	return this;
 }
 
@@ -64,25 +64,25 @@ function removeObserver (obj, path, fn, ctx) {
 	var observers = obj.getObservers(path)
 		, chains = obj.getChains()
 		, idx, chain;
-		
+
 	if (observers && observers.length) {
 		idx = observers.findIndex(function (ln) {
 			return ln.method === fn && (ctx? ln.ctx === ctx: true);
 		});
 		idx > -1 && observers.splice(idx, 1);
 	}
-	
+
 	if ((chain = chains[path]) && !observers.length) {
 		chain.destroy();
 	}
-	
+
 	return obj;
 }
 
 function notifyObservers (obj, path, was, is, opts) {
 	if (obj.isObserving()) {
 		var observers = obj.getObservers(path);
-		
+
 		if (observers && observers.length) {
 			for (var i=0, ln; (ln=observers[i]); ++i) {
 				if (typeof ln.method == "string") obj[ln.method](was, is, path, opts);
@@ -90,7 +90,7 @@ function notifyObservers (obj, path, was, is, opts) {
 			}
 		}
 	} else enqueue(obj, path, was, is, opts);
-	
+
 	return obj;
 }
 
@@ -98,7 +98,7 @@ function enqueue (obj, path, was, is, opts) {
 	if (obj._notificationQueueEnabled) {
 		var queue = obj._notificationQueue || (obj._notificationQueue = {})
 			, ln = queue[path] || (queue[path] = {});
-	
+
 		ln.was = was;
 		ln.is = is;
 		ln.opts = opts;
@@ -108,17 +108,17 @@ function enqueue (obj, path, was, is, opts) {
 function flushQueue (obj) {
 	var queue = obj._notificationQueue
 		, path, ln;
-	
+
 	if (queue) {
 		obj._notificationQueue = null;
-		
+
 		for (path in queue) {
 			ln = queue[path];
 			obj.notify(path, ln.was, ln.is, ln.opts);
 		}
 	}
 }
-	
+
 /**
 * Adds support for notifications on property changes. Most
 * [kinds]{@glossary kind} (including all kinds that inherit from
@@ -218,32 +218,32 @@ function flushQueue (obj) {
 * @public
 */
 var ObserverSupport = {
-	
+
 	/**
 	* @private
 	*/
 	name: "ObserverSupport",
-	
+
 	/**
 	* @private
 	*/
 	_observing: true,
-	
+
 	/**
 	* @private
 	*/
 	_observeCount: 0,
-	
+
 	/**
 	* @private
 	*/
 	_notificationQueue: null,
-	
+
 	/**
 	* @private
 	*/
 	_notificationQueueEnabled: true,
-	
+
 	/**
 	* Determines whether `_observing` is enabled. If
 	* [stopNotifications()]{@link module:enyo/ObserverSupport~ObserverSupport#stopNotifications} has
@@ -256,7 +256,7 @@ var ObserverSupport = {
 	isObserving: function () {
 		return this._observing;
 	},
-	
+
 	/**
 	* Returns an immutable list of [observers]{@link module:enyo/ObserverSupport~ObserverSupport~Observer}
 	* for the given `path`, or all observers for the callee.
@@ -273,27 +273,27 @@ var ObserverSupport = {
 		var euid = this.euid || (this.euid = utils.uid('o')),
 			ret,
 			loc;
-			
+
 		loc = observerTable[euid] || (observerTable[euid] = (
 			this._observers? Object.create(this._observers): {}
 		));
-		
+
 		if (!path) return loc;
-		
+
 		ret = loc[path];
-		
+
 		// if the special property exists...
 		if (loc['*']) ret = ret ? ret.concat(loc['*']) : loc['*'].slice();
 		return ret;
 	},
-	
+
 	/**
 	* @private
 	*/
 	getChains: function () {
 		return this._observerChains || (this._observerChains = {});
 	},
-	
+
 	/**
 	* @deprecated
 	* @alias {@link module:enyo/ObserverSupport~ObserverSupport#observe}
@@ -303,7 +303,7 @@ var ObserverSupport = {
 		// @NOTE: In this case we use apply because of internal variable use of parameters
 		return addObserver.apply(this, arguments);
 	},
-	
+
 	/**
 	* Registers an [observer]{@link module:enyo/ObserverSupport~ObserverSupport~Observer} to be
 	* [notified]{@link module:enyo/ObserverSupport~ObserverSupport#notify} when the given property has
@@ -328,7 +328,7 @@ var ObserverSupport = {
 		// @NOTE: In this case we use apply because of internal variable use of parameters
 		return addObserver.apply(this, arguments);
 	},
-	
+
 	/**
 	* @deprecated
 	* @alias {@link module:enyo/ObserverSupport~ObserverSupport#unobserve}
@@ -337,7 +337,7 @@ var ObserverSupport = {
 	removeObserver: function (path, fn, ctx) {
 		return removeObserver(this, path, fn);
 	},
-	
+
 	/**
 	* Unregisters an [observer]{@link module:enyo/ObserverSupport~ObserverSupport~Observer}. If a `ctx`
 	* (context) was supplied to [observe()]{@link module:enyo/ObserverSupport~ObserverSupport#observe},
@@ -355,7 +355,7 @@ var ObserverSupport = {
 	unobserve: function (path, fn, ctx) {
 		return removeObserver(this, path, fn, ctx);
 	},
-	
+
 	/**
 	* Removes all [observers]{@link module:enyo/ObserverSupport~ObserverSupport~Observer} from the
 	* callee. If a `path` parameter is provided, observers will only be removed
@@ -368,18 +368,18 @@ var ObserverSupport = {
 	removeAllObservers: function (path) {
 		var euid = this.euid
 			, loc = euid && observerTable[euid];
-		
+
 		if (loc) {
 			if (path) {
 				loc[path] = null;
 			} else {
-				observerTable[euid] = null;
+				delete observerTable[euid];
 			}
 		}
-		
+
 		return this;
 	},
-	
+
 	/**
 	* @deprecated
 	* @alias module:enyo/ObserverSupport~ObserverSupport#notify
@@ -388,7 +388,7 @@ var ObserverSupport = {
 	notifyObservers: function (path, was, is, opts) {
 		return notifyObservers(this, path, was, is, opts);
 	},
-	
+
 	/**
 	* Triggers any [observers]{@link module:enyo/ObserverSupport~ObserverSupport~Observer} for the
 	* given `path`. The previous and current values must be supplied. This
@@ -404,7 +404,7 @@ var ObserverSupport = {
 	notify: function (path, was, is, opts) {
 		return notifyObservers(this, path, was, is, opts);
 	},
-	
+
 	/**
 	* Stops all [notifications]{@link module:enyo/ObserverSupport~ObserverSupport#notify} from
 	* propagating. By default, all notifications will be queued and flushed once
@@ -428,7 +428,7 @@ var ObserverSupport = {
 		noQueue && this.disableNotificationQueue();
 		return this;
 	},
-	
+
 	/**
 	* Starts [notifications]{@link module:enyo/ObserverSupport~ObserverSupport#notify} if they have
 	* been [disabled]{@link module:enyo/ObserverSupport~ObserverSupport#stopNotifications}. If the
@@ -452,7 +452,7 @@ var ObserverSupport = {
 		this.isObserving() && flushQueue(this);
 		return this;
 	},
-	
+
 	/**
 	* Re-enables the notification queue, if it was disabled.
 	*
@@ -463,7 +463,7 @@ var ObserverSupport = {
 		this._notificationQueueEnabled = true;
 		return this;
 	},
-	
+
 	/**
 	* If the notification queue is enabled (the default), it will be disabled
 	* and any notifications in the queue will be removed.
@@ -476,14 +476,14 @@ var ObserverSupport = {
 		this._notificationQueue = null;
 		return this;
 	},
-	
+
 	/**
 	* @private
 	*/
 	constructor: kind.inherit(function (sup) {
 		return function () {
 			var chains, chain, path, entries, i;
-			
+
 			// if there are any observers that need to create dynamic chains
 			// we look for and instance those now
 			if (this._observerChains) {
@@ -494,11 +494,11 @@ var ObserverSupport = {
 					for (i = 0; (chain = entries[i]); ++i) this.observe(path, chain.method);
 				}
 			}
-			
+
 			sup.apply(this, arguments);
 		};
 	}),
-	
+
 	/**
 	* @private
 	*/
@@ -507,20 +507,21 @@ var ObserverSupport = {
 			var chains = this._observerChains,
 				path,
 				chain;
-			
+
 			sup.apply(this, arguments);
 			
+			this.removeAllObservers();
 			if (chains) {
 				for (path in chains) {
 					chain = chains[path];
 					chain.destroy();
 				}
-				
+
 				this._observerChains = null;
 			}
 		};
 	})
-	
+
 };
 
 module.exports = ObserverSupport;
@@ -537,21 +538,21 @@ var sup = kind.concatHandler;
 
 /** @private */
 kind.concatHandler = function (ctor, props, instance) {
-	
+
 	sup.call(this, ctor, props, instance);
-	
+
 	if (props === ObserverSupport) return;
 
 	var proto = ctor.prototype || ctor
 		, observers = proto._observers? Object.create(proto._observers): null
 		, incoming = props.observers
 		, chains = proto._observerChains && Object.create(proto._observerChains);
-		
+
 	if (!observers) {
 		if (proto.kindName) observers = {};
 		else return;
 	}
-		
+
 	if (incoming && !(incoming instanceof Array)) {
 		(function () {
 			var tmp = [], deps, name;
@@ -567,7 +568,7 @@ kind.concatHandler = function (ctor, props, instance) {
 		// we need to ensure we don't modify the fixed array of a mixin or reused object
 		// because it could wind up inadvertantly adding the same entry multiple times
 	} else if (incoming) incoming = incoming.slice();
-	
+
 	// this scan is required to figure out what auto-observers might be present
 	for (var key in props) {
 		if (key.slice(-7) == "Changed") {
@@ -575,7 +576,7 @@ kind.concatHandler = function (ctor, props, instance) {
 			incoming.push({method: key, path: key.slice(0, -7)});
 		}
 	}
-	
+
 	var addObserverEntry = function (path, method) {
 		var obs;
 		// we have to make sure that the path isn't a chain because if it is we add it
@@ -590,7 +591,7 @@ kind.concatHandler = function (ctor, props, instance) {
 			if (!obs.find(function (ln) { return ln.method == method; })) obs.push({method: method});
 		}
 	};
-	
+
 	if (incoming) {
 		incoming.forEach(function (ln) {
 			// first we determine if the path itself is an array of paths to observe
@@ -598,7 +599,7 @@ kind.concatHandler = function (ctor, props, instance) {
 			else addObserverEntry(ln.path, ln.method);
 		});
 	}
-	
+
 	// we clear the key so it will not be added to the prototype
 	// delete props.observers;
 	// we update the properties to whatever their new values may be


### PR DESCRIPTION
Issue

Observers and event listeners were not cleaned up on destroy causing object references to enyo kind instances to be leaked.

Fix

- remove all observers and listeners on destroy
- delete entries from the module-scoped tables to prevent euid strings from leaking
- update Collection.destroy() to drop its models as well so those listeners can be cleaned up

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)