### PR TITLE
PLAT-21885-Fix touch issue with Use Handle

### DIFF
--- a/src/gesture/touchGestures.js
+++ b/src/gesture/touchGestures.js
@@ -57,6 +57,7 @@ module.exports = {
 			var g = this.makeGesture('gesturestart', e, {vector: this.gesture, scale: 1, rotation: 0});
 			dispatcher.dispatch(g);
 		}
+		e.preventDefault();
 	},
 
 	/**


### PR DESCRIPTION
Issue: Use handle doesn't collapse irrespective of no.of touches
Cause: mousedown and touchstart both the events are triggered on tap.
Fix: In the touchstart gesture event trigger mechanism, default event is
prevented as it is unnecessary for touch scenario.
Enyo-DCO-1.1-Signed-off-by: Rajyavardhan Reddy P
rajyavardhan.p@lge.com
