### PR TITLE
Fixes ENYO-3204 adds guard for setting the value of a select box in <= IE11

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -164,6 +164,25 @@ module.exports = kind(
 	},
 
 	/**
+	* Updates the `selected` option matching the current value. If the option doesn't have a value,
+	* it will match its content instead.
+	*
+	* @private
+	*/
+	selectOptionByValue: function () {
+		var i, controls, l, c;
+
+		for (i = 0, controls = this.getControls(), l = controls.length; i < l; i++) {
+			c = controls[i];
+			// support 
+			if (c.value ? c.value === this.value : c.content === this.value) {
+				if (i !== this.selected) this.set('selected', i);
+				break;
+			}
+		}
+	},
+
+	/**
 	* @private
 	*/
 	selectedChanged: function () {
@@ -175,8 +194,15 @@ module.exports = kind(
 	* @private
 	*/
 	valueChanged: function () {
-		this.setNodeProperty('value', this.value);
-		this.updateSelectedFromNode();
+		// IE will clear selectedIndex when setting the value directly on the node so instead we
+		// iterate the children, find the matching value, and update selected if necessary.
+		if (platform.ie || platform.edge) {
+			this.selectOptionByValue();
+		}
+		else {
+			this.setNodeProperty('value', this.value);
+			this.updateSelectedFromNode();
+		}
 	},
 
 	/**

--- a/test/tests/Select.js
+++ b/test/tests/Select.js
@@ -2,6 +2,7 @@ var
 	kind = require('enyo/kind');
 
 var
+	Control = require('enyo/Control'),
 	Select = require('enyo/Select');
 
 describe('Select', function () {
@@ -49,6 +50,18 @@ describe('Select', function () {
 			});
 
 			it ('should have the value "four" at render', function () {
+				expect(testSelect.get('value')).to.equal('four');
+			});
+		});
+
+		describe('property interaction', function () {
+			it ('should update the value when selected is changed', function () {
+				testSelect.set('value', 'two')
+				expect(testSelect.get('selected')).to.equal(1);
+			});
+
+			it ('should update selected when the value is changed', function () {
+				testSelect.set('selected', 3)
 				expect(testSelect.get('value')).to.equal('four');
 			});
 		});


### PR DESCRIPTION
Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)