### PR TITLE
ENYO-3219: Refresh scroll thresholds when adding / removing models

### DIFF
--- a/src/NewDataList.js
+++ b/src/NewDataList.js
@@ -151,6 +151,7 @@ module.exports = kind({
 		// as long as calculateMetrics() is called only by reset().
 		this.numItems = num;
 	},
+
 	/**
 	* @private
 	*/
@@ -194,6 +195,34 @@ module.exports = kind({
 		}
 		this.positionChildren();
 	},
+
+	/**
+	* @private
+	*/
+	refreshThresholds: function () {
+		var tt = this.threshold;
+
+		if (tt) {
+			var
+				v = (this.direction === 'vertical'),
+				val = v ? this.scrollTop : this.scrollLeft,
+				delta = this.delta,
+				cb = this.cachedBounds ? this.cachedBounds : this._getScrollBounds(),
+				maxVal = v ? cb.maxTop : cb.maxLeft,
+				d2x = this.dim2extent,
+				head = Math.floor(this.overhang / 2),
+				fvg = Math.floor(val / delta),
+				fg = Math.max(0, fvg - head),
+				f = d2x * fg,
+				nPos = fvg * delta;
+
+			tt.max = Math.min(maxVal, nPos + delta),
+			tt.min = Math.max(0, nPos);
+
+			this.first = f;
+		}
+	},
+
 	/**
 	* @private
 	*/
@@ -326,6 +355,7 @@ module.exports = kind({
 	modelsAdded: kind.inherit(function (sup) {
 		return function() {
 			this.calcBoundaries();
+			this.refreshThresholds();
 			sup.apply(this, arguments);
 		};
 	}),
@@ -336,6 +366,7 @@ module.exports = kind({
 	modelsRemoved: kind.inherit(function (sup) {
 		return function() {
 			this.calcBoundaries();
+			this.refreshThresholds();
 			sup.apply(this, arguments);
 		};
 	}),


### PR DESCRIPTION
If a list is scrolled to the end and the size of the collection
changes, we need to recalculate the scroll thresholds and possibly
adjust the range of items to be rendered.

Until now, we've only adjusted thresholds in the `scroll()` method,
based on the direction and distance we've scrolled. In this fix, we
add a new method, `refreshThresholds()`, which recalculates the
thresholds based on the current scroll value. We call the new
method from `modelsAdded()` and `modelsRemoved()` to make sure that
the thresholds and item range are correct after the size of the
collection has changed.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)