### PR TITLE
ENYO-3164: Make Control be the default kind.

### DIFF
--- a/src/ViewController.js
+++ b/src/ViewController.js
@@ -5,6 +5,9 @@ require('enyo');
 * @module enyo/ViewController
 */
 
+// needed so that the default kind is Control instead of Component, if it isn't required elsewhere
+require('./Control');
+
 var
 	kind = require('./kind'),
 	utils = require('./utils');


### PR DESCRIPTION
### Issue
If `enyo/Control` is never required in an application, the default kind becomes `enyo/Component` instead.

### Fix
We explicitly require `enyo/Control` in `enyo/ViewController`.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>