### PR TITLE
ENYO-3174: Deprecate unstable APIs.

### DIFF
--- a/src/RichText/RichText.js
+++ b/src/RichText/RichText.js
@@ -277,6 +277,7 @@ var RichText = module.exports = kind(
 	* @param {module:enyo/RichText~ModifyType} type - The type of change to apply.
 	* @param {module:enyo/RichText~ModifyDirection} dir - The direction in which to apply the change.
 	* @param {module:enyo/RichText~ModifyAmount} amount - The granularity of the change.
+	* @deprecated since version 2.7
 	* @public
 	*/
 	modifySelection: function (type, dir, amount) {
@@ -291,6 +292,7 @@ var RichText = module.exports = kind(
 	*
 	* @param {module:enyo/RichText~ModifyDirection} dir - The direction in which to apply the change.
 	* @param {module:enyo/RichText~ModifyAmount} amount - The granularity of the change.
+	* @deprecated since version 2.7
 	* @public
 	*/
 	moveCursor: function (dir, amount) {
@@ -300,6 +302,7 @@ var RichText = module.exports = kind(
 	/**
 	* Moves the cursor to end of text field.
 	*
+	* @deprecated since version 2.7
 	* @public
 	*/
 	moveCursorToEnd: function () {
@@ -309,6 +312,7 @@ var RichText = module.exports = kind(
 	/**
 	* Moves the cursor to start of text field.
 	*
+	* @deprecated since version 2.7
 	* @public
 	*/
 	moveCursorToStart: function () {


### PR DESCRIPTION
### Issue
For the `enyo/RichText` control, we had been utilizing some unstable and non-standard APIs (specifically, selection modify) for handling cursor movement, and other selection modification operations. This does not work across different platforms and we should not be promoting the use of these APIs.

### Fix
We have deprecated 4 methods which effectively called one another successively. I realize that `moonstone/RichText` is utilizing `moveCursorToEnd`, which works currently as Moonstone is targeting WebKit platforms, but it seemed repetitive to copy over this functionality to `moonstone/RichText` currently. If and when we actually remove the `moveCursorToEnd` API, we can consider porting this functionality to `moonstone/RichText`, or go another direction with the implementation.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>