### PR TITLE
ENYO-3098: Switch to a logical panel after replacement occurs.

### DIFF
--- a/src/LightPanels/LightPanels.js
+++ b/src/LightPanels/LightPanels.js
@@ -422,7 +422,7 @@ module.exports = kind(
 
 		var lastIndex = this.getPanels().length - 1,
 			nextPanel = this.createPanel(info, moreInfo),
-			newIndex = lastIndex + 1;
+			targetIndex = (opts && opts.targetIndex != null) ? opts.targetIndex : lastIndex + 1;
 		if (this.cacheViews) {
 			this.pruneQueue([info]);
 		}
@@ -433,8 +433,8 @@ module.exports = kind(
 			nextPanel.postTransition();
 		}
 
-		if (!this.animate || (opts && opts.direct)) this.set('index', newIndex, {force: opts && opts.force});
-		else this.animateTo(newIndex);
+		if (!this.animate || (opts && opts.direct)) this.set('index', targetIndex, {force: opts && opts.force});
+		else this.animateTo(targetIndex);
 
 		// TODO: When pushing panels after we have gone back (but have not popped), we need to
 		// adjust the position of the panels after the previous index before our push.
@@ -499,12 +499,15 @@ module.exports = kind(
 	* @param {Number} count - The number of panels we wish to replace.
 	* @param {Object|Object[]} info - The component definition (or array of component definitions)
 	*	for the replacement panel(s).
+	* @param {module:enyo/LightPanels~PushPanelOptions} opts - Additional options to be used when
+	*	pushing multiple panels. Note that for the case of "targetIndex", if this is not specified,
+	*	then the default behavior is to display the first replacement panel.
 	* @return {Object|Object[]|undefined} The panel or array of the panels that were pushed; if
 	*	`undefined`, the replacement could not be processed (i.e. we are currently transitioning).
 	* @public
 	*/
-	replaceAt: function (start, count, info) {
-		var panels, panelsToPop, insertBefore, commonInfo, end;
+	replaceAt: function (start, count, info, opts) {
+		var panels, panelsToPop, insertBefore, commonInfo, end, panelOpts, targetIndex;
 
 		if (this.transitioning) return;
 
@@ -513,13 +516,15 @@ module.exports = kind(
 		end = start + count;
 		insertBefore = panels[end];
 		commonInfo = {addBefore: insertBefore};
+		targetIndex = opts && opts.targetIndex;
+		panelOpts = {direct: true, force: true, targetIndex: targetIndex != null ? targetIndex : start};
 
 		panelsToPop = panels.splice(start, end - start);
 		this.popQueue = (this.popQueue && this.popQueue.concat(panelsToPop)) || panelsToPop;
 
 		// add replacement panels
-		if (utils.isArray(info)) return this.pushPanels(info, commonInfo, {direct: true, force: true});
-		else return this.pushPanel(info, commonInfo, {direct: true, force: true});
+		if (utils.isArray(info)) return this.pushPanels(info, commonInfo, panelOpts);
+		else return this.pushPanel(info, commonInfo, panelOpts);
 	},
 
 


### PR DESCRIPTION
### Issue
When using `replaceAt`, we weren't doing anything intelligent with respect to the destination index, after the replacement had completed. This could result in being left with a panel-less display (not a TV panel, mind you).

### Fix
We have added options support to `replaceAt`, which takes in the same options set as `pushPanel`/`pushPanels` for consistency. We are only concerned with `targetIndex` for the time being, which is used if specified, otherwise the first replacement panel will become the destination panel, after the replacement.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>