### PR TITLE
PLAT-43853: Number input field allows any character in Safari

### DIFF
--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -265,7 +265,7 @@ module.exports = kind(
 	* Fix to safari input type number allowing other characters
 	*/
 	testNumber: function(sender, e) {
-		if (platform.safari && this.type == 'number' && !/[eE.0-9+-]/.test(e.key)) {
+		if (platform.safari && this.type === 'number' && !/[eE.0-9+-]/.test(e.key)) {
 			e.preventDefault();
 		}
 	},

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -265,7 +265,7 @@ module.exports = kind(
 	* Fix to safari input type number allowing other characters
 	*/
 	testNumber: function(sender, e) {
-		if (this.type == 'number' && !/[eE.0-9+-]/.test(e.key)) {
+		if (platform.safari && this.type == 'number' && !/[eE.0-9+-]/.test(e.key)) {
 			e.preventDefault();
 		}
 	},

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -262,9 +262,10 @@ module.exports = kind(
 
 	/**
 	* @private
+	* Fix to safari input type number allowing other characters
 	*/
 	testNumber: function(sender, e) {
-		if(this.type == 'number' && !/[eE.0-9+-]/.test(e.key)){ //&& !/[+\-]?(?:0|[1-9]\d*)(?:\.\d*)?(?:[eE][+\-]?\d+)?/.test(e.key)) {
+		if (this.type == 'number' && !/[eE.0-9+-]/.test(e.key)) {
 			e.preventDefault();
 		}
 	},

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -167,7 +167,8 @@ module.exports = kind(
 		onfocus: 'focused',
 		oninput: 'input',
 		onclear: 'clear',
-		ondragstart: 'dragstart'
+		ondragstart: 'dragstart',
+		onkeypress: 'testNumber'
 	},
 
 	/**
@@ -257,6 +258,15 @@ module.exports = kind(
 			this.setAttribute('value', this.value);
 		}
 		this.detectTextDirectionality((this.value || this.value === 0) ? this.value : this.get('placeholder'));
+	},
+
+	/**
+	* @private
+	*/
+	testNumber: function(sender, e) {
+		if(this.type == 'number' && !/[eE.0-9+-]/.test(e.key)){ //&& !/[+\-]?(?:0|[1-9]\d*)(?:\.\d*)?(?:[eE][+\-]?\d+)?/.test(e.key)) {
+			e.preventDefault();
+		}
 	},
 
 	/**


### PR DESCRIPTION
### Issue Resolved / Feature Added
Enyo Input : Input allows any character in Safari

### Resolution
Safari not handled the same. regExp validation is done in keypress event

### Links
PLAT-43853

### Comments
Enyo-DCO-1.1-Signed-off-by: Anish TD(anish.td@lge.com)