### PR TITLE
ENYO-3411 Notification : Lose focus in various scenarios

### DIFF
--- a/src/ShowingTransitionSupport.js
+++ b/src/ShowingTransitionSupport.js
@@ -180,6 +180,20 @@ var ShowingTransitionSupport = {
 	}),
 
 	/**
+	* Clean-up the existing operation when it's destroyed.
+	* @private
+	*/
+	destroy: kind.inherit(function (sup) {
+		return function () {
+			if (this.showingTransitioning && this._showingTransitionJobFn) {
+				this._showingTransitionJobFn();
+				this._showingTransitionJobFn = null;
+			}
+			return sup.apply(this, arguments);
+		};
+	}),
+
+	/**
 	* Clean-up the existing operation.
 	* @private
 	*/


### PR DESCRIPTION
### Issue
Can't use cursor with mouse or magic remote when Notification popup is destroyed.

### Fix
When notification popup is destroyed, clean-up the existing operation.

ENYO-3411 Notification : Lose focus in various scenarios
Enyo-DCO-1.1-Signed-off-by: Sangwook Lee sangwook1203.lee@lge.com