### PR TITLE
ENYO-3011: Ensure that transition clean-up logic is always executed.

### DIFF
--- a/src/LightPanels/LightPanels.js
+++ b/src/LightPanels/LightPanels.js
@@ -677,13 +677,17 @@ module.exports = kind(
 	*
 	* @param {Object} sender - The event sender.
 	* @param {Object} ev - The event object.
-	* @param {Boolean} [direct] - If `true`, this was a non-animated (direct) transition.
 	* @private
 	*/
-	transitionFinished: function (sender, ev, direct) {
+	transitionFinished: function (sender, ev) {
 		var prevPanel, currPanel;
 
-		if (this.transitioning && ((ev && ev.originator === this.$.client) || direct)) {
+		if (this.transitioning && (!ev || ev.originator === this.$.client)) {
+			if (this._fallbackTimeout) {
+				global.clearTimeout(this._fallbackTimeout);
+				this._fallbackTimeout = null;
+			}
+
 			prevPanel = this._previousPanel;
 			currPanel = this._currentPanel;
 
@@ -805,7 +809,8 @@ module.exports = kind(
 		this._currentPanel = nextPanel;
 
 		// ensure that `transitionFinished` is called in the case where we are not animating
-		if (!this.shouldAnimate() || !animate) this.transitionFinished(null, null, true);
+		if (!this.shouldAnimate() || !animate) this.transitionFinished();
+		else this.setupFallback();
 	},
 
 	/**
@@ -862,6 +867,13 @@ module.exports = kind(
 		for (var idx = 0; idx < viewProps.length; idx++) {
 			this.removeTask(this.getViewId(viewProps[idx]));
 		}
+	},
+
+	/**
+	* @private
+	*/
+	setupFallback: function () {
+		this._fallbackTimeout = global.setTimeout(this.bindSafely('transitionFinished'), this.duration + 100);
 	}
 });
 

--- a/src/LightPanels/LightPanels.js
+++ b/src/LightPanels/LightPanels.js
@@ -873,7 +873,7 @@ module.exports = kind(
 	* @private
 	*/
 	setupFallback: function () {
-		this._fallbackTimeout = global.setTimeout(this.bindSafely('transitionFinished'), this.duration + 100);
+		this._fallbackTimeout = global.setTimeout(this.bindSafely('transitionFinished'), this.duration);
 	}
 });
 


### PR DESCRIPTION
### Issue
When a transitioning element is hidden, the `ontransitionend` event is never fired (https://bugs.webkit.org/show_bug.cgi?id=51945). In the case of `LightPanels`, this prevents some necessary post-transition clean-up that is executed as a result of handling this event.

### Fix
We have added some fallback logic that directly executes the clean-up logic, if it has not already been executed for the current transition. An alternative, and arguably more direct solution, could be to execute the clean-up logic whenever the panels instance is hidden (https://github.com/enyojs/enyo/compare/2.6.0-dev...ENYO-3011-aarontam-1). This works well for the current case and the specific behavior of hiding transitioning elements, but it seemed safer to have a catch-all to handle any other edge cases and quirks we may not be aware of.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>