### PR TITLE
ENYO-3144: Use container-based infrastructure for Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
-language: node_js
 sudo: false
+language: node_js
 node_js:
-  - "0.12"
+  - "node"
 cache:
   directories:
   - $HOME/.npm


### PR DESCRIPTION
### Issue
Travis builds are getting slower and slower due to being on the legacy system.

### Fix
We migrate to using the container-based infrastructure by setting `sudo: false`, per https://docs.travis-ci.com/user/migrating-from-legacy/#How-can-I-use-container-based-infrastructure%3F.

Also, updated the node version to use the latest stable.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>