### PR TITLE
ENYO-3382: Add support showing and hiding method to transition support

### DIFF
--- a/src/ShowingTransitionSupport.js
+++ b/src/ShowingTransitionSupport.js
@@ -180,6 +180,20 @@ var ShowingTransitionSupport = {
 	}),
 
 	/**
+	* Clean-up the existing operation.
+	* @private
+	*/
+	set: kind.inherit(function (sup) {
+		return function (path, value, opts) {
+			if (path === 'showing' && this.showingTransitioning && this._showingTransitionJobFn) {
+				this._showingTransitionJobFn();
+				this._showingTransitionJobFn = null;
+			}
+			return sup.apply(this, arguments);
+		};
+	}),
+
+	/**
 	* Overrides the showingChanged handler to add support for transitions at the right times and
 	* places.
 	*
@@ -190,18 +204,10 @@ var ShowingTransitionSupport = {
 		return function (sender, ev) {
 			var args = arguments;
 
+			// Prepare our visual state
+			this.applyStyle('display', null);
+			this.applyStyle('visibility', null);
 			if (this.showing) {
-				if (this.showingTransitioning && this._showingTransitionJobFn) {
-					// When show is called before hide animation is not finished,
-					// ensure that super call with showing false condition called before show.
-					this.showing = false;
-					this._showingTransitionJobFn();
-					this.showing = true;
-					this._showingTransitionJobFn = null;
-				}
-				// Prepare our visual state
-				this.applyStyle('display', null);
-				this.applyStyle('visibility', null);
 				// Reset our state classes, in case we switched mid-stream
 				this.removeClass(this.hidingClass);
 				this.removeClass(this.hiddenClass);
@@ -228,17 +234,6 @@ var ShowingTransitionSupport = {
 					utils.call(this._shownMethodScope, this.shownMethod);	// Run the supplied method.
 				}
 			} else {
-				if (this.showingTransitioning && this._showingTransitionJobFn) {
-					// When hide is called before show animation is not finished,
-					// ensure that super call with showing true condition called before hide.
-					this.showing = true;
-					this._showingTransitionJobFn();
-					this.showing = false;
-					this._showingTransitionJobFn = null;
-				}
-				// Prepare our visual state
-				this.applyStyle('display', null);
-				this.applyStyle('visibility', null);
 				// Reset our state classes, in case we switched mid-stream
 				this.removeClass(this.showingClass);
 				this.removeClass(this.shownClass);

--- a/src/ShowingTransitionSupport.js
+++ b/src/ShowingTransitionSupport.js
@@ -75,6 +75,26 @@ var ShowingTransitionSupport = {
 	hidingDuration: undefined,
 
 	/**
+	* The method to fire at the start of the "showing" transition. This may be name of a method on the
+	* component, or a function.
+	*
+	* @type {String|Function}
+	* @default undefined
+	* @public
+	*/
+	showingMethod: undefined,
+
+	/**
+	* The method to fire at the start of the "hiding" transition. This may be name of a method on the
+	* component, or a function.
+	*
+	* @type {String|Function}
+	* @default undefined
+	* @public
+	*/
+	hidingMethod: undefined,
+
+	/**
 	* The method to fire at the end of the "showing" transition. This may be name of a method on the
 	* component, or a function.
 	*
@@ -145,6 +165,8 @@ var ShowingTransitionSupport = {
 
 			this.showingDuration = (this.showingDuration === undefined) ? null      : this.showingDuration;
 			this.hidingDuration  = (this.hidingDuration  === undefined) ? null      : this.hidingDuration;
+			this.showingMethod   = (this.showingMethod   === undefined) ? null      : this.showingMethod;
+			this.hidingMethod    = (this.hidingMethod    === undefined) ? null      : this.hidingMethod;
 			this.shownMethod     = (this.shownMethod     === undefined) ? null      : this.shownMethod;
 			this.hiddenMethod    = (this.hiddenMethod    === undefined) ? null      : this.hiddenMethod;
 			this.shownClass      = (this.shownClass      === undefined) ? 'shown'   : this.shownClass;
@@ -176,6 +198,7 @@ var ShowingTransitionSupport = {
 				this.removeClass(this.hidingClass);
 				this.removeClass(this.hiddenClass);
 				sup.apply(this, args);
+				utils.call(this, this.showingMethod);	// Run the supplied method.
 				if (this.showingDuration && this.hasNode()) {
 					this.set('showingTransitioning', true);
 					// Start transition: Apply a class and start a timer.
@@ -199,6 +222,7 @@ var ShowingTransitionSupport = {
 				// Reset our state classes, in case we switched mid-stream
 				this.removeClass(this.showingClass);
 				this.removeClass(this.shownClass);
+				utils.call(this, this.hidingMethod);	// Run the supplied method.
 				if (this.hidingDuration && this.hasNode()) {
 					this.set('showingTransitioning', true);
 					this.addClass(this.hidingClass);

--- a/src/ShowingTransitionSupport.js
+++ b/src/ShowingTransitionSupport.js
@@ -6,8 +6,7 @@
 */
 
 var kind = require('enyo/kind'),
-	utils = require('enyo/utils'),
-	Jobs = require('enyo/jobs');
+	utils = require('enyo/utils');
 
 /**
 * The {@link module:enyo/ShowingTransitionSupport~ShowingTransitionSupport} [mixin]{@glossary mixin}


### PR DESCRIPTION
When we apply showingTransitionSupport on control, it is hard to hook
before showing start timing from app side. This is because the showing
changed handler is calling super call when animation ends.

We add showingMethod and hidingMethod api to support this case.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi (kunmyon.choi@lge.com)