### PR TITLE
ENYO-3376: Calculate scroll boundaries right before refreshThreshold

### DIFF
--- a/src/NewDataList.js
+++ b/src/NewDataList.js
@@ -161,6 +161,7 @@ module.exports = kind({
 			val = v ? this.scrollTop : this.scrollLeft;
 
 		if (val > tt.max || val < tt.min) {
+			this.calcBoundaries();
 			this.refreshThresholds();
 			this.doIt();
 		}


### PR DESCRIPTION
It seems like re-calculate scroll boundaries before refreshThreshold()
since we're using scrollBounds as a base number in refreshThreshold().

Enyo-DCO-1.1-Signed-off-by: Yeram Choi (yeram.choi@lge.com)