### PR TITLE
ENYO-3184: Remove srcElement property for generated media events.

### DIFF
--- a/src/Media.js
+++ b/src/Media.js
@@ -25,7 +25,7 @@ var
 *	propagated the {@glossary event}.
 * @property {Object} event - An [object]{@glossary Object} containing event information.
 * @public
-*/ 
+*/
 
 /**
 * Fires when element can resume playback of the [media]{@link module:enyo/Media~Media} data, but may
@@ -45,7 +45,7 @@ var
 *
 * @event module:enyo/Media~Media#onCanPlayThrough
 * @type {Object}
-* @property {Object} sender - The [component]{@link module:enyo/Component~Component} that most recently 
+* @property {Object} sender - The [component]{@link module:enyo/Component~Component} that most recently
 *	propagated the {@glossary event}.
 * @property {Object} event - An [object]{@glossary Object} containing event information.
 * @public
@@ -357,17 +357,17 @@ module.exports = kind(
 	* @private
 	*/
 	kind: Control,
-	
+
 	/**
 	* @private
 	*/
-	published: 
+	published:
 		/** @lends module:enyo/Media~Media.prototype */ {
-		
+
 		/**
 		* URL of the [media]{@link module:enyo/Media~Media} file to play; may be relative to the
 		* application HTML file.
-		* 
+		*
 		* @type {String}
 		* @default ''
 		* @public
@@ -376,7 +376,7 @@ module.exports = kind(
 
 		/**
 		* If `true`, [media]{@link module:enyo/Media~Media} will automatically start playback when loaded.
-		* 
+		*
 		* @type {Boolean}
 		* @default false
 		* @public
@@ -385,7 +385,7 @@ module.exports = kind(
 
 		/**
 		* The desired speed at which the [media]{@link module:enyo/Media~Media} resource is to play.
-		* 
+		*
 		* @type {Number}
 		* @default 1.0
 		* @public
@@ -394,7 +394,7 @@ module.exports = kind(
 
 		/**
 		* The amount of time, in seconds, to jump forward or backward.
-		* 
+		*
 		* @type {Number}
 		* @default 30
 		* @public
@@ -403,7 +403,7 @@ module.exports = kind(
 
 		/**
 		* The effective playback rate.
-		* 
+		*
 		* @type {Number}
 		* @default 1.0
 		* @public
@@ -418,7 +418,7 @@ module.exports = kind(
 		*	slowRewind: ['-1/2', '-1']
 		* }
 		* ```
-		* 
+		*
 		* @type {Object}
 		* @default {
 		*	fastForward: ['2', '4', '8', '16'],
@@ -438,7 +438,7 @@ module.exports = kind(
 		/**
 		* Indicates how data should be preloaded, reflecting the `preload` HTML attribute.
 		* Will be one of `'none'` (the default), `'metadata'`, or `'auto'`.
-		* 
+		*
 		* @type {String}
 		* @default 'none'
 		* @public
@@ -447,7 +447,7 @@ module.exports = kind(
 
 		/**
 		*  If `true`, [media]{@link module:enyo/Media~Media} playback restarts from beginning when finished.
-		* 
+		*
 		* @type {Boolean}
 		* @default false
 		* @public
@@ -456,7 +456,7 @@ module.exports = kind(
 
 		/**
 		* If `true`, [media]{@link module:enyo/Media~Media} playback is muted.
-		* 
+		*
 		* @type {Boolean}
 		* @default false
 		* @public
@@ -465,7 +465,7 @@ module.exports = kind(
 
 		/**
 		* If `true`, default [media]{@link module:enyo/Media~Media} controls are shown.
-		* 
+		*
 		* @type {Boolean}
 		* @default false
 		* @public
@@ -474,7 +474,7 @@ module.exports = kind(
 
 		/**
 		* Current playback volume, as a number in the range from 0.0 to 1.0.
-		* 
+		*
 		* @type {Number}
 		* @default 1.0
 		* @public
@@ -515,7 +515,7 @@ module.exports = kind(
 		onJumpBackward: '',
 		onStart: ''
 	},
-	
+
 	/**
 	* @private
 	*/
@@ -732,7 +732,7 @@ module.exports = kind(
 	_canPlayThrough: function () {
 		this.doCanPlayThrough();
 	},
-	
+
 	/**
 	* Called when the [duration]{@link module:enyo/Media~Media#duration} attribute has been changed.
 	*
@@ -766,7 +766,7 @@ module.exports = kind(
 
 	/**
 	* Called when an error occurs while fetching media data.
-	* 
+	*
 	* @private
 	*/
 	_error: function () {
@@ -784,7 +784,7 @@ module.exports = kind(
 	},
 	/**
 	* Called when the media duration and dimensions of the media resource/text tracks are ready.
-	* 
+	*
 	* @private
 	*/
 	_loadedMetaData: function () {
@@ -856,7 +856,6 @@ module.exports = kind(
 			this.doStart();
 		}
 		return {
-			srcElement: node,
 			duration: node.duration,
 			currentTime: node.currentTime,
 			playbackRate: this.getPlaybackRate()
@@ -876,7 +875,7 @@ module.exports = kind(
 		return (pbArray.length > 1) ? parseInt(pbArray[0], 10) / parseInt(pbArray[1], 10) : parseInt(rate, 10);
 	},
 	/**
-	* Called when either [defaultPlaybackRate]{@link module:enyo/Media~Media#defaultPlaybackRate} or 
+	* Called when either [defaultPlaybackRate]{@link module:enyo/Media~Media#defaultPlaybackRate} or
 	* [playbackRate]{@link module:enyo/Media~Media#playbackRate} has been updated.
 	*
 	* @fires module:enyo/Media~Media#onSlowforward
@@ -945,7 +944,7 @@ module.exports = kind(
 
 	/**
 	* Called when the media controller position has changed.
-	* 
+	*
 	* @private
 	*/
 	_timeUpdate: function (sender, e) {
@@ -1022,7 +1021,7 @@ module.exports = kind(
 	* Retrieves the ranges of the [media]{@link module:enyo/Media~Media} [source]{@link module:enyo/Media~Media#src}
 	* that have been buffered.
 	*
-	* @returns {TimeRanges} The ranges of the [media]{@link module:enyo/Media~Media} 
+	* @returns {TimeRanges} The ranges of the [media]{@link module:enyo/Media~Media}
 	*	[source]{@link module:enyo/Media~Media#src} that have been buffered.
 	* @public
 	*/
@@ -1059,7 +1058,7 @@ module.exports = kind(
 		return 0;
 	},
 
-	/** 
+	/**
 	* Determines whether the [media]{@link module:enyo/Media~Media} element is paused.
 	*
 	* @returns {Boolean} `true` if the [media]{@link module:enyo/Media~Media} is paused;
@@ -1072,11 +1071,11 @@ module.exports = kind(
 		}
 	},
 
-	/** 
-	* Retrieves the ranges of the [media]{@link module:enyo/Media~Media} [source]{@link module:enyo/Media~Media#src} 
+	/**
+	* Retrieves the ranges of the [media]{@link module:enyo/Media~Media} [source]{@link module:enyo/Media~Media#src}
 	* that have been played, if any.
 	*
-	* @returns {TimeRanges} The ranges of the [media]{@link module:enyo/Media~Media} 
+	* @returns {TimeRanges} The ranges of the [media]{@link module:enyo/Media~Media}
 	*	[source]{@link module:enyo/Media~Media#src} that have been played.
 	* @public
 	*/
@@ -1086,7 +1085,7 @@ module.exports = kind(
 		}
 	},
 
-	/** 
+	/**
 	* Determines the [readiness]{@glossary readyState} of the [media]{@link module:enyo/Media~Media}.
 	*
 	* @returns {ReadyState} The [readiness]{@glossary readyState} state.
@@ -1098,7 +1097,7 @@ module.exports = kind(
 		}
 	},
 
-	/** 
+	/**
 	* Retrieves the ranges of the [media]{@link module:enyo/Media~Media} [source]{@link module:enyo/Media~Media#src}
 	* that the user may seek to, if any.
 	*
@@ -1112,7 +1111,7 @@ module.exports = kind(
 		}
 	},
 
-	/** 
+	/**
 	* Sets current player position in the [media]{@link module:enyo/Media~Media} element.
 	*
 	* @param {Number} time - The player position, in seconds.
@@ -1124,7 +1123,7 @@ module.exports = kind(
 		}
 	},
 
-	/** 
+	/**
 	* Implements custom rewind functionality (until browsers support negative playback rate).
 	*
 	* @public
@@ -1136,7 +1135,7 @@ module.exports = kind(
 
 	/**
 	* Calculates the time that has elapsed since.
-	* 
+	*
 	* @private
 	*/
 	_rewind: function () {
@@ -1149,7 +1148,7 @@ module.exports = kind(
 		this.startRewindJob();
 	},
 
-	/** 
+	/**
 	* Starts rewind job.
 	*
 	* @public
@@ -1159,7 +1158,7 @@ module.exports = kind(
 		Job(this.id + 'rewind', this.bindSafely('_rewind'), 100);
 	},
 
-	/** 
+	/**
 	* Stops rewind job.
 	*
 	* @public
@@ -1168,7 +1167,7 @@ module.exports = kind(
 		Job.stop(this.id + 'rewind');
 	},
 
-	/** 
+	/**
 	* Determines whether the [media]{@link module:enyo/Media~Media} is currently seeking to a new position.
 	*
 	* @returns {Boolean} `true` if currently seeking; otherwise, `false`.
@@ -1180,7 +1179,7 @@ module.exports = kind(
 		}
 	},
 
-	/** 
+	/**
 	* Determines whether the [media]{@link module:enyo/Media~Media} is currently in a paused state.
 	*
 	* @returns {Boolean} `true` if paused; otherwise, `false`.
@@ -1190,7 +1189,7 @@ module.exports = kind(
 		return this.hasNode() ? this.hasNode().paused : true;
 	},
 
-	/** 
+	/**
 	* Fast forwards the [media]{@link module:enyo/Media~Media}, taking into account the current
 	* playback state.
 	*
@@ -1248,7 +1247,7 @@ module.exports = kind(
 
 	},
 
-	/** 
+	/**
 	* Rewinds the [media]{@link module:enyo/Media~Media}, taking into account the current
 	* playback state.
 	*
@@ -1322,7 +1321,7 @@ module.exports = kind(
 		}
 	},
 
-	/** 
+	/**
 	* Jumps backward by an amount specified by the [jumpSec]{@link module:enyo/Media~Media#jumpSec}
 	* property.
 	*
@@ -1343,7 +1342,7 @@ module.exports = kind(
 		this.doJumpBackward(utils.mixin(this.createEventData(), {jumpSize: this.jumpSec}));
 	},
 
-	/** 
+	/**
 	* Jumps forward by an amount specified by the [jumpSec]{@link module:enyo/Media~Media#jumpSec}
 	* property.
 	*
@@ -1364,7 +1363,7 @@ module.exports = kind(
 		this.doJumpForward(utils.mixin(this.createEventData(), {jumpSize: this.jumpSec}));
 	},
 
-	/** 
+	/**
 	* Jumps to the beginning of the [media]{@link module:enyo/Media~Media} content.
 	*
 	* @public
@@ -1382,7 +1381,7 @@ module.exports = kind(
 		this._prevCommand = 'jumpToStart';
 	},
 
-	/** 
+	/**
 	* Jumps to the end of the [media]{@link module:enyo/Media~Media} content.
 	*
 	* @public

--- a/src/Video.js
+++ b/src/Video.js
@@ -120,7 +120,7 @@ var
 * ```
 *
 * To play a video, call `this.$.video.play()`.
-* 
+*
 * To get a reference to the actual HTML 5 Video element, call `this.$.video.hasNode()`.
 *
 * @class Video
@@ -144,12 +144,12 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	published: 
+	published:
 		/** @lends module:enyo/Video~Video.prototype */ {
 
 		/**
 		* Source URL of the video file; may be relative to the application's HTML file.
-		* 
+		*
 		* @type {String}
 		* @default ''
 		* @public
@@ -159,7 +159,7 @@ module.exports = kind(
 		/**
 		* An [object]{@glossary Object} that may be used to specify multiple sources for the
 		* same video file.
-		* 
+		*
 		* @type {Object}
 		* @default null
 		* @public
@@ -168,7 +168,7 @@ module.exports = kind(
 
 		/**
 		* Source of image file to show when video is not available.
-		* 
+		*
 		* @type {String}
 		* @default ''
 		* @public
@@ -177,7 +177,7 @@ module.exports = kind(
 
 		/**
 		* If `true`, controls for starting and stopping the video player are shown.
-		* 
+		*
 		* @type {Boolean}
 		* @default false
 		* @public
@@ -190,7 +190,7 @@ module.exports = kind(
 		* - `'auto'`: Preload the video data as soon as possible.
 		* - `'metadata'`: Preload only the video metadata.
 		* - `'none'`: Do not preload any video data.
-		* 
+		*
 		* @type {String}
 		* @default 'metadata'
 		* @public
@@ -199,7 +199,7 @@ module.exports = kind(
 
 		/**
 		* If `true`, video will automatically start playing.
-		* 
+		*
 		* @type {Boolean}
 		* @default false
 		* @public
@@ -209,7 +209,7 @@ module.exports = kind(
 		/**
 		* If `true`, when playback is finished, the video player will restart from
 		* the beginning.
-		* 
+		*
 		* @type {Boolean}
 		* @default false
 		* @public
@@ -218,7 +218,7 @@ module.exports = kind(
 
 		/**
 		* If `true`, video will be stretched to fill the entire window (webOS only).
-		* 
+		*
 		* @type {Boolean}
 		* @default false
 		* @public
@@ -227,7 +227,7 @@ module.exports = kind(
 
 		/**
 		* The video aspect ratio, expressed as `width:height`.
-		* 
+		*
 		* @type {Number}
 		* @default 0
 		* @public
@@ -236,7 +236,7 @@ module.exports = kind(
 
 		/**
 		* Number of seconds to jump forward or backward.
-		* 
+		*
 		* @type {Number}
 		* @default 30
 		* @public
@@ -245,7 +245,7 @@ module.exports = kind(
 
 		/**
 		* Video playback rate.
-		* 
+		*
 		* @type {Number}
 		* @default 1
 		* @public
@@ -262,7 +262,7 @@ module.exports = kind(
 		*	slowRewind: ['-1/2', '-1']
 		* }
 		* ```
-		* 
+		*
 		* @type {Object}
 		* @default {
 		*	fastForward: ['2', '4', '8', '16'],
@@ -443,10 +443,10 @@ module.exports = kind(
 			return;
 		}
 	},
-	
+
 	/**
 	* Loads the current video [source]{@link module:enyo/Video~Video#src}.
-	* 
+	*
 	* @public
 	*/
 	load: function () {
@@ -456,7 +456,7 @@ module.exports = kind(
 	/**
 	* Unloads the current video [source]{@link module:enyo/Video~Video#src}, stopping all
 	* playback and buffering.
-	* 
+	*
 	* @public
 	*/
 	unload: function() {
@@ -469,7 +469,7 @@ module.exports = kind(
 
 	/**
 	* Initiates playback of the video data.
-	* 
+	*
 	* @public
 	*/
 	play: function () {
@@ -484,7 +484,7 @@ module.exports = kind(
 
 	/**
 	* Pauses video playback.
-	* 
+	*
 	* @public
 	*/
 	pause: function () {
@@ -556,7 +556,7 @@ module.exports = kind(
 
 	/**
 	* Changes the playback speed via [selectPlaybackRate()]{@link module:enyo/Video~Video#selectPlaybackRate}.
-	* 
+	*
 	* @public
 	*/
 	rewind: function () {
@@ -667,9 +667,9 @@ module.exports = kind(
 	},
 
 	/**
-	* Jumps to beginning of media [source]{@link module:enyo/Video~Video#src} and sets 
+	* Jumps to beginning of media [source]{@link module:enyo/Video~Video#src} and sets
 	* [playbackRate]{@link module:enyo/Video~Video#playbackRate} to `1`.
-	* 
+	*
 	* @public
 	*/
 	jumpToStart: function () {
@@ -686,9 +686,9 @@ module.exports = kind(
 	},
 
 	/**
-	* Jumps to end of media [source]{@link module:enyo/Video~Video#src} and sets 
+	* Jumps to end of media [source]{@link module:enyo/Video~Video#src} and sets
 	* [playbackRate]{@link module:enyo/Video~Video#playbackRate} to `1`.
-	* 
+	*
 	* @public
 	*/
 	jumpToEnd: function () {
@@ -705,7 +705,7 @@ module.exports = kind(
 	},
 
 	/**
-	* Sets the playback rate type (from the [keys]{@glossary Object.keys} of 
+	* Sets the playback rate type (from the [keys]{@glossary Object.keys} of
 	* [playbackRateHash]{@link module:enyo/Video~Video#playbackRateHash}).
 	*
 	* @param {String} cmd - Key of the playback rate type.
@@ -716,7 +716,7 @@ module.exports = kind(
 	},
 
 	/**
-	* Changes [playbackRate]{@link module:enyo/Video~Video#playbackRate} to a valid value when initiating 
+	* Changes [playbackRate]{@link module:enyo/Video~Video#playbackRate} to a valid value when initiating
 	* fast forward or rewind.
 	*
 	* @param {Number} idx - The index of the desired playback rate.
@@ -743,7 +743,7 @@ module.exports = kind(
 
 	/**
 	* Sets [playbackRate]{@link module:enyo/Video~Video#playbackRate}.
-	* 
+	*
 	* @param {String} rate - The desired playback rate.
 	* @public
 	*/
@@ -847,7 +847,7 @@ module.exports = kind(
 
 	/**
 	* Implements custom rewind functionality (until browsers support negative playback rate).
-	* 
+	*
 	* @private
 	*/
 	beginRewind: function () {
@@ -857,7 +857,7 @@ module.exports = kind(
 
 	/**
 	* Calculates the time that has elapsed since
-	* 
+	*
 	* @private
 	*/
 	_rewind: function () {
@@ -874,7 +874,7 @@ module.exports = kind(
 
 	/**
 	* Starts rewind job.
-	* 
+	*
 	* @private
 	*/
 	startRewindJob: function () {
@@ -884,7 +884,7 @@ module.exports = kind(
 
 	/**
 	* Stops rewind job.
-	* 
+	*
 	* @private
 	*/
 	stopRewindJob: function () {
@@ -893,7 +893,7 @@ module.exports = kind(
 
 	/**
 	* Calculates numeric value of playback rate (with support for fractions).
-	* 
+	*
 	* @private
 	*/
 	calcNumberValueOfPlaybackRate: function (rate) {
@@ -902,7 +902,7 @@ module.exports = kind(
 	},
 
 	/**
-	* 
+	*
 	* Updates the [aspectRatio]{@link module:enyo/Video~Video#aspectRatio} property when the
 	* video's metadata is received.
 	*
@@ -980,7 +980,6 @@ module.exports = kind(
 			this.doStart();
 		}
 		return {
-			srcElement: node,
 			duration: node.duration,
 			currentTime: node.currentTime,
 			playbackRate: this.getPlaybackRate()
@@ -989,7 +988,7 @@ module.exports = kind(
 
 	/**
 	* Normalizes Enyo-generated `onPlay` [events]{@glossary event}.
-	* 
+	*
 	* @fires module:enyo/Video~Video#doPlay
 	* @private
 	*/
@@ -1007,7 +1006,7 @@ module.exports = kind(
 
 	/**
 	* All HTML5 [video]{@glossary video} [events]{@glossary event}.
-	* 
+	*
 	* @private
 	*/
 	hookupVideoEvents: function () {


### PR DESCRIPTION
### Issue
We had previously been providing a `srcElement` property for our generated media events. This is more of an optional change, and we are not utilizing this property anywhere internally, but in the spirit of being more standards-compliant and consistent, we should move away from this.

### Fix
We have removed the `srcElement` property when generating media events.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>