### PR TITLE
PLAT-23335: Added proportional scaling support to Resolution Independence

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -495,6 +495,26 @@ var dom = module.exports = {
 	},
 
 	/**
+	* Removes a class from `document.body`. This defers the actual class change if nothing has been
+	* rendered into `body` yet.
+	*
+	* @param {String} s - The class name to remove from the document's `body`.
+	* @public
+	*/
+	removeBodyClass: function(s) {
+		if (!utils.exists(roots.roots) || roots.roots.length === 0) {
+			if (dom._bodyClasses) {
+				dom._bodyClasses = dom._bodyClasses.filter(function (cl) {
+					return (cl !== s);
+				});
+			}
+		}
+		else {
+			dom.removeClass(document.body, s);
+		}
+	},
+
+	/**
 	* Returns an object describing the absolute position on the screen, relative to the top left
 	* corner of the screen. This function takes into account account absolute/relative
 	* `offsetParent` positioning, `scroll` position, and CSS transforms (currently

--- a/src/resolution.js
+++ b/src/resolution.js
@@ -80,7 +80,7 @@ var ri = module.exports = {
 
 		if (rez.height > rez.width) {
 			portrait = true;
-			const swap = rez.width;
+			var swap = rez.width;
 			rez.width = rez.height;
 			rez.height = swap;
 		}

--- a/src/resolution.js
+++ b/src/resolution.js
@@ -76,11 +76,12 @@ var ri = module.exports = {
 		var i,
 			portrait = false,
 			types = _screenTypes,
-			bestMatch = types[types.length - 1].name;
+			bestMatch = types[types.length - 1].name,
+			swap;
 
 		if (rez.height > rez.width) {
 			portrait = true;
-			var swap = rez.width;
+			swap = rez.width;
 			rez.width = rez.height;
 			rez.height = swap;
 		}

--- a/src/resolution.js
+++ b/src/resolution.js
@@ -74,11 +74,20 @@ var ri = module.exports = {
 			width: global.innerWidth
 		};
 		var i,
+			portrait = false,
 			types = _screenTypes,
 			bestMatch = types[types.length - 1].name;
 
+		if (rez.height > rez.width) {
+			portrait = true;
+			const swap = rez.width;
+			rez.width = rez.height;
+			rez.height = swap;
+		}
+
 		// loop thorugh resolutions
 		for (i = types.length - 1; i >= 0; i--) {
+			types[i].orientation = portrait ? 'portrait' : 'landscape';
 			// find the one that matches our current size or is smaller. default to the first.
 			if (rez.width <= types[i].width) {
 				bestMatch = types[i].name;
@@ -105,6 +114,9 @@ var ri = module.exports = {
 			var scrObj = getScreenTypeObject(type);
 			if (scrObj.aspectRatioName) {
 				Dom.addBodyClass('enyo-aspect-ratio-' + scrObj.aspectRatioName.toLowerCase());
+			}
+			if (scrObj.orientation) {
+				Dom.addBodyClass('enyo-orientation-' + scrObj.orientation);
 			}
 			return type;
 		}


### PR DESCRIPTION
This change includes:
* PLAT-23332 #1455 
* Dynamic application of the base font size on the document object. No longer reliant on external CSS.
* A new enyo/dom method: removeBodyClasses
* RI configuration object
* Screen resize (or reorientation) event listeners for dynamic changes to the screen size
* Switches internal usage of string based current screen type to screenTypeObject for quicker lookups and ...
* More accurate body-class application with no overlap from previous executions.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens <blake.stephens@lge.com>