### PR TITLE
ENYO-3375: Re-calculate _last when refreshThreshold is executed

### DIFF
--- a/src/NewDataList.js
+++ b/src/NewDataList.js
@@ -197,6 +197,7 @@ module.exports = kind({
 			}
 
 			this.first = f;
+			this._last = Math.min(f + this.numItems, this.collection.length) - 1;
 		}
 	},
 


### PR DESCRIPTION
In guard5way(), we used _last value as a limit condition.
However, _last value wasn't updated as our expectation and we couldn't guard
5way correctly.

Enyo-DCO-1.1-Signed-off-by: Yeram Choi yeram.choi@lge.com