### PR TITLE
PLAT-21046: Reduce the time from QPA touch to swap buffer update

### DIFF
--- a/src/ViewManager/ViewManager.js
+++ b/src/ViewManager/ViewManager.js
@@ -386,7 +386,7 @@ var ViewMgr = kind(
 	dragView: null,
 
 	/**
-	 * 
+	 *
 	 *
 	 * @type {Boolean}
 	 */
@@ -978,6 +978,8 @@ var ViewMgr = kind(
 		this.dragView = null;
 		this.dragBounds = this.getBounds();
 
+		this.handleDrag(sender, event);
+
 		return true;
 	},
 
@@ -1099,7 +1101,7 @@ var ViewMgr = kind(
 
 		if (draggable) {
 			this.decorateDragEvent(event);
-			dragging = 
+			dragging =
 				// check direction against orientation to ignore drags that don't apply to this. the
 				// check should only be necessary for the first drag event so it's further guarded
 				// by the special 'start' value of dragging.
@@ -1108,7 +1110,7 @@ var ViewMgr = kind(
 				// Intentionally ignoring draggable mode here so dragView will reference the
 				// becoming-active view even if we are only supporting flick and not drag
 				this.canDrag(event.direction);
-		
+
 			this.set('dragging', dragging);
 		}
 


### PR DESCRIPTION
Issue
------
: To update swapbuffer when dragging a panel in enyo/ViewManager, we need 1 touchstart event and 2 touchmove event ( One for dragstart, the other for drag ) because enyo/ViewManager actually move a panel with "drag" event.
 
Fix
------
: I called "drag" event handler ( enyo/ViewManager.handleDrag) in "dragstart" event handler (enyo/ViewManager.handleDragStart) so that enyo/ViewManager could move a panel with "dragstart" event. 

After fixing, I could reduce the minimum time from QPA touch to swap buffer update.

JIRA  | PLAT-21046 garnet/PanelManagerSample | PLAT-21057 garnet/ContextualPanelSample
------------ | ------------ | -------------
default | 135ms  | 143ms
Call "drag" event handler | 113ms  | 91ms


https://jira2.lgsvl.com/browse/PLAT-21046
https://jira2.lgsvl.com/browse/PLAT-21057

Enyo-DCO-1.1-Signed-off-by: YB Sung <yb.sung@lge.com>