### PR TITLE
ENYO-3230: Do not bubble up onActivate event on rendered

### DIFF
--- a/src/Checkbox/Checkbox.js
+++ b/src/Checkbox/Checkbox.js
@@ -107,9 +107,6 @@ module.exports = kind(
 	rendered: kind.inherit(function (sup) {
 		return function() {
 			sup.apply(this, arguments);
-			if (this.active) {
-				this.activeChanged();
-			}
 			this.checkedChanged();
 		};
 	}),


### PR DESCRIPTION
Issue
---
For every `active` checkboxes, it fires `onActivate` event on rendered. This can cause a problem as certain controls handles `onActivate` and may result in unexpected behaviors.

Fix
---
Do no bubble up `onAcivate` event on rendered.

Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>