### PR TITLE
[ENYO-3770]NewDataList: threshold is not updated between -Infinity and Infinity

### DIFF
--- a/src/NewDataList.js
+++ b/src/NewDataList.js
@@ -30,7 +30,7 @@ module.exports = kind({
 	/**
 	* Returns an array of list items that are currently visible (whether partially
 	* or fully).
-	* 
+	*
 	* Experimental API -- subject to change.
 	*
 	* @public
@@ -41,7 +41,7 @@ module.exports = kind({
 
 	/**
 	* Returns an array of list items that are currently fully visible.
-	* 
+	*
 	* Experimental API -- subject to change.
 	*
 	* @public
@@ -52,7 +52,7 @@ module.exports = kind({
 
 	/**
 	* Scrolls to a list item (specified by index).
-	* 
+	*
 	* @param {number} index - The (zero-based) index of the item to scroll to
 	* @param {Object} opts - Scrolling options (see enyo/Scrollable#scrollTo)
 	* @public
@@ -126,7 +126,7 @@ module.exports = kind({
 		else if (d2x === 'auto') {
 			d2x = 1;
 		}
-		
+
 		d1 = sp + is1;
 		d2 = sp + is2;
 
@@ -338,7 +338,7 @@ module.exports = kind({
 			sup.apply(this, arguments);
 		};
 	}),
-	
+
 	/**
 	* @private
 	*/
@@ -354,6 +354,7 @@ module.exports = kind({
 	* @private
 	*/
 	collectionResetHandler: function () {
+		this.calculateMetrics();
 		this.calcBoundaries();
 	},
 


### PR DESCRIPTION
### Issue
In Photo&Video application use case, I can see the blank in the last of NewDataList.
Bacause thereshold's max is Infinity. So, threshold is not updated after scrolling down.
If we change from list that min of threshold is -Infinity and max of threashold is Infinity to other list that need to refresh threshold. At that time, max value of threshold is Infinity. This value have to be proper max value.

### Fix
I added `calculateMetrics` inside collection `ResetHandler` function in enyo.NewDataList.
This is for update when collection is changed by filter of bucketFilter.

ENYO-3770 NewDataList: threshold is not updated between -Infinity and Infinity
Enyo-DCO-1.1-Signed-off-by: Sangwook Lee sangwook1203.lee@lge.com