### PR TITLE
PLAT-16999: Avoid to tear down and regenerate page DOM elements while scrolling a list

### DIFF
--- a/src/HTMLStringDelegate.js
+++ b/src/HTMLStringDelegate.js
@@ -121,7 +121,7 @@ module.exports = {
 	*/
 	renderContent: function (control) {
 		if (control.name === "page1" || control.name ==="page2") {
-			if (!control.generated || (control.generated && control.node.textContent == "")) {
+			if (!control.generated || (control.generated && control.node.textContent === "")) {
 				if (control.generated) this.teardownChildren(control);
 				if (control.hasNode()) control.node.innerHTML = this.generateInnerHtml(control);
 			} else {

--- a/src/HTMLStringDelegate.js
+++ b/src/HTMLStringDelegate.js
@@ -16,7 +16,7 @@ var selfClosing = {img: 1, hr: 1, br: 1, area: 1, base: 1, basefont: 1, input: 1
 * @public
 */
 module.exports = {
-	
+
 	/**
 	* @private
 	*/
@@ -30,34 +30,34 @@ module.exports = {
 			break;
 		}
 	},
-	
+
 	/**
 	* @private
 	*/
 	render: function (control) {
 		if (control.parent) {
 			control.parent.beforeChildRender(control);
-			
+
 			if (!control.parent.generated) return;
 			if (control.tag === null) return control.parent.render();
 		}
-		
+
 		if (!control.hasNode()) this.renderNode(control);
 		if (control.hasNode()) {
 			this.renderDom(control);
 			if (control.generated) control.rendered();
 		}
 	},
-	
+
 	/**
 	* @private
 	*/
 	renderInto: function (control, parentNode) {
 		parentNode.innerHTML = this.generateHtml(control);
-		
+
 		if (control.generated) control.rendered();
 	},
-	
+
 	/**
 	* @private
 	*/
@@ -67,7 +67,7 @@ module.exports = {
 		control.addNodeToParent();
 		control.set('generated', true);
 	},
-	
+
 	/**
 	* @private
 	*/
@@ -76,13 +76,13 @@ module.exports = {
 		this.renderStyles(control);
 		this.renderContent(control);
 	},
-	
+
 	/**
 	* @private
 	*/
 	renderStyles: function (control) {
 		var style = control.style;
-		
+
 		// we can safely do this knowing it will synchronize properly without a double
 		// set in the DOM because we're flagging the internal property
 		if (control.hasNode()) {
@@ -94,7 +94,7 @@ module.exports = {
 			control.set('style', style);
 		}
 	},
-	
+
 	/**
 	* @private
 	*/
@@ -103,7 +103,7 @@ module.exports = {
 			node = control.hasNode(),
 			key,
 			val;
-		
+
 		if (node) {
 			for (key in attrs) {
 				val = attrs[key];
@@ -115,22 +115,31 @@ module.exports = {
 			}
 		}
 	},
-	
+
 	/**
 	* @private
 	*/
 	renderContent: function (control) {
-		if (control.generated) this.teardownChildren(control);
-		if (control.hasNode()) control.node.innerHTML = this.generateInnerHtml(control);
+		if (control.name === "page1" || control.name ==="page2") {
+			if (!control.generated || (control.generated && control.node.textContent == "")) {
+				if (control.generated) this.teardownChildren(control);
+				if (control.hasNode()) control.node.innerHTML = this.generateInnerHtml(control);
+			} else {
+				// Nothing
+			}
+		} else {
+			if (control.generated) this.teardownChildren(control);
+			if (control.hasNode()) control.node.innerHTML = this.generateInnerHtml(control);
+		}
 	},
-	
+
 	/**
 	* @private
 	*/
 	generateHtml: function (control) {
 		var content,
 			html;
-		
+
 		if (control.canGenerate === false) {
 			return '';
 		}
@@ -149,7 +158,7 @@ module.exports = {
 		control.set('generated', true);
 		return html;
 	},
-	
+
 	/**
 	* @private
 	*/
@@ -158,14 +167,14 @@ module.exports = {
 		if (!control.tagsValid) this.prepareTags(control);
 		return control._openTag + content + control._closeTag;
 	},
-	
+
 	/**
 	* @private
 	*/
 	generateInnerHtml: function (control) {
 		var allowHtml = control.allowHtml,
 			content;
-		
+
 		// flow can alter the way that html content is rendered inside
 		// the container regardless of whether there are children.
 		control.flow();
@@ -175,7 +184,7 @@ module.exports = {
 			return allowHtml ? content : Dom.escape(content);
 		}
 	},
-	
+
 	/**
 	* @private
 	*/
@@ -184,21 +193,21 @@ module.exports = {
 			html = '',
 			i = 0,
 			delegate;
-		
+
 		for (; (child = control.children[i]); ++i) {
 			delegate = child.renderDelegate || this;
 			html += delegate.generateHtml(child);
 		}
-		
+
 		return html;
 	},
-	
+
 	/**
 	* @private
 	*/
 	prepareTags: function (control) {
 		var html = '';
-		
+
 		// open tag
 		html += '<' + control.tag + (control.style ? ' style="' + control.style + '"' : '');
 		html += this.attributesToHtml(control.attributes);
@@ -209,10 +218,10 @@ module.exports = {
 			control._openTag = html + '>';
 			control._closeTag = '</' + control.tag + '>';
 		}
-		
+
 		control.tagsValid = true;
 	},
-	
+
 	/**
 	* @private
 	*/
@@ -220,26 +229,26 @@ module.exports = {
 		var key,
 			val,
 			html = '';
-			
+
 		for (key in attrs) {
 			val = attrs[key];
 			if (val != null && val !== false && val !== '') {
 				html += ' ' + key + '="' + this.escapeAttribute(val) + '"';
 			}
 		}
-		
+
 		return html;
 	},
-	
+
 	/**
 	* @private
 	*/
 	escapeAttribute: function (text) {
 		if (typeof text != 'string') return text;
-	
+
 		return String(text).replace(/&/g, '&amp;').replace(/\"/g, '&quot;');
 	},
-	
+
 	/**
 	* @private
 	*/
@@ -250,11 +259,11 @@ module.exports = {
 			}
 			this.teardownChildren(control, cache);
 		}
-			
+
 		control.node = null;
 		control.set('generated', false);
 	},
-	
+
 	/**
 	* @private
 	*/

--- a/src/VerticalDelegate.js
+++ b/src/VerticalDelegate.js
@@ -180,7 +180,7 @@ module.exports = {
 			view = (page.children[i - page.start] || list.createComponent({}));
 			// disable notifications until all properties to be updated
 			// have been
-			view.teardownRender();
+			// view.teardownRender();
 			view.stopNotifications();
 			view.set('model', data.at(i));
 			view.set('index', i);


### PR DESCRIPTION
Issue
------
: When swapping pages while scrolling a list, it took long time to tear down and regenerate page DOM elements.
: This is POC
 
Fix
------
: I avoided to tear down and regenerate page DOM elements while scrolling a list.

Enyo-DCO-1.1-Signed-off-by: YB Sung <yb.sung@lge.com>