### PR TITLE
ENYO-3339: Fix video rewinding.

### DIFF
--- a/src/Video.js
+++ b/src/Video.js
@@ -869,7 +869,16 @@ module.exports = kind(
 		;
 
 		this.setCurrentTime(newTime);
-		this.startRewindJob();
+
+		if (newTime > 0) {
+			this.startRewindJob();
+		} else { // continue the previous action (play / pause)
+			if (this.playbackRate < -1) {
+				this.play();
+			} else {
+				this.pause();
+			}
+		}
 	},
 
 	/**


### PR DESCRIPTION
### Issue

When starting a rewind action for an `enyo/Video` control, the rewind job continues indefinitely.
### Fix

We guard against continuing the rewind job if the current time is before the starting position. Additionally, we attempt to preserve the original action (i.e. pause or play) in the case where the rewind job should end. If the playback rate is less than -1 (i.e. -2), that means the user initiated the rewind action while the video was playing; similarly, if the playback rate is greater than -1 (i.e. -1/2), the user initiated the rewind action while the video was paused.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
