### PR TITLE
ENYO-3465: height() of verticalDelegate report null reference error

### DIFF
--- a/src/VerticalDelegate.js
+++ b/src/VerticalDelegate.js
@@ -35,6 +35,7 @@ module.exports = {
 	* @private
 	*/
 	initList: function (list) {
+		list._updateBounds = true;
 		list.posProp   = 'top';
 		list.upperProp = 'top';
 		list.lowerProp = 'bottom';


### PR DESCRIPTION
Issue:
We do call updateBounds and cache when _updateBounds is true, and use
cached value when _updateBounds is false or undefined. The _updateBounds
is undefined on create and set to false from updateBounds. We call
updateBounds form rendered and didResize. So, there is a change of
calling height() when _updateBounds is undefined.

Fix:
We can avoid this change by setting _updateBounds to true on initList
which means it need to cache. Then height() will call updateBounds to
measure metric and DOM.getBounds will return invalid values but there
will be no null reference error.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi (kunmyon.choi@lge.com)