### PR TITLE
ENYO-3244: Use strict equality check for content.

### DIFF
--- a/src/Control/Control.js
+++ b/src/Control/Control.js
@@ -1516,7 +1516,7 @@ var Control = module.exports = kind(
 		var was = this.content;
 		this.content = content;
 
-		if (was != content) this.notify('content', was, content);
+		if (was !== content) this.notify('content', was, content);
 
 		return this;
 	},


### PR DESCRIPTION
### Issue
For cases where we are changing the content from one falsy value to another (i.e. from the empty string `''` to `0`), the content does not update due to the equality check.

### Fix
I could not think of any cases where we would want to guard against updating the content when switching from one falsy value to another, so the guard has been changed to a strict equality check.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>