### PR TITLE
ENYO-3333: apply opacity 0 on off screen light panel

### DIFF
--- a/src/LightPanels/LightPanels.less
+++ b/src/LightPanels/LightPanels.less
@@ -95,6 +95,7 @@
 
 		> .offscreen {
 			visibility: hidden;
+			opacity: 0;
 		}
 
 		.enyo-locale-right-to-left & > * {


### PR DESCRIPTION
Issue:
LightPanel is set visibility: hidden; on offscreen panel.
When element like checkbox is have visibility: visible; inside of
panel, then it will be shown even if panel is hidden. In popOnBack
case, check mark shown at the end of transition shortly. But, in
static panels case the check mark will be shown permenently.

Fix:
We apply opacity: 0; also to effectively hide all the children and
also not loosing the ability of blocking event and tap index handle.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi (kunmyon.choi@lge.com)