### PR TITLE
PLAT-17000: Apply rAF into Control.applyStyle

### DIFF
--- a/src/Control/Control.js
+++ b/src/Control/Control.js
@@ -33,7 +33,7 @@ var styleBuffer = [];
 
 var applyStyleToDom = function() {
 	var length = styleBuffer.length;
-	if (length == 0) {
+	if (length === 0) {
 		return;
 	}
 
@@ -113,8 +113,7 @@ var applyStyleToDom = function() {
 		// it is rendered
 		delegate.invalidate(that, 'style');
 	}
-}
-
+};
 
 /**
 * Called by `Control.teardownRender()`. In certain circumstances,

--- a/src/Control/Control.js
+++ b/src/Control/Control.js
@@ -40,25 +40,25 @@ var applyStyleToDom = function() {
 	for (var i = 0; i < length; i++) {
 
 		var obj = styleBuffer.pop(),
-			that = obj.that,
+			control = obj.control,
 			prop = obj.prop,
 			value = obj.value;
 
-		// NOTE: that method deliberately avoids calling set('style', ...) for performance
+		// NOTE: this method deliberately avoids calling set('style', ...) for performance
 		// as it will have already been parsed by the browser so we pass it on via the
 		// notification system which is the same
 
-		// TODO: Wish we could delay that potentially...
+		// TODO: Wish we could delay this potentially...
 		// if we have a node we render the value immediately and update our style string
 		// in the process to keep them synchronized
-		var node = that.hasNode(),
-			delegate = that.renderDelegate || Control.renderDelegate;
+		var node = control.hasNode(),
+			delegate = control.renderDelegate || Control.renderDelegate;
 
-		// FIXME: that is put in place for a Firefox bug where setting a style value of a node
+		// FIXME: this is put in place for a Firefox bug where setting a style value of a node
 		// via its CSSStyleDeclaration object (by accessing its node.style property) does
-		// not work when using a CSS property name that contains one or more dash, and requires
-		// setting the property via the JavaScript-style property name. that fix should be
-		// removed once that issue has been resolved in the Firefox mainline and its variants
+		// not work when using a CSS property name this contains one or more dash, and requires
+		// setting the property via the JavaScript-style property name. this fix should be
+		// removed once this issue has been resolved in the Firefox mainline and its variants
 		// (it is currently resolved in the 36.0a1 nightly):
 		// https://bugzilla.mozilla.org/show_bug.cgi?id=1083457
 		if (node && (platform.firefox < 35 || platform.firefoxOS || platform.androidFirefox)) {
@@ -74,44 +74,44 @@ var applyStyleToDom = function() {
 
 				// cssText is an internal property used to help know when to sync and not
 				// sync with the node in styleChanged
-				that.style = that.cssText = node.style.cssText;
+				control.style = control.cssText = node.style.cssText;
 
 				// otherwise we have to try and prepare it for the next time it is rendered we
 				// will need to update it because it will not be synchronized
 			} else {
-				that.set('style', that.style + (' ' + prop + ':' + value + ';'));
+				control.set('style', control.style + (' ' + prop + ':' + value + ';'));
 			}
 		} else {
 
-			// in that case we are trying to clear the style property so if we have the node
+			// in this case we are trying to clear the style property so if we have the node
 			// we let the browser handle whatever the value should be now and otherwise
 			// we have to parse it out of the style string and wait to be rendered
 
 			if (node) {
 				node.style[prop] = '';
-				that.style = that.cssText = node.style.cssText;
+				control.style = control.cssText = node.style.cssText;
 
 				// we need to invalidate the style for the delegate
-				delegate.invalidate(that, 'style');
+				delegate.invalidate(control, 'style');
 			} else {
-				var style = that.style;
+				var style = control.style;
 
-				// that is a rare case to nullify the style of a control that is not
+				// this is a rare case to nullify the style of a control this is not
 				// rendered or does not have a node
 				style = style.replace(new RegExp(
-					// that looks a lot worse than it is. The complexity stems from needing to
-					// match a url container that can have other characters including semi-
-					// colon and also that the last property may/may-not end with one
+					// this looks a lot worse than it is. The complexity stems from needing to
+					// match a url container this can have other characters including semi-
+					// colon and also this the last property may/may-not end with one
 					'\\s*' + prop + '\\s*:\\s*[a-zA-Z0-9\\ ()_\\-\'"%,]*(?:url\\(.*\\)\\s*[a-zA-Z0-9\\ ()_\\-\'"%,]*)?\\s*(?:;|;?$)',
 					'gi'
 				),'');
-				that.set('style', style);
+				control.set('style', style);
 			}
 		}
 		// we need to invalidate the style for the delegate -- regardless of whether or
-		// not the node exists to ensure that the tag is updated properly the next time
+		// not the node exists to ensure this the tag is updated properly the next time
 		// it is rendered
-		delegate.invalidate(that, 'style');
+		delegate.invalidate(control, 'style');
 	}
 };
 
@@ -702,7 +702,7 @@ var Control = module.exports = kind(
 	*/
 	applyStyle: function (prop, value) {
 		styleBuffer.push({
-			that: this,
+			control: this,
 			prop: prop,
 			value: value
 		});

--- a/src/ScrollMath.js
+++ b/src/ScrollMath.js
@@ -19,7 +19,7 @@ var
 *
 * @event module:enyo/ScrollMath~ScrollMath#onScrollStart
 * @type {Object}
-* @property {Object} sender - The [component]{@link module:enyo/Component~Component} that most recently 
+* @property {Object} sender - The [component]{@link module:enyo/Component~Component} that most recently
 *	propagated the {@glossary event}.
 * @property {module:enyo/Scroller~Scroller~ScrollEvent} event - An [object]{@glossary Object} containing
 *	event information.
@@ -31,7 +31,7 @@ var
 *
 * @event module:enyo/ScrollMath~ScrollMath#onScroll
 * @type {Object}
-* @property {Object} sender - The [component]{@link module:enyo/Component~Component} that most recently 
+* @property {Object} sender - The [component]{@link module:enyo/Component~Component} that most recently
 *	propagated the {@glossary event}.
 * @property {module:enyo/Scroller~Scroller~ScrollEvent} event - An [object]{@glossary Object} containing
 *	event information.
@@ -43,7 +43,7 @@ var
 *
 * @event module:enyo/ScrollMath~ScrollMath#onScrollStop
 * @type {Object}
-* @property {Object} sender - The [component]{@link module:enyo/Component~Component} that most recently 
+* @property {Object} sender - The [component]{@link module:enyo/Component~Component} that most recently
 *	propagated the {@glossary event}.
 * @property {module:enyo/Scroller~Scroller~ScrollEvent} event - An [object]{@glossary Object} containing
 *	event information.
@@ -54,7 +54,7 @@ var
 * {@link module:enyo/ScrollMath~ScrollMath} implements a scrolling dynamics simulation. It is a
 * helper [kind]{@glossary kind} used by other [scroller]{@link module:enyo/Scroller~Scroller}
 * kinds, such as {@link module:enyo/TouchScrollStrategy~TouchScrollStrategy}.
-* 
+*
 * `enyo.ScrollMath` is not typically created in application code.
 *
 * @class ScrollMath
@@ -73,10 +73,10 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	published: 
+	published:
 		/** @lends module:enyo/ScrollMath~ScrollMath.prototype */ {
 
-		/** 
+		/**
 		* Set to `true` to enable vertical scrolling.
 		*
 		* @type {Boolean}
@@ -85,7 +85,7 @@ module.exports = kind(
 		*/
 		vertical: true,
 
-		/** 
+		/**
 		* Set to `true` to enable horizontal scrolling.
 		*
 		* @type {Boolean}
@@ -106,95 +106,95 @@ module.exports = kind(
 	},
 
 	/**
-	* "Spring" damping returns the scroll position to a value inside the boundaries. Lower 
+	* "Spring" damping returns the scroll position to a value inside the boundaries. Lower
 	* values provide faster snapback.
 	*
 	* @private
 	*/
 	kSpringDamping: 0.93,
 
-	/** 
-	* "Drag" damping resists dragging the scroll position beyond the boundaries. Lower values 
+	/**
+	* "Drag" damping resists dragging the scroll position beyond the boundaries. Lower values
 	* provide more resistance.
 	*
 	* @private
 	*/
 	kDragDamping: 0.5,
-	
-	/** 
+
+	/**
 	* "Friction" damping reduces momentum over time. Lower values provide more friction.
 	*
 	* @private
 	*/
 	kFrictionDamping: 0.97,
 
-	/** 
-	* Additional "friction" damping applied when momentum carries the viewport into overscroll. 
+	/**
+	* Additional "friction" damping applied when momentum carries the viewport into overscroll.
 	* Lower values provide more friction.
 	*
 	* @private
 	*/
 	kSnapFriction: 0.9,
-	
-	/** 
+
+	/**
 	* Scalar applied to `flick` event velocity.
 	*
 	* @private
 	*/
 	kFlickScalar: 15,
 
-	/** 
-	* Limits the maximum allowable flick. On Android > 2, we limit this to prevent compositing 
+	/**
+	* Limits the maximum allowable flick. On Android > 2, we limit this to prevent compositing
 	* artifacts.
 	*
 	* @private
 	*/
 	kMaxFlick: platform.android > 2 ? 2 : 1e9,
-	
-	/** 
-	* The value used in [friction()]{@link module:enyo/ScrollMath~ScrollMath#friction} to determine if the delta 
+
+	/**
+	* The value used in [friction()]{@link module:enyo/ScrollMath~ScrollMath#friction} to determine if the delta
 	* (e.g., y - y0) is close enough to zero to consider as zero.
 	*
 	* @private
 	*/
 	kFrictionEpsilon: platform.webos >= 4 ? 1e-1 : 1e-2,
-	
-	/** 
+
+	/**
 	* Top snap boundary, generally `0`.
 	*
 	* @private
 	*/
 	topBoundary: 0,
-	
-	/** 
+
+	/**
 	* Right snap boundary, generally `(viewport width - content width)`.
 	*
 	* @private
 	*/
 	rightBoundary: 0,
-	
-	/** 
+
+	/**
 	* Bottom snap boundary, generally `(viewport height - content height)`.
 	*
 	* @private
 	*/
 	bottomBoundary: 0,
-	
-	/** 
+
+	/**
 	* Left snap boundary, generally `0`.
 	*
 	* @private
 	*/
 	leftBoundary: 0,
-	
-	/** 
+
+	/**
 	* Animation time step.
 	*
 	* @private
 	*/
 	interval: 20,
-	
-	/** 
+
+	/**
 	* Flag to enable frame-based animation; if `false`, time-based animation is used.
 	*
 	* @private
@@ -267,7 +267,7 @@ module.exports = kind(
 	},
 
 	/**
-	* Boundary damping function. Returns damped `value` based on `coeff` on one side of 
+	* Boundary damping function. Returns damped `value` based on `coeff` on one side of
 	* `origin`.
 	*
 	* @private
@@ -289,7 +289,7 @@ module.exports = kind(
 	},
 
 	/**
-	* Dual-boundary damping function. Returns damped `value` based on `coeff` when exceeding 
+	* Dual-boundary damping function. Returns damped `value` based on `coeff` when exceeding
 	* either boundary.
 	*
 	* @private
@@ -334,7 +334,7 @@ module.exports = kind(
 		this[ex] = this[ex0] + c * dp;
 	},
 
-	/** 
+	/**
 	* One unit of time for simulation.
 	*
 	* @private
@@ -410,8 +410,6 @@ module.exports = kind(
 		var fn = this.bindSafely(function() {
 			// wall-clock time
 			var t1 = utils.perfNow();
-			// schedule next frame
-			this.job = animation.requestAnimationFrame(fn);
 			// delta from last wall clock time
 			var dt = t1 - t0;
 			// record the time for next delta
@@ -464,17 +462,14 @@ module.exports = kind(
 			y0 = this.y;
 			x0 = this.x;
 		});
-		this.job = animation.requestAnimationFrame(fn);
+		fn();
 	},
-	
+
 	/**
 	* @private
 	*/
 	start: function () {
-		if (!this.job) {
-			this.doScrollStart();
-			this.animate();
-		}
+		this.animate();
 	},
 
 	/**
@@ -533,7 +528,7 @@ module.exports = kind(
 		if (this.dragging) {
 			v = this.canScrollY();
 			h = this.canScrollX();
-		
+
 			dy = v ? e.pageY - this.my : 0;
 			this.uy = dy + this.py;
 			// provides resistance against dragging into overscroll
@@ -643,7 +638,7 @@ module.exports = kind(
 			dX = dY;
 			dY = 0;
 		}
-		
+
 		if (dY && canY) {
 			tY = -(refY + (dY * m));
 			shouldScroll = true;
@@ -670,7 +665,7 @@ module.exports = kind(
 	// NOTE: Yip/Orvell method for determining scroller instantaneous velocity
 	// FIXME: incorrect if called when scroller is in overscroll region
 	// because does not account for additional overscroll damping.
-	
+
 	/**
 	* Scrolls to the specified position.
 	*
@@ -754,7 +749,7 @@ module.exports = kind(
 	setScrollPosition: function (pos) {
 		this.setScrollY(pos);
 	},
-	
+
 	canScrollX: function() {
 		return this.horizontal && this.rightBoundary < 0;
 	},
@@ -764,9 +759,9 @@ module.exports = kind(
 	},
 
 
-	/** 
+	/**
 	* Determines whether or not the [scroller]{@link module:enyo/Scroller~Scroller} is actively moving.
-	* 
+	*
 	* @return {Boolean} `true` if actively moving; otherwise, `false`.
 	* @private
 	*/
@@ -774,9 +769,9 @@ module.exports = kind(
 		return Boolean(this.job);
 	},
 
-	/** 
+	/**
 	* Determines whether or not the [scroller]{@link module:enyo/Scroller~Scroller} is in overscroll.
-	* 
+	*
 	* @return {Boolean} `true` if in overscroll; otherwise, `false`.
 	* @private
 	*/

--- a/src/ScrollMath.js
+++ b/src/ScrollMath.js
@@ -406,63 +406,60 @@ module.exports = kind(
 		var t0 = utils.perfNow(), t = 0;
 		// delta tracking
 		var x0, y0;
-		// animation handler
-		var fn = this.bindSafely(function() {
-			// wall-clock time
-			var t1 = utils.perfNow();
-			// delta from last wall clock time
-			var dt = t1 - t0;
-			// record the time for next delta
-			t0 = t1;
-			// user drags override animation
-			if (this.dragging) {
-				this.y0 = this.y = this.uy;
-				this.x0 = this.x = this.ux;
-				this.endX = this.endY = null;
-			}
-			// frame-time accumulator
-			// min acceptable time is 16ms (60fps)
-			t += Math.max(16, dt);
-			// prevent snapping to originally desired scroll position if we are in overscroll
-			if (this.isInOverScroll()) {
-				this.endX = null;
-				this.endY = null;
 
-				this.takeBoundarySnapshot();
-			}
-			else {
-				this.discardBoundarySnapshot();
+		// wall-clock time
+		var t1 = utils.perfNow();
+		// delta from last wall clock time
+		var dt = t1 - t0;
+		// record the time for next delta
+		t0 = t1;
+		// user drags override animation
+		if (this.dragging) {
+			this.y0 = this.y = this.uy;
+			this.x0 = this.x = this.ux;
+			this.endX = this.endY = null;
+		}
+		// frame-time accumulator
+		// min acceptable time is 16ms (60fps)
+		t += Math.max(16, dt);
+		// prevent snapping to originally desired scroll position if we are in overscroll
+		if (this.isInOverScroll()) {
+			this.endX = null;
+			this.endY = null;
 
-				// alternate fixed-time step strategy:
-				if (this.fixedTime) {
-					t = this.interval;
-				}
-			}
-			// consume some t in simulation
-			t = this.simulate(t);
-			// scroll if we have moved, otherwise the animation is stalled and we can stop
-			if (y0 != this.y || x0 != this.x) {
-				this.scroll();
-			} else if (!this.dragging) {
-				// set final values
-				if (this.endX != null) {
-					this.x = this.x0 = this.endX;
-				}
-				if (this.endY != null) {
-					this.y = this.y0 = this.endY;
-				}
+			this.takeBoundarySnapshot();
+		}
+		else {
+			this.discardBoundarySnapshot();
 
-				this.stop();
-				this.scroll();
-				this.doScrollStop();
-
-				this.endX = null;
-				this.endY = null;
+			// alternate fixed-time step strategy:
+			if (this.fixedTime) {
+				t = this.interval;
 			}
-			y0 = this.y;
-			x0 = this.x;
-		});
-		fn();
+		}
+		// consume some t in simulation
+		t = this.simulate(t);
+		// scroll if we have moved, otherwise the animation is stalled and we can stop
+		if (y0 != this.y || x0 != this.x) {
+			this.scroll();
+		} else if (!this.dragging) {
+			// set final values
+			if (this.endX != null) {
+				this.x = this.x0 = this.endX;
+			}
+			if (this.endY != null) {
+				this.y = this.y0 = this.endY;
+			}
+
+			this.stop();
+			this.scroll();
+			this.doScrollStop();
+
+			this.endX = null;
+			this.endY = null;
+		}
+		y0 = this.y;
+		x0 = this.x;
 	},
 
 	/**

--- a/src/touch.js
+++ b/src/touch.js
@@ -4,14 +4,13 @@ var
 	utils = require('./utils'),
 	gesture = require('./gesture'),
 	dispatcher = require('./dispatcher'),
-	platform = require('./platform');
+	platform = require('./platform'),
+	animation = require('./animation');
 
 var
 	Dom = require('./dom'),
 	Job = require('./job'),
 	Control = require('./Control');
-
-var rAF = global.requestAnimationFrame;
 
 function dispatch (e) {
 	return dispatcher.dispatch(e);
@@ -82,7 +81,7 @@ Dom.requiresWindow(function() {
 			Job.stop('resetGestureEvents');
 
 			if (this.clientYBefore != e.changedTouches[0].clientY) {
-				rAF(Control.applyStyleToDom);
+				animation.requestAnimationFrame(Control.applyStyleToDom);
 				this.clientYBefore = e.changedTouches[0].clientY;
 			}
 

--- a/src/touch.js
+++ b/src/touch.js
@@ -8,7 +8,10 @@ var
 
 var
 	Dom = require('./dom'),
-	Job = require('./job');
+	Job = require('./job'),
+	Control = require('./Control');
+
+var rAF = global.requestAnimationFrame;
 
 function dispatch (e) {
 	return dispatcher.dispatch(e);
@@ -21,7 +24,7 @@ Dom.requiresWindow(function() {
 
 	/**
 	* Add touch-specific gesture feature
-	* 
+	*
 	* @private
 	*/
 
@@ -29,7 +32,7 @@ Dom.requiresWindow(function() {
 	* @private
 	*/
 	var oldevents = gesture.events;
-	
+
 	/**
 	* @private
 	*/
@@ -39,7 +42,7 @@ Dom.requiresWindow(function() {
 		gesture.events = touchGesture;
 		gesture.events.touchstart(e);
 	};
-	
+
 	/**
 	* @private
 	*/
@@ -49,6 +52,11 @@ Dom.requiresWindow(function() {
 		* @private
 		*/
 		_touchCount: 0,
+
+		/**
+		* @private
+		*/
+		clientYBefore: -1,
 
 		/**
 		* @private
@@ -72,6 +80,12 @@ Dom.requiresWindow(function() {
 		*/
 		touchmove: function (e) {
 			Job.stop('resetGestureEvents');
+
+			if (this.clientYBefore != e.changedTouches[0].clientY) {
+				rAF(Control.applyStyleToDom);
+				this.clientYBefore = e.changedTouches[0].clientY;
+			}
+
 			// NOTE: allow user to supply a node to exclude from event
 			// target finding via the drag event.
 			var de = gesture.drag.dragEvent;
@@ -121,10 +135,10 @@ Dom.requiresWindow(function() {
 		},
 
 		/**
-		* Use `mouseup()` after touches are done to reset {@glossary event} handling 
+		* Use `mouseup()` after touches are done to reset {@glossary event} handling
 		* back to default; this works as long as no one did a `preventDefault()` on
 		* the touch events.
-		* 
+		*
 		* @private
 		*/
 		mouseup: function () {
@@ -170,9 +184,9 @@ Dom.requiresWindow(function() {
 		},
 
 		/**
-		* NOTE: Will find only 1 element under the touch and will fail if an element is 
+		* NOTE: Will find only 1 element under the touch and will fail if an element is
 		* positioned outside the bounding box of its parent.
-		* 
+		*
 		* @private
 		*/
 		findTargetTraverse: function (node, x, y) {
@@ -223,6 +237,6 @@ Dom.requiresWindow(function() {
 			}
 		}
 	};
-	
+
 	touchGesture.connect();
 });


### PR DESCRIPTION
Issue
------
: We need to reduce JS execution time to handle touchmove and to update DOM element while scrolling a list.
 
Fix
------
: I applied rAF into not enyo/ScrollMath.animate.fn() but enyo/Control.applyStyle() and called enyo/ScrollMath.animate.fn() directly when handing "touchmove" event.

Enyo-DCO-1.1-Signed-off-by: YB Sung <yb.sung@lge.com>