### PR TITLE
ENYO-3403: Remove exists option from initContainer mixin.

### DIFF
--- a/src/DataList/DataList.js
+++ b/src/DataList/DataList.js
@@ -472,7 +472,7 @@ var DataList = module.exports = kind(
 		return function () {
 			var o = utils.clone(this.get('containerOptions')),
 				s = this.get('scrollerOptions');
-			if (s) { utils.mixin(o, s, {exists: true}); }
+			if (s) { utils.mixin(o, s); }
 			this.set('containerOptions', o);
 			sup.apply(this, arguments);
 		};


### PR DESCRIPTION
When mixin have exists true option, it is not copy falsy value.
We added spotlightRememberFocus option for container that is try to find
nearest neighbor on 5way focus enters into container. The undefined and
true value have same meaning by definition here.

Problem happens when initcontainer of DataList is copying
scrollerOptions which is having spotlightRememberFocus false.
Because, mixin is not copy falsy value and undefined means true
for spotlightRememberFocus property.

We remove exists option from initContainer mixin. So, it can copy
falsy value.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi (kunmyon.choi@lge.com)