### PR TITLE
Fixes ENYO-3208

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -328,8 +328,7 @@ var dom = module.exports = {
 	* @public
 	*/
 	removeNode: function (node) {
-		if (node.remove) node.remove();
-		else if (node.parentNode) node.parentNode.removeChild(node);
+		if (node.parentNode) node.parentNode.removeChild(node);
 	},
 
 	/**


### PR DESCRIPTION
IE11 doesn't support node.remove() and the test for it fails for
<select> elements which do have a remove method for another purpose.
Since remove() is effectively just sugar, we remove it to ensure
compatibility.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)