### PR TITLE
ENYO-3210: Added better support for trackpad scrolling in Firefox.

### DIFF
--- a/src/gesture/gesture.js
+++ b/src/gesture/gesture.js
@@ -14,7 +14,6 @@ var
 	touchGestures = require('./touchGestures'),
 	gestureUtil = require('./util');
 
-
 /**
 * Enyo supports a set of normalized events that work similarly across all supported platforms.
 * These events are provided so that users can write a single set of event handlers for
@@ -84,7 +83,7 @@ var gesture = module.exports = {
 
 		// We have added some logic to synchronize up and down events in certain scenarios (i.e.
 		// clicking multiple buttons with a mouse) and to generally guard against any potential
-		// asymmetry, but a full solution would be to maintain a map of up/down events as an 
+		// asymmetry, but a full solution would be to maintain a map of up/down events as an
 		// ideal solution, for future work.
 		e._tapPrevented = this.downEvent && this.downEvent._tapPrevented && this.downEvent.which == e.which;
 		e.preventTap = function() {
@@ -259,7 +258,7 @@ var gesture = module.exports = {
 	/**
 	* @todo I'd rather refine the public API of gesture rather than simply forwarding the internal
 	*   drag module but this will work in the interim. - ryanjduffy
-	* 
+	*
 	* Known Consumers:
 	*  - Spotlight.onAcceleratedKey - (prepare|begin|end)Hold()
 	*  - Moonstone - configureHoldPulse()
@@ -334,13 +333,18 @@ module.exports.events = {
 dom.requiresWindow(function() {
 	if (document.addEventListener) {
 		document.addEventListener('DOMMouseScroll', function(inEvent) {
-			var e = utils.clone(inEvent);
+			var e = utils.clone(inEvent),
+				isVertical = e.VERTICAL_AXIS == e.axis,
+				wheelDelta;
 			e.preventDefault = function() {
 				inEvent.preventDefault();
 			};
 			e.type = 'mousewheel';
-			var p = e.VERTICAL_AXIS == e.axis ? 'wheelDeltaY' : 'wheelDeltaX';
-			e[p] =  e.detail * -40;
+
+			wheelDelta = e.detail * -40;
+			e.wheelDeltaY = isVertical ? wheelDelta : 0;
+			e.wheelDeltaX = isVertical ? 0 : wheelDelta;
+
 			dispatcher.dispatch(e);
 		}, false);
 	}


### PR DESCRIPTION
### Issue
For environments where we are using a trackpad for scrolling, as opposed to a standard scroll wheel, there are issues with scrolling in Firefox, specifically when using a non-native scroller (i.e. Moonstone scroller, which relies on the value of the `wheelDeltaY` event property).

### Fix
In short, handling mouse wheel events is broken and incomplete as a web standard, currently.

The `mousewheel` event we are currently handling is deprecated and not supported at all in Firefox. I had initially implemented a version of the cross-browser mouse wheel handling as recommended by MDN (https://developer.mozilla.org/en-US/docs/Web/Events/wheel#Listening_to_this_event_across_browser), but the current, standard `wheel` event does not handle scroll inversion and provides no way to detect or account for this case. 

Our existing technique for handling Firefox scrolling is to listen for the `DomMouseWheel` event, but for the case of trackpads, because it is difficult to scroll exclusively in a single axis, scrolling in both the x and the y axes are encapsulated in separate event instances. This causes problems with Moonstone's scroll strategy, as this results in math calculations involving an `undefined` `wheelDeltaY` value in some cases (these cases cause fatal errors that cannot be recovered from). There was also an issue where using the trackpad would result in significant pauses and hitches with scrolling. This was resolved by fixing our rAF support for Firefox in https://github.com/enyojs/enyo/pull/1414.

To resolve the outstanding issue, I have made a tweak to the Firefox-specific scroll code in `gesture` to normalize any `undefined` values to 0. This allows horizontal scrolling and cases where we have scrolling in both axes to work properly. Adding guard code to the `mousewheel` handler in the strategy would not suffice for these cases, and this has the added benefit of encapsulating the fix within the Firefox-specific handler.

### Notes
I would be very open to hearing about any alternatives I may have missed. That being said, I feel that this change is not necessarily high-risk, as all of the logic is encapsulated in a handler for a Firefox-specific event.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>