### PR TITLE
ENYO-3411: Clear job function in case of destroy

### DIFF
--- a/src/ShowingTransitionSupport.js
+++ b/src/ShowingTransitionSupport.js
@@ -178,7 +178,7 @@ var ShowingTransitionSupport = {
 			this.showingChanged();
 		};
 	}),
-	
+
 	/**
 	* Clean-up the existing operation.
 	* @priavate

--- a/src/ShowingTransitionSupport.js
+++ b/src/ShowingTransitionSupport.js
@@ -181,7 +181,7 @@ var ShowingTransitionSupport = {
 
 	/**
 	* Clean-up the existing operation.
-	* @priavate
+	* @private
 	*/
 	clearJobFn: function () {
 		if (this.showingTransitioning && this._showingTransitionJobFn) {

--- a/src/ShowingTransitionSupport.js
+++ b/src/ShowingTransitionSupport.js
@@ -178,16 +178,35 @@ var ShowingTransitionSupport = {
 			this.showingChanged();
 		};
 	}),
-
+	
 	/**
 	* Clean-up the existing operation.
+	* @priavate
+	*/
+	clearJobFn: function () {
+		if (this.showingTransitioning && this._showingTransitionJobFn) {
+			this._showingTransitionJobFn();
+			this._showingTransitionJobFn = null;
+		}
+	},
+
+	/**
+	* @private
+	*/
+	destroy: kind.inherit(function (sup) {
+		return function () {
+			this.clearJobFn();
+			return sup.apply(this, arguments);
+		};
+	}),
+
+	/**
 	* @private
 	*/
 	set: kind.inherit(function (sup) {
 		return function (path, value, opts) {
-			if (path === 'showing' && this.showingTransitioning && this._showingTransitionJobFn) {
-				this._showingTransitionJobFn();
-				this._showingTransitionJobFn = null;
+			if (path === 'showing') {
+				this.clearJobFn();
 			}
 			return sup.apply(this, arguments);
 		};


### PR DESCRIPTION
Job should be executed although control is destroy.

Enyo-DCO-1.1-Signed-off-by: Yeram Choi (yeram.choi@lge.com)