### PR TITLE
ENYO-3130: Touch/gesture fix

### DIFF
--- a/src/platform.js
+++ b/src/platform.js
@@ -41,13 +41,12 @@ exports = module.exports = {
 	* `true` if the platform has native single-finger [events]{@glossary event}.
 	* @public
 	*/
-	touch: Boolean(('ontouchstart' in window) || window.navigator.msMaxTouchPoints || window.navigator.maxTouchPoints),
+	touch: Boolean(('ontouchstart' in window) || window.navigator.msMaxTouchPoints || (window.navigator.msManipulationViewsEnabled && window.navigator.maxTouchPoints)),
 	/**
 	* `true` if the platform has native double-finger [events]{@glossary event}.
 	* @public
 	*/
-	gesture: Boolean(('ongesturestart' in window) || (window.navigator.msMaxTouchPoints && window.navigator.msMaxTouchPoints > 1) || (window.navigator.maxTouchPoints && window.navigator.maxTouchPoints > 1))
-
+	gesture: Boolean(('ongesturestart' in window) || ('onmsgesturestart' in window && window.navigator.msMaxTouchPoints && window.navigator.msMaxTouchPoints > 1) || ('onmsgesturestart' in window && window.navigator.maxTouchPoints && window.navigator.maxTouchPoints > 1))
 	/**
 	* The name of the platform that was detected or `undefined` if the platform
 	* was unrecognized. This value is the key name for the major version of the

--- a/src/platform.js
+++ b/src/platform.js
@@ -47,6 +47,7 @@ exports = module.exports = {
 	* @public
 	*/
 	gesture: Boolean(('ongesturestart' in window) || ('onmsgesturestart' in window && window.navigator.msMaxTouchPoints && window.navigator.msMaxTouchPoints > 1) || ('onmsgesturestart' in window && window.navigator.maxTouchPoints && window.navigator.maxTouchPoints > 1))
+	
 	/**
 	* The name of the platform that was detected or `undefined` if the platform
 	* was unrecognized. This value is the key name for the major version of the

--- a/src/platform.js
+++ b/src/platform.js
@@ -46,7 +46,7 @@ exports = module.exports = {
 	* `true` if the platform has native double-finger [events]{@glossary event}.
 	* @public
 	*/
-	gesture: Boolean(('ongesturestart' in window) || ('onmsgesturestart' in window && window.navigator.msMaxTouchPoints && window.navigator.msMaxTouchPoints > 1) || ('onmsgesturestart' in window && window.navigator.maxTouchPoints && window.navigator.maxTouchPoints > 1))
+	gesture: Boolean(('ongesturestart' in window) || ('onmsgesturestart' in window && (window.navigator.msMaxTouchPoints > 1 || window.navigator.maxTouchPoints > 1)))
 
 	/**
 	* The name of the platform that was detected or `undefined` if the platform

--- a/src/platform.js
+++ b/src/platform.js
@@ -47,7 +47,7 @@ exports = module.exports = {
 	* @public
 	*/
 	gesture: Boolean(('ongesturestart' in window) || ('onmsgesturestart' in window && window.navigator.msMaxTouchPoints && window.navigator.msMaxTouchPoints > 1) || ('onmsgesturestart' in window && window.navigator.maxTouchPoints && window.navigator.maxTouchPoints > 1))
-	
+
 	/**
 	* The name of the platform that was detected or `undefined` if the platform
 	* was unrecognized. This value is the key name for the major version of the


### PR DESCRIPTION
### Issue
Certain platforms will return an incorrect platform touch/gesture value, due to a recent change. 

### Fix
As this issue was introduced after adding specific IE-Edge browser support, we need to verify that only Edge/IE are affected by the new conditional(s) to check touch/gesture support. IE9 does not support touch, so we don't worry about that.

Gesture Support
IE10, IE11, and Edge all support the proprietary `onmsgesturestart` event, so we can simply check for this to determine MS gesture support.

Touch Support
IE10 supports the already-in-use `msMaxTouchPoints` property and Edge/IE11 support `msManipulationViewsEnabled` and `maxTouchPoints`, both which return the touch manipulation ability and if touch points are available.

Enyo-DCO-1.1-Signed-off-by: Jeremy Thomas <jeremy.thomas@lge.com>