### PR TITLE
ENYO-3395: remove 'shifted' class asynchronously

### DIFF
--- a/src/LightPanels/LightPanels.js
+++ b/src/LightPanels/LightPanels.js
@@ -651,15 +651,14 @@ module.exports = kind(
 			prevPanel = this._previousPanel;
 			currPanel = this._currentPanel;
 
-			if (prevPanel) {
-				prevPanel.removeClass('shifted');
-				prevPanel.addClass('offscreen');
-			}
+			prevPanel && prevPanel.addClass('offscreen');
 
 			this.removeClass('transitioning');
 			this.transitioning = false;
 
 			utils.asyncMethod(this, function () {
+				prevPanel && prevPanel.removeClass('shifted');
+
 				this.cleanUpPanel(prevPanel);
 				this.cleanUpPanel(currPanel);
 


### PR DESCRIPTION
To fit desired timing, it's better to delay removing 'shifted' class.

Enyo-DCO-1.1-Signed-off-by: Yeram Choi (yeram.choi@lge.com)