### PR TITLE
ENYO-3222: Adding support for cancelAnimationFrame.

### DIFF
--- a/src/Animator.js
+++ b/src/Animator.js
@@ -59,13 +59,13 @@ var
 * to [endValue]{@link module:enyo/Animator~Animator#endValue} during the animation, based on the
 * [function]{@glossary Function} referenced by the
 * [easingFunction]{@link module:enyo/Animator~Animator#easingFunction} property.
-* 
+*
 * Event handlers may be specified as functions. If specified, the handler function will
 * be used to handle the event directly, without sending the event to its
 * [owner]{@link module:enyo/Component~Component#owner} or [bubbling]{@link module:enyo/Component~Component#bubble} it.
 * The [context]{@link module:enyo/Animator~Animator#context} property may be used to call the supplied
 * event functions in a particular `this` context.
-* 
+*
 * During animation, an {@link module:enyo/jobs} priority of 5 is registered to defer low priority
 * tasks.
 *
@@ -79,14 +79,14 @@ module.exports = kind(
 	/**
 	* A context in which to run the specified {@glossary event} handlers. If this is
 	* not specified or is falsy, then the [global object]{@glossary global} is used.
-	* 
+	*
 	* @name context
 	* @type {Object}
 	* @default undefined
 	* @memberOf module:enyo/Animator~Animator.prototype
 	* @public
 	*/
-		
+
 	name: 'enyo.Animator',
 
 	/**
@@ -97,10 +97,10 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	published: 
+	published:
 		/** @lends module:enyo/Animator~Animator.prototype */ {
-		
-		/** 
+
+		/**
 		* Animation duration in milliseconds
 		*
 		* @type {Number}
@@ -109,7 +109,7 @@ module.exports = kind(
 		*/
 		duration: 350,
 
-		/** 
+		/**
 		* Value of [value]{@link module:enyo/Animator~Animator#value} property at the beginning of an animation.
 		*
 		* @type {Number}
@@ -118,7 +118,7 @@ module.exports = kind(
 		*/
 		startValue: 0,
 
-		/** 
+		/**
 		* Value of [value]{@link module:enyo/Animator~Animator#value} property at the end of an animation.
 		*
 		* @type {Number}
@@ -127,8 +127,8 @@ module.exports = kind(
 		*/
 		endValue: 1,
 
-		/** 
-		* Node that must be visible in order for the animation to continue. This reference is 
+		/**
+		* Node that must be visible in order for the animation to continue. This reference is
 		* destroyed when the animation ceases.
 		*
 		* @type {Object}
@@ -137,17 +137,17 @@ module.exports = kind(
 		*/
 		node: null,
 
-		/** 
-		* [Function]{@glossary Function} that determines how the animation progresses from 
+		/**
+		* [Function]{@glossary Function} that determines how the animation progresses from
 		* [startValue]{@link module:enyo/Animator~Animator#startValue} to [endValue]{@link module:enyo/Animator~Animator#endValue}.
-		* 
+		*
 		* @type {Function}
 		* @default module:enyo/easing~easing.cubicOut
 		* @public
 		*/
 		easingFunction: animation.easing.cubicOut
 	},
-	
+
 	/*
 	* @private
 	*/
@@ -179,7 +179,7 @@ module.exports = kind(
 		};
 	}),
 
-	/** 
+	/**
 	* Plays the animation.
 	*
 	* @param {Object} props - As a convenience, this [hash]{@glossary Object} will be mixed
@@ -203,7 +203,7 @@ module.exports = kind(
 		return this;
 	},
 
-	/** 
+	/**
 	* Stops the animation and fires the associated {@glossary event}.
 	*
 	* @fires module:enyo/Animator~Animator#onStop
@@ -235,9 +235,9 @@ module.exports = kind(
 		return this;
 	},
 
-	/** 
+	/**
 	* Reverses the direction of a running animation.
-	* 
+	*
 	* @return {this} The callee for chaining.
 	* @public
 	*/
@@ -277,7 +277,7 @@ module.exports = kind(
 	* @private
 	*/
 	cancel: function () {
-		animation.cancelRequestAnimationFrame(this.job);
+		animation.cancelAnimationFrame(this.job);
 		this.node = null;
 		this.job = null;
 

--- a/src/Loop.js
+++ b/src/Loop.js
@@ -9,7 +9,8 @@ var
 	kind = require('./kind');
 
 var
-	CoreObject = require('./CoreObject');
+	CoreObject = require('./CoreObject'),
+	animation = require('./animation');
 
 module.exports = kind.singleton({
 	/** @lends module:enyo/Loop */
@@ -44,7 +45,7 @@ module.exports = kind.singleton({
 	* @private
 	*/
 	trigger: function () {
-		global.requestAnimationFrame(this.lcb || this.initLoopCallback());
+		animation.requestAnimationFrame(this.lcb || this.initLoopCallback());
 	},
 	/**
 	* @private

--- a/src/ScrollMath.js
+++ b/src/ScrollMath.js
@@ -19,7 +19,7 @@ var
 *
 * @event module:enyo/ScrollMath~ScrollMath#onScrollStart
 * @type {Object}
-* @property {Object} sender - The [component]{@link module:enyo/Component~Component} that most recently 
+* @property {Object} sender - The [component]{@link module:enyo/Component~Component} that most recently
 *	propagated the {@glossary event}.
 * @property {module:enyo/Scroller~Scroller~ScrollEvent} event - An [object]{@glossary Object} containing
 *	event information.
@@ -31,7 +31,7 @@ var
 *
 * @event module:enyo/ScrollMath~ScrollMath#onScroll
 * @type {Object}
-* @property {Object} sender - The [component]{@link module:enyo/Component~Component} that most recently 
+* @property {Object} sender - The [component]{@link module:enyo/Component~Component} that most recently
 *	propagated the {@glossary event}.
 * @property {module:enyo/Scroller~Scroller~ScrollEvent} event - An [object]{@glossary Object} containing
 *	event information.
@@ -43,7 +43,7 @@ var
 *
 * @event module:enyo/ScrollMath~ScrollMath#onScrollStop
 * @type {Object}
-* @property {Object} sender - The [component]{@link module:enyo/Component~Component} that most recently 
+* @property {Object} sender - The [component]{@link module:enyo/Component~Component} that most recently
 *	propagated the {@glossary event}.
 * @property {module:enyo/Scroller~Scroller~ScrollEvent} event - An [object]{@glossary Object} containing
 *	event information.
@@ -54,7 +54,7 @@ var
 * {@link module:enyo/ScrollMath~ScrollMath} implements a scrolling dynamics simulation. It is a
 * helper [kind]{@glossary kind} used by other [scroller]{@link module:enyo/Scroller~Scroller}
 * kinds, such as {@link module:enyo/TouchScrollStrategy~TouchScrollStrategy}.
-* 
+*
 * `enyo/ScrollMath` is not typically created in application code.
 *
 * @class ScrollMath
@@ -73,10 +73,10 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	published: 
+	published:
 		/** @lends module:enyo/ScrollMath~ScrollMath.prototype */ {
 
-		/** 
+		/**
 		* Set to `true` to enable vertical scrolling.
 		*
 		* @type {Boolean}
@@ -85,7 +85,7 @@ module.exports = kind(
 		*/
 		vertical: true,
 
-		/** 
+		/**
 		* Set to `true` to enable horizontal scrolling.
 		*
 		* @type {Boolean}
@@ -106,95 +106,95 @@ module.exports = kind(
 	},
 
 	/**
-	* "Spring" damping returns the scroll position to a value inside the boundaries. Lower 
+	* "Spring" damping returns the scroll position to a value inside the boundaries. Lower
 	* values provide faster snapback.
 	*
 	* @private
 	*/
 	kSpringDamping: 0.93,
 
-	/** 
-	* "Drag" damping resists dragging the scroll position beyond the boundaries. Lower values 
+	/**
+	* "Drag" damping resists dragging the scroll position beyond the boundaries. Lower values
 	* provide more resistance.
 	*
 	* @private
 	*/
 	kDragDamping: 0.5,
-	
-	/** 
+
+	/**
 	* "Friction" damping reduces momentum over time. Lower values provide more friction.
 	*
 	* @private
 	*/
 	kFrictionDamping: 0.97,
 
-	/** 
-	* Additional "friction" damping applied when momentum carries the viewport into overscroll. 
+	/**
+	* Additional "friction" damping applied when momentum carries the viewport into overscroll.
 	* Lower values provide more friction.
 	*
 	* @private
 	*/
 	kSnapFriction: 0.9,
-	
-	/** 
+
+	/**
 	* Scalar applied to `flick` event velocity.
 	*
 	* @private
 	*/
 	kFlickScalar: 15,
 
-	/** 
-	* Limits the maximum allowable flick. On Android > 2, we limit this to prevent compositing 
+	/**
+	* Limits the maximum allowable flick. On Android > 2, we limit this to prevent compositing
 	* artifacts.
 	*
 	* @private
 	*/
 	kMaxFlick: platform.android > 2 ? 2 : 1e9,
-	
-	/** 
-	* The value used in [friction()]{@link module:enyo/ScrollMath~ScrollMath#friction} to determine if the delta 
+
+	/**
+	* The value used in [friction()]{@link module:enyo/ScrollMath~ScrollMath#friction} to determine if the delta
 	* (e.g., y - y0) is close enough to zero to consider as zero.
 	*
 	* @private
 	*/
 	kFrictionEpsilon: platform.webos >= 4 ? 1e-1 : 1e-2,
-	
-	/** 
+
+	/**
 	* Top snap boundary, generally `0`.
 	*
 	* @private
 	*/
 	topBoundary: 0,
-	
-	/** 
+
+	/**
 	* Right snap boundary, generally `(viewport width - content width)`.
 	*
 	* @private
 	*/
 	rightBoundary: 0,
-	
-	/** 
+
+	/**
 	* Bottom snap boundary, generally `(viewport height - content height)`.
 	*
 	* @private
 	*/
 	bottomBoundary: 0,
-	
-	/** 
+
+	/**
 	* Left snap boundary, generally `0`.
 	*
 	* @private
 	*/
 	leftBoundary: 0,
-	
-	/** 
+
+	/**
 	* Animation time step.
 	*
 	* @private
 	*/
 	interval: 20,
-	
-	/** 
+
+	/**
 	* Flag to enable frame-based animation; if `false`, time-based animation is used.
 	*
 	* @private
@@ -267,7 +267,7 @@ module.exports = kind(
 	},
 
 	/**
-	* Boundary damping function. Returns damped `value` based on `coeff` on one side of 
+	* Boundary damping function. Returns damped `value` based on `coeff` on one side of
 	* `origin`.
 	*
 	* @private
@@ -289,7 +289,7 @@ module.exports = kind(
 	},
 
 	/**
-	* Dual-boundary damping function. Returns damped `value` based on `coeff` when exceeding 
+	* Dual-boundary damping function. Returns damped `value` based on `coeff` when exceeding
 	* either boundary.
 	*
 	* @private
@@ -334,7 +334,7 @@ module.exports = kind(
 		this[ex] = this[ex0] + c * dp;
 	},
 
-	/** 
+	/**
 	* One unit of time for simulation.
 	*
 	* @private
@@ -466,7 +466,7 @@ module.exports = kind(
 		});
 		this.job = animation.requestAnimationFrame(fn);
 	},
-	
+
 	/**
 	* @private
 	*/
@@ -483,7 +483,7 @@ module.exports = kind(
 	stop: function (fire) {
 		var job = this.job;
 		if (job) {
-			this.job = animation.cancelRequestAnimationFrame(job);
+			this.job = animation.cancelAnimationFrame(job);
 		}
 		if (fire) {
 			this.doScrollStop();
@@ -533,7 +533,7 @@ module.exports = kind(
 		if (this.dragging) {
 			v = this.canScrollY();
 			h = this.canScrollX();
-		
+
 			dy = v ? e.pageY - this.my : 0;
 			this.uy = dy + this.py;
 			// provides resistance against dragging into overscroll
@@ -643,7 +643,7 @@ module.exports = kind(
 			dX = dY;
 			dY = 0;
 		}
-		
+
 		if (dY && canY) {
 			tY = -(refY + (dY * m));
 			shouldScroll = true;
@@ -670,7 +670,7 @@ module.exports = kind(
 	// NOTE: Yip/Orvell method for determining scroller instantaneous velocity
 	// FIXME: incorrect if called when scroller is in overscroll region
 	// because does not account for additional overscroll damping.
-	
+
 	/**
 	* Scrolls to the specified position.
 	*
@@ -754,7 +754,7 @@ module.exports = kind(
 	setScrollPosition: function (pos) {
 		this.setScrollY(pos);
 	},
-	
+
 	canScrollX: function() {
 		return this.horizontal && this.rightBoundary < 0;
 	},
@@ -764,9 +764,9 @@ module.exports = kind(
 	},
 
 
-	/** 
+	/**
 	* Determines whether or not the [scroller]{@link module:enyo/Scroller~Scroller} is actively moving.
-	* 
+	*
 	* @return {Boolean} `true` if actively moving; otherwise, `false`.
 	* @private
 	*/
@@ -774,9 +774,9 @@ module.exports = kind(
 		return Boolean(this.job);
 	},
 
-	/** 
+	/**
 	* Determines whether or not the [scroller]{@link module:enyo/Scroller~Scroller} is in overscroll.
-	* 
+	*
 	* @return {Boolean} `true` if in overscroll; otherwise, `false`.
 	* @private
 	*/

--- a/src/ViewManager/ViewManager.js
+++ b/src/ViewManager/ViewManager.js
@@ -93,8 +93,6 @@
 * @public
 */
 
-var rAF = window.requestAnimationFrame;
-
 var
 	animation = require('../animation'),
 	kind = require('../kind'),

--- a/src/animation.js
+++ b/src/animation.js
@@ -9,18 +9,21 @@ var
 	platform = require('./platform'),
 	utils = require('./utils');
 
-var ms = Math.round(1000/60);
-var prefix = ['webkit', 'moz', 'ms', 'o', ''];
-var r = 'requestAnimationFrame';
-var c = 'cancel' + utils.cap(r);
+var ms = Math.round(1000/60),
+	prefix = ['', 'webkit', 'moz', 'ms', 'o'],
+	rAF = 'requestAnimationFrame',
+	cRAF = 'cancelRequestAnimationFrame',
+	cAF = 'cancelAnimationFrame',
+	i, pl, p, wcRAF, wrAF, wcAF,
+	_requestFrame, _cancelFrame, cancelFrame;
 
 /*
 * Fallback on setTimeout
 *
 * @private
 */
-var _requestFrame = function(inCallback) {
-	return global.setTimeout(inCallback, ms);
+_requestFrame = function(callback) {
+	return global.setTimeout(callback, ms);
 };
 
 /*
@@ -28,23 +31,26 @@ var _requestFrame = function(inCallback) {
 *
 * @private
 */
-var _cancelFrame = function(inId) {
-	return global.clearTimeout(inId);
+_cancelFrame = function(id) {
+	return global.clearTimeout(id);
 };
 
-for (var i = 0, pl = prefix.length, p, wc, wr; (p = prefix[i]) || i < pl; i++) {
+for (i = 0, pl = prefix.length; (p = prefix[i]) || i < pl; i++) {
 	// if we're on ios 6 just use setTimeout, requestAnimationFrame has some kinks
 	if (platform.ios === 6) {
 		break;
 	}
 
 	// if prefixed, becomes Request and Cancel
-	wc = p ? (p + utils.cap(c)) : c;
-	wr = p ? (p + utils.cap(r)) : r;
+	wrAF = p ? (p + utils.cap(rAF)) : rAF;
+	wcRAF = p ? (p + utils.cap(cRAF)) : cRAF;
+	wcAF = p ? (p + utils.cap(cAF)) : cAF;
+
 	// Test for cancelRequestAnimationFrame, because some browsers (Firefix 4-10) have a request without a cancel
-	if (global[wc]) {
-		_cancelFrame = global[wc];
-		_requestFrame = global[wr];
+	cancelFrame = global[wcAF] || global[wcRAF];
+	if (cancelFrame) {
+		_cancelFrame = cancelFrame;
+		_requestFrame = global[wrAF];
 		if (p == 'webkit') {
 			/*
 				Note: In Chrome, the first return value of webkitRequestAnimationFrame is 0.
@@ -76,10 +82,21 @@ exports.requestAnimationFrame = function(callback, node) {
 /**
 * Cancels a requested animation callback with the specified id.
 *
+* @param {Number} id - The identifier of an animation request we wish to cancel.
+* @deprecated since 2.7.0
 * @public
 */
-exports.cancelRequestAnimationFrame = function(inId) {
-	return _cancelFrame(inId);
+exports.cancelRequestAnimationFrame = function(id) {
+	return _cancelFrame(id);
+};
+/**
+* Cancels a requested animation callback with the specified id.
+*
+* @param {Number} id - The identifier of an animation request we wish to cancel.
+* @public
+*/
+exports.cancelAnimationFrame = function(id) {
+	return _cancelFrame(id);
 };
 
 /**


### PR DESCRIPTION
### Issue
Web engines such as Mozilla do not support `cancelRequestAnimationFrame`, and instead support the more-standard `cancelAnimationFrame`.

### Fix
Aside from some minor refactoring, we have provided support for either `cancelRequestAnimationFrame` or `cancelAnimationFrame` as older WebKit only supported `cancelRequestAnimationFrame`. Additionally, we have updated our animation API to provide a `cancelAnimationFrame` method and have deprecated the previous `cancelRequestAnimationFrame` method, in the name of consistency with the standard animation API. Also, considered having the deprecated `cancelRequestAnimationFrame` method call `cancelAnimationFrame`, but decided against it as the method effectively calls a single method itself.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>