### PR TITLE
ENYO-3431 Scrim isn't hidden when notification is destroyed in showing

### DIFF
--- a/src/Popup/Popup.js
+++ b/src/Popup/Popup.js
@@ -325,6 +325,7 @@ var Popup = module.exports = kind(
 	*/
 	destroy: kind.inherit(function (sup) {
 		return function() {
+			this.showHideScrim(false);
 			this.release();
 			sup.apply(this, arguments);
 		};


### PR DESCRIPTION
Issue

Scrim is not hidden when notification is destroyed in showing status.

Fix

When notification is destroyed, showHideScrim is called to hide scrim.
Enyo-DCO-1.1-Signed-off-by: Yeram Choi (yeram.choi@lge.com)