### PR TITLE
PLAT-47295: Resolution now better matches the screen shape

### DIFF
--- a/src/resolution.js
+++ b/src/resolution.js
@@ -84,9 +84,7 @@ var ri = module.exports = {
 	* Update the common measured boundary object. This object is used as "what size screen are we
 	* looking at". Providing no arguments has no effect and updates nothing.
 	*
-	* @memberOf ui/resolution
 	* @param {Node} measurementNode A standard DOM node or the `window` node.
-	*
 	* @returns {undefined}
 	* @private
 	*/
@@ -109,10 +107,7 @@ var ri = module.exports = {
 	* @public
 	*/
 	getScreenType: function (rez) {
-		rez = rez || _workspaceBounds || {
-			height: 1080,
-			width: 1920
-		};
+		rez = rez || _workspaceBounds;
 
 		var types = _screenTypes,
 			bestMatch = types[types.length - 1].name; // Blindly set the first screen type, in case no matches are found later.
@@ -128,7 +123,7 @@ var ri = module.exports = {
 
 		// Loop thorugh resolutions, last->first, largest->smallest
 		for (var i = types.length - 1; i >= 0; i--) {
-			// Find the screenType that matches our current size or is smaller. Default to the first.
+			// Find the screenType that matches our current size or is smaller.
 			if (rez.height <= types[i].height && rez.width <= types[i].width) {
 				bestMatch = types[i].name;
 			}

--- a/src/resolution.js
+++ b/src/resolution.js
@@ -352,7 +352,11 @@ var ri = module.exports = {
 };
 
 ri.config = util.clone(configDefaults);
-ri.init(document.body);
+// Directly attaching to DOMContentLoaded gets this function executed much sooner than waiting for 'load' from dispacher.
+document.addEventListener('DOMContentLoaded', function () {
+	console.log('document.body:', document.body);
+	ri.init({measurementNode: document.body});
+});
 
 // We need to re-initialize the resolution config before any components receive their resize event
 // and calculate any resolution-dependent values. There's currently no means in dispatcher to jump

--- a/src/resolution.js
+++ b/src/resolution.js
@@ -354,7 +354,6 @@ var ri = module.exports = {
 ri.config = util.clone(configDefaults);
 // Directly attaching to DOMContentLoaded gets this function executed much sooner than waiting for 'load' from dispacher.
 document.addEventListener('DOMContentLoaded', function () {
-	console.log('document.body:', document.body);
 	ri.init({measurementNode: document.body});
 });
 

--- a/src/resolution.js
+++ b/src/resolution.js
@@ -123,7 +123,7 @@ var ri = module.exports = {
 
 		// Loop thorugh resolutions, last->first, largest->smallest
 		for (var i = types.length - 1; i >= 0; i--) {
-			// Find the screenType that matches our current size or is smaller.
+			// Does the current resolution fit inside this screenType definition? If so, save it as the current best match.
 			if (rez.height <= types[i].height && rez.width <= types[i].width) {
 				bestMatch = types[i].name;
 			}


### PR DESCRIPTION
And measures `document.body` instead of `window` so components are scaled based on Enyo's available rendering area rather than the physical window dimensions.
Height is also factored into the check now too.
