### PR TITLE
ENYO-2692: Reset metrics for pages before jump on scrollToIndex

### DIFF
--- a/src/VerticalDelegate.js
+++ b/src/VerticalDelegate.js
@@ -360,6 +360,8 @@ module.exports = {
 				callback();
 			}
 		} else {
+			// Reset metrics before jump position
+			list.metrics.pages = {};
 			// we do this to ensure we trigger the paging event when necessary
 			this.resetToPosition(list, this.pagePosition(list, p));
 			// now retry the original logic until we have this right


### PR DESCRIPTION
Issue:
 The pageForIndex is calculated from (i / perPage) and pagePosition is calculated by accumulating each page height. That page height is comes from measured page size when the page is already generated. But, when page is not generated, defaultPageSize (perPage * childSize) is used instead. So, there is a chance of mistake that create pages not including the control i. The scrollToIndex fails to find c on recursive call and it enters infinite loops.

Fix:
Reset page metrics before calling pagePosition so that it can generate
right pages.

Enyo-DCO-1.1-Signed-Off-By: Kunmyon Choi (kunmyon.choi@lge.com)